### PR TITLE
Add image display support to Championships and Standings

### DIFF
--- a/frontend/src/components/Championships.css
+++ b/frontend/src/components/Championships.css
@@ -21,6 +21,41 @@
   border-color: #d4af37;
 }
 
+.championship-image-container {
+  width: 100%;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+  overflow: hidden;
+  border-radius: 4px;
+  background-color: #0f0f0f;
+}
+
+.championship-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.championship-image-placeholder {
+  width: 100%;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f0f0f;
+  border: 1px dashed #333;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.championship-image-placeholder span {
+  color: #666;
+  font-size: 0.875rem;
+}
+
 .championship-header {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/Championships.tsx
+++ b/frontend/src/components/Championships.tsx
@@ -86,6 +86,19 @@ export default function Championships() {
       <div className="championships-grid">
         {championships.map((championship) => (
           <div key={championship.championshipId} className="championship-card">
+            {championship.imageUrl ? (
+              <div className="championship-image-container">
+                <img
+                  src={championship.imageUrl}
+                  alt={championship.name}
+                  className="championship-image"
+                />
+              </div>
+            ) : (
+              <div className="championship-image-placeholder">
+                <span>No Image</span>
+              </div>
+            )}
             <div className="championship-header">
               <h3>{championship.name}</h3>
               <span className="championship-type">

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -56,6 +56,36 @@
   font-weight: bold;
 }
 
+.standings-table .image-header {
+  width: 60px;
+}
+
+.standings-table .wrestler-image-cell {
+  width: 60px;
+  padding: 0.5rem;
+}
+
+.standings-table .wrestler-thumbnail {
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #333;
+}
+
+.standings-table .no-image-placeholder {
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #1a1a1a;
+  border: 1px dashed #333;
+  border-radius: 4px;
+  color: #666;
+  font-size: 0.875rem;
+}
+
 .loading, .error, .empty-state {
   text-align: center;
   padding: 2rem;

--- a/frontend/src/components/Standings.tsx
+++ b/frontend/src/components/Standings.tsx
@@ -55,6 +55,7 @@ export default function Standings() {
           <thead>
             <tr>
               <th>Rank</th>
+              <th className="image-header">Image</th>
               <th>Player</th>
               <th>Wrestler</th>
               <th>Wins</th>
@@ -73,6 +74,17 @@ export default function Standings() {
               return (
                 <tr key={player.playerId}>
                   <td className="rank">{index + 1}</td>
+                  <td className="wrestler-image-cell">
+                    {player.imageUrl ? (
+                      <img
+                        src={player.imageUrl}
+                        alt={player.currentWrestler}
+                        className="wrestler-thumbnail"
+                      />
+                    ) : (
+                      <div className="no-image-placeholder">-</div>
+                    )}
+                  </td>
                   <td className="player-name">{player.name}</td>
                   <td className="wrestler-name">{player.currentWrestler}</td>
                   <td className="wins">{player.wins}</td>


### PR DESCRIPTION
## Summary
This PR adds image display functionality to both the Championships and Standings components, enhancing the visual presentation of the application with championship logos and wrestler thumbnails.

## Key Changes

**Championships Component:**
- Added new CSS classes for championship image container and placeholder styling
- Implemented conditional rendering to display championship images when available
- Added fallback "No Image" placeholder for championships without images
- Images are contained within a fixed-height container with proper aspect ratio handling

**Standings Component:**
- Added new image column to the standings table
- Implemented wrestler thumbnail display (50x50px) with rounded corners
- Added placeholder styling for wrestlers without images
- Updated table header to include new "Image" column

**Styling:**
- Championship images: 200px height container with dark background (#0f0f0f)
- Wrestler thumbnails: 50x50px with cover object-fit and subtle borders
- Placeholders use dashed borders and muted text color (#666) for visual distinction
- All images have proper border-radius (4px) for consistent design

## Implementation Details
- Images use `object-fit` to maintain aspect ratios while fitting container dimensions
- Conditional rendering checks for `imageUrl` property to determine display mode
- Placeholder elements provide clear visual feedback when images are unavailable
- CSS follows existing design patterns with dark theme colors

https://claude.ai/code/session_01JGZBciCsAJcT5qojsaiaQK