### PR TITLE
Add dev environment support with separate deployment stage

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -208,45 +208,62 @@ aws configure set aws_secret_access_key xIvJd4Vyt2kAZbbK1ZNdtm/W8CvHtSFdjxxBpXwC
 aws configure set region us-east-1 --profile league-szn
 ```
 
-### Live URLs
+---
 
-- **Frontend**: http://leagueszn.jpdxsolo.com
-- **Backend API**: https://9pcccl0caj.execute-api.us-east-1.amazonaws.com/dev
-- **S3 Bucket**: `leagueszn.jpdxsolo.com`
+### Environment Overview
 
-### Deploy Backend to AWS
+| Environment | Frontend URL | Backend API | S3 Bucket | Serverless Stage |
+|-------------|--------------|-------------|-----------|------------------|
+| **Prod** | http://leagueszn.jpdxsolo.com | https://9pcccl0caj.execute-api.us-east-1.amazonaws.com/dev | `leagueszn.jpdxsolo.com` | `dev` (default) |
+| **Dev** | http://dev.leagueszn.jpdxsolo.com | https://dgsmskbzb2.execute-api.us-east-1.amazonaws.com/devtest | `dev.leagueszn.jpdxsolo.com` | `devtest` |
+
+**Note**: Prod uses serverless stage `dev` for historical reasons (to preserve existing table names). Dev uses stage `devtest`.
+
+---
+
+### Deploy to PROD
+
+Deploy backend and frontend to production:
+
 ```bash
-cd backend
-npx serverless deploy --aws-profile league-szn
-```
-
-This deploys:
-- Lambda functions for all API endpoints
-- API Gateway
-- DynamoDB tables (Players, Matches, Championships, ChampionshipHistory, Tournaments)
-
-### Deploy Frontend to S3
-```bash
-cd frontend
-npm run build
-aws s3 sync dist s3://leagueszn.jpdxsolo.com --profile league-szn --delete
-```
-
-### Full Deployment (Both)
-```bash
-# From project root
+# Backend only
 cd backend && npx serverless deploy --aws-profile league-szn
-cd ../frontend && npm run build && aws s3 sync dist s3://leagueszn.jpdxsolo.com --profile league-szn --delete
+
+# Frontend only
+cd frontend && npm run build && aws s3 sync dist s3://leagueszn.jpdxsolo.com --profile league-szn --delete
+
+# Full deployment (both)
+cd backend && npx serverless deploy --aws-profile league-szn && cd ../frontend && npm run build && aws s3 sync dist s3://leagueszn.jpdxsolo.com --profile league-szn --delete
 ```
+
+---
+
+### Deploy to DEV
+
+Deploy backend and frontend to dev/testing environment:
+
+```bash
+# Backend only
+cd backend && npx serverless deploy --stage devtest --aws-profile league-szn
+
+# Frontend only (uses .env.devtest)
+cd frontend && npm run build -- --mode devtest && aws s3 sync dist s3://dev.leagueszn.jpdxsolo.com --profile league-szn --delete
+
+# Full deployment (both)
+cd backend && npx serverless deploy --stage devtest --aws-profile league-szn && cd ../frontend && npm run build -- --mode devtest && aws s3 sync dist s3://dev.leagueszn.jpdxsolo.com --profile league-szn --delete
+```
+
+---
 
 ### DNS Configuration (Namecheap)
 
 Domain `jpdxsolo.com` DNS is managed in Namecheap.
 
-CNAME record for subdomain:
+CNAME records for subdomains:
 | Type | Host | Value |
 |------|------|-------|
 | CNAME | leagueszn | leagueszn.jpdxsolo.com.s3-website-us-east-1.amazonaws.com |
+| CNAME | dev.leagueszn | dev.leagueszn.jpdxsolo.com.s3-website-us-east-1.amazonaws.com |
 
 ## Known Limitations / TODO
 

--- a/frontend/.env.devtest
+++ b/frontend/.env.devtest
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://dgsmskbzb2.execute-api.us-east-1.amazonaws.com/devtest


### PR DESCRIPTION
## Summary
This PR adds support for a separate development environment alongside the existing production environment. It introduces a new `devtest` serverless stage with its own API Gateway endpoint, S3 bucket, and frontend configuration.

## Key Changes
- **Environment Documentation**: Restructured deployment documentation with a clear environment overview table showing prod and dev configurations
- **Dev Environment Setup**: 
  - Added `devtest` serverless stage for backend deployments
  - Created separate S3 bucket (`dev.leagueszn.jpdxsolo.com`) for dev frontend
  - New dev API Gateway endpoint (`https://dgsmskbzb2.execute-api.us-east-1.amazonaws.com/devtest`)
- **Frontend Configuration**: Added `.env.devtest` file with dev API endpoint for Vite build system
- **Deployment Instructions**: Separated and clarified deployment commands for prod vs dev environments with options for backend-only, frontend-only, or full deployments
- **DNS Configuration**: Added CNAME record for `dev.leagueszn` subdomain pointing to dev S3 bucket

## Implementation Details
- Prod environment continues using serverless stage `dev` for historical reasons (preserves existing DynamoDB table names)
- Dev environment uses stage `devtest` to avoid conflicts with production resources
- Frontend build system supports environment-specific configuration via `--mode devtest` flag
- All deployment commands are now explicit about which environment they target

https://claude.ai/code/session_01BgP5TmnQKJynrnAYHZ7ksy