### PR TITLE
feat: Add how-to-use guide pages for users and admins

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Standings from './components/Standings';
 import Championships from './components/Championships';
 import Matches from './components/Matches';
 import Tournaments from './components/Tournaments';
+import UserGuide from './components/UserGuide';
 import AdminPanel from './components/admin/AdminPanel';
 import './App.css';
 
@@ -17,6 +18,7 @@ function App() {
             <Link to="/championships">Championships</Link>
             <Link to="/matches">Matches</Link>
             <Link to="/tournaments">Tournaments</Link>
+            <Link to="/guide">Help</Link>
             <Link to="/admin">Admin</Link>
           </nav>
         </header>
@@ -26,6 +28,7 @@ function App() {
             <Route path="/championships" element={<Championships />} />
             <Route path="/matches" element={<Matches />} />
             <Route path="/tournaments" element={<Tournaments />} />
+            <Route path="/guide" element={<UserGuide />} />
             <Route path="/admin" element={<AdminPanel />} />
           </Routes>
         </main>

--- a/frontend/src/components/UserGuide.css
+++ b/frontend/src/components/UserGuide.css
@@ -1,0 +1,188 @@
+.user-guide {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.guide-intro {
+  font-size: 1.1rem;
+  color: #ccc;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.guide-section {
+  background-color: #1a1a1a;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid #333;
+}
+
+.guide-section h3 {
+  color: #d4af37;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.guide-section > p {
+  color: #ccc;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.guide-subsection {
+  margin-top: 1.5rem;
+}
+
+.guide-subsection h4 {
+  color: #fff;
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.guide-subsection h5 {
+  color: #d4af37;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.info-table {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.info-table th {
+  text-align: left;
+  padding: 0.75rem;
+  background-color: #252525;
+  color: #d4af37;
+}
+
+.info-table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #333;
+}
+
+.info-table td:first-child {
+  font-weight: bold;
+  color: #fff;
+  width: 120px;
+}
+
+.info-table td:last-child {
+  color: #ccc;
+}
+
+.formula-box {
+  background-color: #252525;
+  padding: 1rem;
+  border-radius: 4px;
+  font-family: monospace;
+  color: #d4af37;
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+.steps-list {
+  padding-left: 1.5rem;
+  color: #ccc;
+  line-height: 1.8;
+}
+
+.steps-list li {
+  margin-bottom: 0.5rem;
+}
+
+.steps-list ul {
+  margin-top: 0.5rem;
+  padding-left: 1.5rem;
+  list-style-type: disc;
+}
+
+.feature-list {
+  padding-left: 1.5rem;
+  color: #ccc;
+  line-height: 1.8;
+}
+
+.feature-list li {
+  margin-bottom: 0.5rem;
+}
+
+.winner-text {
+  color: #4ade80;
+  font-weight: bold;
+}
+
+.loser-text {
+  color: #f87171;
+  font-weight: bold;
+}
+
+.draw-text {
+  color: #fbbf24;
+  font-weight: bold;
+}
+
+.tournament-type-box {
+  background-color: #252525;
+  padding: 1rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  border-left: 3px solid #d4af37;
+}
+
+.tournament-type-box h5 {
+  margin-bottom: 0.5rem;
+}
+
+.tournament-type-box ul {
+  padding-left: 1.5rem;
+  color: #ccc;
+  line-height: 1.6;
+}
+
+.tips-section {
+  background-color: #1a2a1a;
+  border-color: #2a4a2a;
+}
+
+.tips-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.tip-card {
+  background-color: #252525;
+  padding: 1rem;
+  border-radius: 4px;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.tip-icon {
+  background-color: #d4af37;
+  color: #000;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.tip-card p {
+  color: #ccc;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.tip-card strong {
+  color: #fff;
+}

--- a/frontend/src/components/UserGuide.tsx
+++ b/frontend/src/components/UserGuide.tsx
@@ -1,0 +1,191 @@
+import './UserGuide.css';
+
+export default function UserGuide() {
+  return (
+    <div className="user-guide">
+      <h2>How to Use This Site</h2>
+      <p className="guide-intro">
+        Welcome to the WWE 2K League Management System! This guide will help you navigate
+        the site and understand all the features available to you.
+      </p>
+
+      <section className="guide-section">
+        <h3>Standings Page</h3>
+        <p>The Standings page is the home page and shows the current league rankings.</p>
+
+        <div className="guide-subsection">
+          <h4>What You Can See</h4>
+          <table className="info-table">
+            <thead>
+              <tr>
+                <th>Column</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Rank</td>
+                <td>Player's position based on win percentage</td>
+              </tr>
+              <tr>
+                <td>Player</td>
+                <td>The player's name</td>
+              </tr>
+              <tr>
+                <td>Wrestler</td>
+                <td>The WWE wrestler they currently play as</td>
+              </tr>
+              <tr>
+                <td>W / L / D</td>
+                <td>Total wins, losses, and draws</td>
+              </tr>
+              <tr>
+                <td>Win %</td>
+                <td>Win percentage calculated from their record</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className="guide-subsection">
+          <h4>How Rankings Work</h4>
+          <p>
+            Players are ranked by their win percentage. Players with more wins and fewer
+            losses will appear higher on the standings.
+          </p>
+          <div className="formula-box">
+            Win % = Wins / (Wins + Losses + Draws) x 100
+          </div>
+        </div>
+      </section>
+
+      <section className="guide-section">
+        <h3>Championships Page</h3>
+        <p>View all the championships in the league and their history.</p>
+
+        <div className="guide-subsection">
+          <h4>Viewing Championships</h4>
+          <ol className="steps-list">
+            <li>Navigate to <strong>Championships</strong> in the navigation bar</li>
+            <li>You'll see all active championships displayed as cards</li>
+            <li>Each championship card shows:
+              <ul>
+                <li>Championship name and belt image</li>
+                <li>Type (Singles or Tag Team)</li>
+                <li>Current champion(s)</li>
+              </ul>
+            </li>
+          </ol>
+        </div>
+
+        <div className="guide-subsection">
+          <h4>Viewing Championship History</h4>
+          <ol className="steps-list">
+            <li>Click on any championship card</li>
+            <li>A modal window will appear showing the complete history</li>
+            <li>The history displays all previous champions, dates won/lost, and total days held</li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="guide-section">
+        <h3>Matches Page</h3>
+        <p>View all scheduled and completed matches in the league.</p>
+
+        <div className="guide-subsection">
+          <h4>Filtering Matches</h4>
+          <p>At the top of the page, you can filter matches by status:</p>
+          <ul className="feature-list">
+            <li><strong>All</strong> - Shows all matches</li>
+            <li><strong>Scheduled</strong> - Shows only upcoming matches</li>
+            <li><strong>Completed</strong> - Shows only finished matches</li>
+          </ul>
+        </div>
+
+        <div className="guide-subsection">
+          <h4>Match Information</h4>
+          <p>Each match card displays:</p>
+          <ul className="feature-list">
+            <li><strong>Date</strong> - When the match is scheduled or took place</li>
+            <li><strong>Match Type</strong> - Singles, Tag Team, Triple Threat, Fatal 4-Way, Six Pack Challenge, or Battle Royal</li>
+            <li><strong>Stipulation</strong> - Special match rules (Ladder, Steel Cage, Hell in a Cell, etc.)</li>
+            <li><strong>Participants</strong> - Who is competing in the match</li>
+            <li><strong>Championship Badge</strong> - Indicates if it's a title match</li>
+          </ul>
+        </div>
+
+        <div className="guide-subsection">
+          <h4>Match Results</h4>
+          <p>For completed matches, you'll also see:</p>
+          <ul className="feature-list">
+            <li><span className="winner-text">Winners</span> - Highlighted in green</li>
+            <li><span className="loser-text">Losers</span> - Shown in the results section</li>
+            <li><span className="draw-text">Draw</span> - If the match ended in a draw</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="guide-section">
+        <h3>Tournaments Page</h3>
+        <p>Follow tournament brackets and standings for ongoing and completed tournaments.</p>
+
+        <div className="guide-subsection">
+          <h4>Tournament Types</h4>
+          <p>The league supports two tournament formats:</p>
+
+          <div className="tournament-type-box">
+            <h5>Single Elimination</h5>
+            <ul>
+              <li>Traditional bracket-style tournament</li>
+              <li>If you lose, you're eliminated</li>
+              <li>Winners advance to the next round</li>
+              <li>Last person standing wins the tournament</li>
+            </ul>
+          </div>
+
+          <div className="tournament-type-box">
+            <h5>Round Robin (G1 Climax Style)</h5>
+            <ul>
+              <li>Every participant faces every other participant</li>
+              <li>Points awarded: <strong>Win = 2 pts</strong>, <strong>Draw = 1 pt</strong>, <strong>Loss = 0 pts</strong></li>
+              <li>Player with the most points at the end wins</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="guide-subsection">
+          <h4>Tournament Information</h4>
+          <p>Each tournament card shows:</p>
+          <ul className="feature-list">
+            <li>Tournament name and type</li>
+            <li>Status (Upcoming, In Progress, or Completed)</li>
+            <li>Number of participants</li>
+            <li>Current bracket or standings</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="guide-section tips-section">
+        <h3>Tips for Following the League</h3>
+        <div className="tips-grid">
+          <div className="tip-card">
+            <span className="tip-icon">1</span>
+            <p><strong>Check Standings Regularly</strong> - See who's climbing the rankings</p>
+          </div>
+          <div className="tip-card">
+            <span className="tip-icon">2</span>
+            <p><strong>Watch for Championship Matches</strong> - These are marked with a special badge</p>
+          </div>
+          <div className="tip-card">
+            <span className="tip-icon">3</span>
+            <p><strong>Follow Tournament Progress</strong> - Tournaments often determine championship opportunities</p>
+          </div>
+          <div className="tip-card">
+            <span className="tip-icon">4</span>
+            <p><strong>Review Match History</strong> - Filter by "Completed" to catch up on results you missed</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminGuide.css
+++ b/frontend/src/components/admin/AdminGuide.css
@@ -1,0 +1,199 @@
+.admin-guide {
+  max-width: 800px;
+}
+
+.admin-guide h3 {
+  color: #d4af37;
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.admin-guide .guide-intro {
+  color: #ccc;
+  margin-bottom: 2rem;
+  line-height: 1.5;
+}
+
+.admin-guide-section {
+  background-color: #252525;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid #333;
+}
+
+.admin-guide-section h4 {
+  color: #d4af37;
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #444;
+}
+
+.admin-guide-section > p {
+  color: #ccc;
+  margin-bottom: 1rem;
+}
+
+.guide-block {
+  background-color: #1a1a1a;
+  border-radius: 4px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.guide-block:last-child {
+  margin-bottom: 0;
+}
+
+.guide-block h5 {
+  color: #fff;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.guide-block h6 {
+  color: #d4af37;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.guide-block ol,
+.guide-block ul {
+  padding-left: 1.5rem;
+  color: #ccc;
+  line-height: 1.7;
+}
+
+.guide-block li {
+  margin-bottom: 0.25rem;
+}
+
+.guide-block ul ul {
+  margin-top: 0.25rem;
+}
+
+.highlight-box {
+  border-left: 3px solid #d4af37;
+}
+
+.important-box {
+  border-left: 3px solid #4ade80;
+  background-color: #1a2a1a;
+}
+
+.match-type-table {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.match-type-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.match-type-table td:first-child {
+  width: 150px;
+  color: #d4af37;
+}
+
+.match-type-table td:last-child {
+  color: #ccc;
+}
+
+.winner-label {
+  background-color: #166534;
+  color: #4ade80;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.85rem;
+}
+
+.loser-label {
+  background-color: #7f1d1d;
+  color: #f87171;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.85rem;
+}
+
+.draw-label {
+  background-color: #78350f;
+  color: #fbbf24;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.85rem;
+}
+
+.tournament-comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.tournament-type {
+  background-color: #252525;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.tournament-type ul {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.workflow-section {
+  background-color: #1a2a2a;
+  border-color: #2a4a4a;
+}
+
+.workflow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.workflow-step {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  background-color: #1a1a1a;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.step-number {
+  background-color: #d4af37;
+  color: #000;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.step-content {
+  flex: 1;
+}
+
+.step-content strong {
+  color: #fff;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.step-content p {
+  color: #ccc;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .tournament-comparison {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/admin/AdminGuide.tsx
+++ b/frontend/src/components/admin/AdminGuide.tsx
@@ -1,0 +1,274 @@
+import './AdminGuide.css';
+
+export default function AdminGuide() {
+  return (
+    <div className="admin-guide">
+      <h3>Admin Guide</h3>
+      <p className="guide-intro">
+        This guide explains how to manage the WWE 2K League as an administrator.
+        Use the tabs above to access different management features.
+      </p>
+
+      <section className="admin-guide-section">
+        <h4>Managing Players</h4>
+        <p>The <strong>Manage Players</strong> tab allows you to add and edit players in the league.</p>
+
+        <div className="guide-block">
+          <h5>Adding a New Player</h5>
+          <ol>
+            <li>Navigate to the <strong>Manage Players</strong> tab</li>
+            <li>Fill in the player details:
+              <ul>
+                <li><strong>Player Name</strong> - The person's real name or gamertag</li>
+                <li><strong>Wrestler Name</strong> - The WWE wrestler they will play as</li>
+                <li><strong>Wrestler Image</strong> (optional) - Upload a photo of the wrestler</li>
+              </ul>
+            </li>
+            <li>Click <strong>Add Player</strong> to save</li>
+          </ol>
+        </div>
+
+        <div className="guide-block">
+          <h5>Editing a Player</h5>
+          <ol>
+            <li>Find the player in the players table</li>
+            <li>Click the <strong>Edit</strong> button next to their name</li>
+            <li>Update the player name, wrestler, or image</li>
+            <li>Click <strong>Save</strong> to confirm changes</li>
+          </ol>
+        </div>
+
+        <div className="guide-block">
+          <h5>Image Upload Guidelines</h5>
+          <ul>
+            <li>Supported formats: JPEG, PNG, GIF, WebP</li>
+            <li>Maximum file size: 5MB</li>
+            <li>Images are stored securely and displayed in standings</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="admin-guide-section">
+        <h4>Scheduling Matches</h4>
+        <p>The <strong>Schedule Match</strong> tab allows you to create upcoming matches.</p>
+
+        <div className="guide-block">
+          <h5>Creating a Match</h5>
+          <ol>
+            <li>Navigate to the <strong>Schedule Match</strong> tab</li>
+            <li>Fill in the match details:
+              <ul>
+                <li><strong>Date & Time</strong> - When the match will take place</li>
+                <li><strong>Match Type</strong> - Singles, Tag Team, Triple Threat, Fatal 4-Way, Six Pack Challenge, or Battle Royal</li>
+                <li><strong>Stipulation</strong> (optional) - Ladder, Steel Cage, Hell in a Cell, etc.</li>
+                <li><strong>Participants</strong> - Select 2 or more players</li>
+              </ul>
+            </li>
+            <li>Optionally enable <strong>Championship Match</strong> and select the title on the line</li>
+            <li>Optionally associate the match with a <strong>Tournament</strong></li>
+            <li>Click <strong>Schedule Match</strong> to save</li>
+          </ol>
+        </div>
+
+        <div className="guide-block highlight-box">
+          <h5>Match Types Explained</h5>
+          <table className="match-type-table">
+            <tbody>
+              <tr>
+                <td><strong>Singles</strong></td>
+                <td>1 vs 1 match</td>
+              </tr>
+              <tr>
+                <td><strong>Tag Team</strong></td>
+                <td>2 vs 2 match</td>
+              </tr>
+              <tr>
+                <td><strong>Triple Threat</strong></td>
+                <td>3 participants, first to pin/submit wins</td>
+              </tr>
+              <tr>
+                <td><strong>Fatal 4-Way</strong></td>
+                <td>4 participants, first to pin/submit wins</td>
+              </tr>
+              <tr>
+                <td><strong>Six Pack Challenge</strong></td>
+                <td>6 participants, first to pin/submit wins</td>
+              </tr>
+              <tr>
+                <td><strong>Battle Royal</strong></td>
+                <td>Multiple participants, last one standing wins</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="admin-guide-section">
+        <h4>Recording Results</h4>
+        <p>The <strong>Record Results</strong> tab allows you to enter match outcomes.</p>
+
+        <div className="guide-block">
+          <h5>Recording a Match Result</h5>
+          <ol>
+            <li>Navigate to the <strong>Record Results</strong> tab</li>
+            <li>Select a scheduled match from the dropdown</li>
+            <li>Mark each participant as:
+              <ul>
+                <li><span className="winner-label">Winner</span> - Won the match</li>
+                <li><span className="loser-label">Loser</span> - Lost the match</li>
+                <li><span className="draw-label">Draw</span> - Match ended in a draw (if applicable)</li>
+              </ul>
+            </li>
+            <li>Click <strong>Record Result</strong> to save</li>
+          </ol>
+        </div>
+
+        <div className="guide-block important-box">
+          <h5>What Happens When You Record a Result</h5>
+          <ul>
+            <li>Player win/loss/draw records are automatically updated</li>
+            <li>League standings are recalculated</li>
+            <li>If it's a championship match, the title changes hands to the winner</li>
+            <li>If it's a tournament match, brackets/standings are updated</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="admin-guide-section">
+        <h4>Managing Championships</h4>
+        <p>The <strong>Championships</strong> tab allows you to create and manage titles.</p>
+
+        <div className="guide-block">
+          <h5>Creating a Championship</h5>
+          <ol>
+            <li>Navigate to the <strong>Championships</strong> tab</li>
+            <li>Fill in the championship details:
+              <ul>
+                <li><strong>Championship Name</strong> - e.g., "World Heavyweight Championship"</li>
+                <li><strong>Type</strong> - Singles or Tag Team</li>
+                <li><strong>Belt Image</strong> (optional) - Upload an image of the championship belt</li>
+              </ul>
+            </li>
+            <li>Click <strong>Create Championship</strong> to save</li>
+          </ol>
+        </div>
+
+        <div className="guide-block">
+          <h5>Editing a Championship</h5>
+          <ol>
+            <li>Find the championship in the table</li>
+            <li>Click the <strong>Edit</strong> button</li>
+            <li>Update the name, type, or image</li>
+            <li>Click <strong>Save</strong> to confirm changes</li>
+          </ol>
+        </div>
+
+        <div className="guide-block">
+          <h5>How Championships Work</h5>
+          <ul>
+            <li>When you schedule a championship match, select the title at stake</li>
+            <li>When the match result is recorded, if the challenger wins, they become the new champion</li>
+            <li>Championship history is automatically tracked with dates and reign lengths</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="admin-guide-section">
+        <h4>Creating Tournaments</h4>
+        <p>The <strong>Tournaments</strong> tab allows you to create and manage tournaments.</p>
+
+        <div className="guide-block">
+          <h5>Creating a Tournament</h5>
+          <ol>
+            <li>Navigate to the <strong>Tournaments</strong> tab</li>
+            <li>Fill in the tournament details:
+              <ul>
+                <li><strong>Tournament Name</strong> - e.g., "King of the Ring 2024"</li>
+                <li><strong>Type</strong> - Single Elimination or Round Robin</li>
+                <li><strong>Participants</strong> - Select the players competing</li>
+              </ul>
+            </li>
+            <li>Click <strong>Create Tournament</strong> to save</li>
+          </ol>
+        </div>
+
+        <div className="guide-block highlight-box">
+          <h5>Tournament Types</h5>
+          <div className="tournament-comparison">
+            <div className="tournament-type">
+              <h6>Single Elimination</h6>
+              <ul>
+                <li>Minimum 4 participants</li>
+                <li>Bracket is auto-generated</li>
+                <li>Losers are eliminated</li>
+                <li>Winners advance to next round</li>
+                <li>Best for quick tournaments</li>
+              </ul>
+            </div>
+            <div className="tournament-type">
+              <h6>Round Robin</h6>
+              <ul>
+                <li>Minimum 2 participants</li>
+                <li>Everyone faces everyone</li>
+                <li>Points: Win=2, Draw=1, Loss=0</li>
+                <li>Most points wins</li>
+                <li>Best for league-style play</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className="guide-block">
+          <h5>Managing Tournament Matches</h5>
+          <ol>
+            <li>After creating a tournament, schedule matches via <strong>Schedule Match</strong></li>
+            <li>Select the tournament from the dropdown when scheduling</li>
+            <li>Record results as matches are completed</li>
+            <li>Standings/brackets update automatically</li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="admin-guide-section workflow-section">
+        <h4>Typical Admin Workflow</h4>
+        <div className="workflow-steps">
+          <div className="workflow-step">
+            <span className="step-number">1</span>
+            <div className="step-content">
+              <strong>Add Players</strong>
+              <p>Set up all league participants with their wrestlers</p>
+            </div>
+          </div>
+          <div className="workflow-step">
+            <span className="step-number">2</span>
+            <div className="step-content">
+              <strong>Create Championships</strong>
+              <p>Set up the titles that will be contested</p>
+            </div>
+          </div>
+          <div className="workflow-step">
+            <span className="step-number">3</span>
+            <div className="step-content">
+              <strong>Schedule Matches</strong>
+              <p>Create the match card for upcoming events</p>
+            </div>
+          </div>
+          <div className="workflow-step">
+            <span className="step-number">4</span>
+            <div className="step-content">
+              <strong>Record Results</strong>
+              <p>Enter outcomes after matches are played</p>
+            </div>
+          </div>
+          <div className="workflow-step">
+            <span className="step-number">5</span>
+            <div className="step-content">
+              <strong>Repeat</strong>
+              <p>Continue scheduling and recording as the season progresses</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminPanel.tsx
+++ b/frontend/src/components/admin/AdminPanel.tsx
@@ -6,9 +6,10 @@ import ScheduleMatch from './ScheduleMatch';
 import RecordResult from './RecordResult';
 import ManageChampionships from './ManageChampionships';
 import CreateTournament from './CreateTournament';
+import AdminGuide from './AdminGuide';
 import './AdminPanel.css';
 
-type AdminTab = 'players' | 'schedule' | 'results' | 'championships' | 'tournaments';
+type AdminTab = 'players' | 'schedule' | 'results' | 'championships' | 'tournaments' | 'guide';
 
 export default function AdminPanel() {
   const [isAuthenticated, setIsAuthenticated] = useState(authApi.isAuthenticated());
@@ -67,6 +68,12 @@ export default function AdminPanel() {
         >
           Tournaments
         </button>
+        <button
+          className={`tab ${activeTab === 'guide' ? 'active' : ''}`}
+          onClick={() => setActiveTab('guide')}
+        >
+          Help
+        </button>
       </div>
 
       <div className="admin-content">
@@ -75,6 +82,7 @@ export default function AdminPanel() {
         {activeTab === 'results' && <RecordResult />}
         {activeTab === 'championships' && <ManageChampionships />}
         {activeTab === 'tournaments' && <CreateTournament />}
+        {activeTab === 'guide' && <AdminGuide />}
       </div>
     </div>
   );


### PR DESCRIPTION
- Add UserGuide page accessible via Help link in main navigation
- Add AdminGuide tab in Admin Panel for admin-specific instructions
- User guide covers Standings, Championships, Matches, and Tournaments
- Admin guide covers player management, match scheduling, recording results, championship management, and tournament creation

https://claude.ai/code/session_01J7o8NwK1RzbkLDqJcayKyy