### PR TITLE
Add tag team match support with team-based scheduling and results

### DIFF
--- a/frontend/src/components/Matches.css
+++ b/frontend/src/components/Matches.css
@@ -122,3 +122,25 @@
 .match-result .losers strong {
   color: #f87171;
 }
+
+/* Tag Team Match Styles */
+.tag-team-participants {
+  display: inline;
+}
+
+.team-display {
+  font-weight: 500;
+}
+
+.team-vs {
+  color: #d4af37;
+  font-weight: bold;
+  padding: 0 0.25rem;
+}
+
+.tag-team-result .team-result {
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+  margin-left: 0.25rem;
+}

--- a/frontend/src/components/Matches.tsx
+++ b/frontend/src/components/Matches.tsx
@@ -38,6 +38,30 @@ export default function Matches() {
     return player ? player.name : t('common.unknown');
   };
 
+  const isTagTeamMatch = (match: Match): boolean => {
+    return match.teams !== undefined && match.teams.length >= 2;
+  };
+
+  const formatTeamMembers = (team: string[]): string => {
+    return team.map(getPlayerName).join(' & ');
+  };
+
+  const getTeamParticipants = (match: Match) => {
+    if (!isTagTeamMatch(match)) {
+      return match.participants.map(getPlayerName).join(', ');
+    }
+
+    // Format as "Team 1 vs Team 2 vs Team 3..."
+    return match.teams!.map((team, index) => (
+      <span key={index} className="team-display">
+        {formatTeamMembers(team)}
+        {index < match.teams!.length - 1 && (
+          <span className="team-vs"> {t('common.vs')} </span>
+        )}
+      </span>
+    ));
+  };
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -52,6 +76,31 @@ export default function Matches() {
       return <span className="status-completed">{t('common.completed')}</span>;
     }
 
+    // For tag team matches, show team-based results
+    if (isTagTeamMatch(match) && match.winningTeam !== undefined) {
+      const winningTeam = match.teams![match.winningTeam];
+      const losingTeams = match.teams!.filter((_, index) => index !== match.winningTeam);
+
+      return (
+        <div className="match-result tag-team-result">
+          <div className="winners">
+            <strong>{t('matches.winningTeam')}:</strong>{' '}
+            <span className="team-result">{formatTeamMembers(winningTeam)}</span>
+          </div>
+          <div className="losers">
+            <strong>{losingTeams.length > 1 ? t('matches.losingTeams') : t('matches.losingTeam')}:</strong>{' '}
+            {losingTeams.map((team, index) => (
+              <span key={index} className="team-result">
+                {formatTeamMembers(team)}
+                {index < losingTeams.length - 1 && ', '}
+              </span>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    // Standard match results
     const winners = match.winners.map(getPlayerName).join(', ');
     const losers = match.losers.map(getPlayerName).join(', ');
 
@@ -129,7 +178,13 @@ export default function Matches() {
 
               <div className="match-participants">
                 <strong>{t('matches.participants')}:</strong>{' '}
-                {match.participants.map(getPlayerName).join(', ')}
+                {isTagTeamMatch(match) ? (
+                  <span className="tag-team-participants">
+                    {getTeamParticipants(match)}
+                  </span>
+                ) : (
+                  match.participants.map(getPlayerName).join(', ')
+                )}
               </div>
 
               <div className="match-result-section">

--- a/frontend/src/components/admin/RecordResult.css
+++ b/frontend/src/components/admin/RecordResult.css
@@ -157,6 +157,63 @@
   background-color: #444 !important;
 }
 
+/* Tag Team Selection Styles */
+.teams-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.team-option {
+  background-color: #0f0f0f;
+  border: 2px solid #333;
+  border-radius: 8px;
+  padding: 1.25rem;
+  cursor: pointer;
+  transition: all 0.3s;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.team-option:hover {
+  border-color: #4ade80;
+}
+
+.team-option.winner {
+  border-color: #4ade80;
+  background-color: #14532d;
+}
+
+.team-info {
+  flex: 1;
+}
+
+.team-label {
+  font-weight: bold;
+  color: #d4af37;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.team-members-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.team-member-name {
+  background-color: #1a1a1a;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  color: #fff;
+}
+
+.team-option.winner .team-member-name {
+  background-color: #166534;
+}
+
 @media (max-width: 768px) {
   .matches-result-grid {
     grid-template-columns: 1fr;

--- a/frontend/src/components/admin/RecordResult.tsx
+++ b/frontend/src/components/admin/RecordResult.tsx
@@ -1,13 +1,16 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { matchesApi, playersApi } from '../../services/api';
 import type { Match, Player } from '../../types';
 import './RecordResult.css';
 
 export default function RecordResult() {
+  const { t } = useTranslation();
   const [matches, setMatches] = useState<Match[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
   const [selectedMatch, setSelectedMatch] = useState<Match | null>(null);
   const [winners, setWinners] = useState<string[]>([]);
+  const [winningTeamIndex, setWinningTeamIndex] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -40,9 +43,12 @@ export default function RecordResult() {
   const handleMatchSelect = (match: Match) => {
     setSelectedMatch(match);
     setWinners([]);
+    setWinningTeamIndex(null);
     setError(null);
     setSuccess(null);
   };
+
+  const isTagTeamMatch = selectedMatch?.teams && selectedMatch.teams.length >= 2;
 
   const handleWinnerToggle = (playerId: string) => {
     setWinners(prev =>
@@ -52,25 +58,72 @@ export default function RecordResult() {
     );
   };
 
+  const handleTeamWinnerSelect = (teamIndex: number) => {
+    if (!selectedMatch?.teams) return;
+
+    if (winningTeamIndex === teamIndex) {
+      // Deselect this team
+      setWinningTeamIndex(null);
+      setWinners([]);
+    } else {
+      // Select this team as winner
+      setWinningTeamIndex(teamIndex);
+      setWinners(selectedMatch.teams[teamIndex]);
+    }
+  };
+
+  const getPlayerNameShort = (playerId: string): string => {
+    const player = players.find(p => p.playerId === playerId);
+    return player ? player.name : t('common.unknown');
+  };
+
   const handleSubmit = async () => {
     if (!selectedMatch) return;
 
-    if (winners.length === 0) {
-      setError('Please select at least one winner');
-      return;
-    }
+    if (isTagTeamMatch) {
+      // Tag team match validation
+      if (winningTeamIndex === null || winners.length === 0) {
+        setError(t('recordResult.selectWinningTeam'));
+        return;
+      }
 
-    const losers = selectedMatch.participants.filter(p => !winners.includes(p));
+      // All non-winning team members are losers
+      const losers = selectedMatch.participants.filter(p => !winners.includes(p));
 
-    try {
-      setError(null);
-      await matchesApi.recordResult(selectedMatch.matchId, { winners, losers });
-      setSuccess('Match result recorded successfully!');
-      setSelectedMatch(null);
-      setWinners([]);
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to record result');
+      try {
+        setError(null);
+        await matchesApi.recordResult(selectedMatch.matchId, {
+          winners,
+          losers,
+          winningTeam: winningTeamIndex
+        });
+        setSuccess(t('recordResult.success'));
+        setSelectedMatch(null);
+        setWinners([]);
+        setWinningTeamIndex(null);
+        await loadData();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t('recordResult.error'));
+      }
+    } else {
+      // Standard match validation
+      if (winners.length === 0) {
+        setError(t('recordResult.selectWinner'));
+        return;
+      }
+
+      const losers = selectedMatch.participants.filter(p => !winners.includes(p));
+
+      try {
+        setError(null);
+        await matchesApi.recordResult(selectedMatch.matchId, { winners, losers });
+        setSuccess(t('recordResult.success'));
+        setSelectedMatch(null);
+        setWinners([]);
+        await loadData();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t('recordResult.error'));
+      }
     }
   };
 
@@ -136,23 +189,54 @@ export default function RecordResult() {
                 </div>
 
                 <div className="participants-selection">
-                  <h4>Select Winner(s)</h4>
-                  <div className="participants-list">
-                    {selectedMatch.participants.map(playerId => (
-                      <div
-                        key={playerId}
-                        className={`participant-option ${winners.includes(playerId) ? 'winner' : ''}`}
-                        onClick={() => handleWinnerToggle(playerId)}
-                      >
-                        <div className="participant-info">
-                          {getPlayerName(playerId)}
-                        </div>
-                        {winners.includes(playerId) && (
-                          <span className="winner-badge">Winner</span>
-                        )}
+                  {isTagTeamMatch ? (
+                    <>
+                      <h4>{t('recordResult.selectWinningTeamTitle')}</h4>
+                      <div className="teams-list">
+                        {selectedMatch.teams!.map((team, teamIndex) => (
+                          <div
+                            key={teamIndex}
+                            className={`team-option ${winningTeamIndex === teamIndex ? 'winner' : ''}`}
+                            onClick={() => handleTeamWinnerSelect(teamIndex)}
+                          >
+                            <div className="team-info">
+                              <div className="team-label">{t('recordResult.team')} {teamIndex + 1}</div>
+                              <div className="team-members-list">
+                                {team.map(playerId => (
+                                  <span key={playerId} className="team-member-name">
+                                    {getPlayerNameShort(playerId)}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                            {winningTeamIndex === teamIndex && (
+                              <span className="winner-badge">{t('recordResult.winner')}</span>
+                            )}
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
+                    </>
+                  ) : (
+                    <>
+                      <h4>{t('recordResult.selectWinners')}</h4>
+                      <div className="participants-list">
+                        {selectedMatch.participants.map(playerId => (
+                          <div
+                            key={playerId}
+                            className={`participant-option ${winners.includes(playerId) ? 'winner' : ''}`}
+                            onClick={() => handleWinnerToggle(playerId)}
+                          >
+                            <div className="participant-info">
+                              {getPlayerName(playerId)}
+                            </div>
+                            {winners.includes(playerId) && (
+                              <span className="winner-badge">{t('recordResult.winner')}</span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
                 </div>
 
                 <div className="result-actions">

--- a/frontend/src/components/admin/ScheduleMatch.css
+++ b/frontend/src/components/admin/ScheduleMatch.css
@@ -88,8 +88,159 @@
   border: 1px solid #166534;
 }
 
+/* Tag Team Selection Styles */
+.tag-team-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.team-section {
+  background-color: #0f0f0f;
+  border: 2px solid #333;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.team-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.team-header h4 {
+  margin: 0;
+  color: #d4af37;
+  font-size: 1rem;
+}
+
+.remove-team-btn {
+  background-color: #991b1b;
+  color: #fff;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.remove-team-btn:hover {
+  background-color: #b91c1c;
+}
+
+.team-members {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-height: 2rem;
+  padding: 0.5rem;
+  background-color: #1a1a1a;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.team-member-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background-color: #d4af37;
+  color: #000;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: bold;
+}
+
+.remove-member-btn {
+  background: none;
+  border: none;
+  color: #000;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  margin-left: 0.25rem;
+}
+
+.remove-member-btn:hover {
+  color: #991b1b;
+}
+
+.no-members {
+  color: #666;
+  font-style: italic;
+  font-size: 0.875rem;
+}
+
+.team-players-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.5rem;
+}
+
+.team-players-grid .participant-card {
+  padding: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.participant-card.in-other-team {
+  opacity: 0.5;
+  cursor: not-allowed;
+  border-color: #444;
+}
+
+.other-team-label {
+  font-size: 0.7rem;
+  color: #888;
+  margin-top: 0.25rem;
+}
+
+.add-team-btn {
+  background-color: #1a1a1a;
+  border: 2px dashed #333;
+  color: #888;
+  padding: 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.add-team-btn:hover {
+  border-color: #d4af37;
+  color: #d4af37;
+}
+
+.teams-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.team-count {
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.team-count.valid {
+  background-color: #14532d;
+  color: #4ade80;
+}
+
+.team-count.invalid {
+  background-color: #450a0a;
+  color: #f87171;
+}
+
 @media (max-width: 640px) {
   .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .team-players-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/components/admin/ScheduleMatch.tsx
+++ b/frontend/src/components/admin/ScheduleMatch.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { matchesApi, playersApi, championshipsApi, tournamentsApi, seasonsApi } from '../../services/api';
 import type { Player, Championship, Tournament, Season } from '../../types';
 import './ScheduleMatch.css';
 
 export default function ScheduleMatch() {
+  const { t } = useTranslation();
   const [players, setPlayers] = useState<Player[]>([]);
   const [championships, setChampionships] = useState<Championship[]>([]);
   const [tournaments, setTournaments] = useState<Tournament[]>([]);
@@ -11,6 +13,9 @@ export default function ScheduleMatch() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+
+  // Tag team state: array of teams, each team is an array of player IDs
+  const [teams, setTeams] = useState<string[][]>([[], []]);
 
   const [formData, setFormData] = useState({
     date: '',
@@ -53,45 +58,83 @@ export default function ScheduleMatch() {
     }
   };
 
+  const isTagTeamMatch = formData.matchType === 'tag';
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
     setSuccess(null);
 
-    if (formData.participants.length < 2) {
-      setError('Please select at least 2 participants');
-      return;
-    }
+    if (isTagTeamMatch) {
+      // For tag team matches, validate teams
+      const validTeams = teams.filter(team => team.length >= 2);
+      if (validTeams.length < 2) {
+        setError(t('scheduleMatch.tagTeam.minTeamsError'));
+        return;
+      }
+      // All participants are members of all teams combined
+      const allParticipants = teams.flat();
 
-    try {
-      await matchesApi.schedule({
-        date: new Date(formData.date).toISOString(),
-        matchType: formData.matchType,
-        stipulation: formData.stipulation,
-        participants: formData.participants,
-        isChampionship: formData.isChampionship,
-        championshipId: formData.championshipId || undefined,
-        tournamentId: formData.tournamentId || undefined,
-        seasonId: formData.seasonId || undefined,
-        status: 'scheduled',
-      });
+      try {
+        await matchesApi.schedule({
+          date: new Date(formData.date).toISOString(),
+          matchType: formData.matchType,
+          stipulation: formData.stipulation,
+          participants: allParticipants,
+          teams: validTeams,
+          isChampionship: formData.isChampionship,
+          championshipId: formData.championshipId || undefined,
+          tournamentId: formData.tournamentId || undefined,
+          seasonId: formData.seasonId || undefined,
+          status: 'scheduled',
+        });
 
-      setSuccess('Match scheduled successfully!');
-      // Reset form but keep the active season selected
-      const activeSeason = seasons.find(s => s.status === 'active');
-      setFormData({
-        date: '',
-        matchType: 'singles',
-        stipulation: '',
-        participants: [],
-        isChampionship: false,
-        championshipId: '',
-        tournamentId: '',
-        seasonId: activeSeason?.seasonId || '',
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to schedule match');
+        setSuccess(t('scheduleMatch.success'));
+        resetForm();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t('scheduleMatch.error'));
+      }
+    } else {
+      // Non-tag team match validation
+      if (formData.participants.length < 2) {
+        setError(t('scheduleMatch.minParticipantsError'));
+        return;
+      }
+
+      try {
+        await matchesApi.schedule({
+          date: new Date(formData.date).toISOString(),
+          matchType: formData.matchType,
+          stipulation: formData.stipulation,
+          participants: formData.participants,
+          isChampionship: formData.isChampionship,
+          championshipId: formData.championshipId || undefined,
+          tournamentId: formData.tournamentId || undefined,
+          seasonId: formData.seasonId || undefined,
+          status: 'scheduled',
+        });
+
+        setSuccess(t('scheduleMatch.success'));
+        resetForm();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t('scheduleMatch.error'));
+      }
     }
+  };
+
+  const resetForm = () => {
+    const activeSeason = seasons.find(s => s.status === 'active');
+    setFormData({
+      date: '',
+      matchType: 'singles',
+      stipulation: '',
+      participants: [],
+      isChampionship: false,
+      championshipId: '',
+      tournamentId: '',
+      seasonId: activeSeason?.seasonId || '',
+    });
+    setTeams([[], []]);
   };
 
   const handleParticipantToggle = (playerId: string) => {
@@ -101,6 +144,53 @@ export default function ScheduleMatch() {
         ? prev.participants.filter(id => id !== playerId)
         : [...prev.participants, playerId],
     }));
+  };
+
+  // Tag team helper functions
+  const handleTeamMemberToggle = (teamIndex: number, playerId: string) => {
+    setTeams(prev => {
+      const newTeams = [...prev];
+      const team = [...newTeams[teamIndex]];
+
+      if (team.includes(playerId)) {
+        // Remove from this team
+        newTeams[teamIndex] = team.filter(id => id !== playerId);
+      } else {
+        // Remove from other teams first
+        newTeams.forEach((t, i) => {
+          if (i !== teamIndex) {
+            newTeams[i] = t.filter(id => id !== playerId);
+          }
+        });
+        // Add to this team
+        newTeams[teamIndex] = [...team, playerId];
+      }
+
+      return newTeams;
+    });
+  };
+
+  const addTeam = () => {
+    setTeams(prev => [...prev, []]);
+  };
+
+  const removeTeam = (teamIndex: number) => {
+    if (teams.length <= 2) return; // Keep at least 2 teams
+    setTeams(prev => prev.filter((_, i) => i !== teamIndex));
+  };
+
+  const getPlayerTeamIndex = (playerId: string): number => {
+    return teams.findIndex(team => team.includes(playerId));
+  };
+
+  const getPlayerName = (playerId: string): string => {
+    const player = players.find(p => p.playerId === playerId);
+    return player ? player.name : t('common.unknown');
+  };
+
+  const handleMatchTypeChange = (newType: string) => {
+    setFormData(prev => ({ ...prev, matchType: newType, participants: [] }));
+    setTeams([[], []]);
   };
 
   if (loading) {
@@ -128,19 +218,19 @@ export default function ScheduleMatch() {
           </div>
 
           <div className="form-group">
-            <label htmlFor="matchType">Match Type</label>
+            <label htmlFor="matchType">{t('scheduleMatch.matchType')}</label>
             <select
               id="matchType"
               value={formData.matchType}
-              onChange={(e) => setFormData({ ...formData, matchType: e.target.value })}
+              onChange={(e) => handleMatchTypeChange(e.target.value)}
               required
             >
-              <option value="singles">Singles</option>
-              <option value="tag">Tag Team</option>
-              <option value="triple-threat">Triple Threat</option>
-              <option value="fatal-4-way">Fatal 4-Way</option>
-              <option value="six-pack">Six Pack Challenge</option>
-              <option value="battle-royal">Battle Royal</option>
+              <option value="singles">{t('scheduleMatch.matchTypes.singles')}</option>
+              <option value="tag">{t('scheduleMatch.matchTypes.tag')}</option>
+              <option value="triple-threat">{t('scheduleMatch.matchTypes.tripleThread')}</option>
+              <option value="fatal-4-way">{t('scheduleMatch.matchTypes.fatal4Way')}</option>
+              <option value="six-pack">{t('scheduleMatch.matchTypes.sixPack')}</option>
+              <option value="battle-royal">{t('scheduleMatch.matchTypes.battleRoyal')}</option>
             </select>
           </div>
         </div>
@@ -228,26 +318,101 @@ export default function ScheduleMatch() {
           </div>
         )}
 
-        <div className="form-group">
-          <label>Participants (Select {formData.matchType === 'singles' ? '2' : '2+'})</label>
-          <div className="participants-grid">
-            {players.map(player => (
-              <div
-                key={player.playerId}
-                className={`participant-card ${formData.participants.includes(player.playerId) ? 'selected' : ''}`}
-                onClick={() => handleParticipantToggle(player.playerId)}
-              >
-                <div className="participant-name">{player.name}</div>
-                <div className="participant-wrestler">{player.currentWrestler}</div>
-              </div>
-            ))}
+        {isTagTeamMatch ? (
+          /* Tag Team Selection UI */
+          <div className="form-group">
+            <label>{t('scheduleMatch.tagTeam.selectTeams')}</label>
+            <div className="tag-team-container">
+              {teams.map((team, teamIndex) => (
+                <div key={teamIndex} className="team-section">
+                  <div className="team-header">
+                    <h4>{t('scheduleMatch.tagTeam.team')} {teamIndex + 1}</h4>
+                    {teams.length > 2 && (
+                      <button
+                        type="button"
+                        className="remove-team-btn"
+                        onClick={() => removeTeam(teamIndex)}
+                      >
+                        {t('common.delete')}
+                      </button>
+                    )}
+                  </div>
+                  <div className="team-members">
+                    {team.length > 0 ? (
+                      team.map(playerId => (
+                        <span key={playerId} className="team-member-tag">
+                          {getPlayerName(playerId)}
+                          <button
+                            type="button"
+                            className="remove-member-btn"
+                            onClick={() => handleTeamMemberToggle(teamIndex, playerId)}
+                          >
+                            ×
+                          </button>
+                        </span>
+                      ))
+                    ) : (
+                      <span className="no-members">{t('scheduleMatch.tagTeam.noMembers')}</span>
+                    )}
+                  </div>
+                  <div className="team-players-grid">
+                    {players.filter(p => !team.includes(p.playerId)).map(player => {
+                      const playerTeamIndex = getPlayerTeamIndex(player.playerId);
+                      const isInOtherTeam = playerTeamIndex !== -1 && playerTeamIndex !== teamIndex;
+                      return (
+                        <div
+                          key={player.playerId}
+                          className={`participant-card ${isInOtherTeam ? 'in-other-team' : ''}`}
+                          onClick={() => !isInOtherTeam && handleTeamMemberToggle(teamIndex, player.playerId)}
+                        >
+                          <div className="participant-name">{player.name}</div>
+                          <div className="participant-wrestler">{player.currentWrestler}</div>
+                          {isInOtherTeam && (
+                            <div className="other-team-label">
+                              {t('scheduleMatch.tagTeam.team')} {playerTeamIndex + 1}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+              <button type="button" className="add-team-btn" onClick={addTeam}>
+                + {t('scheduleMatch.tagTeam.addTeam')}
+              </button>
+            </div>
+            <div className="teams-summary">
+              {teams.map((team, i) => (
+                <span key={i} className={`team-count ${team.length >= 2 ? 'valid' : 'invalid'}`}>
+                  {t('scheduleMatch.tagTeam.team')} {i + 1}: {team.length} {t('scheduleMatch.tagTeam.members')}
+                </span>
+              ))}
+            </div>
           </div>
-          <div className="selected-count">
-            Selected: {formData.participants.length}
+        ) : (
+          /* Standard Participant Selection UI */
+          <div className="form-group">
+            <label>{t('scheduleMatch.participants')} ({formData.matchType === 'singles' ? '2' : '2+'})</label>
+            <div className="participants-grid">
+              {players.map(player => (
+                <div
+                  key={player.playerId}
+                  className={`participant-card ${formData.participants.includes(player.playerId) ? 'selected' : ''}`}
+                  onClick={() => handleParticipantToggle(player.playerId)}
+                >
+                  <div className="participant-name">{player.name}</div>
+                  <div className="participant-wrestler">{player.currentWrestler}</div>
+                </div>
+              ))}
+            </div>
+            <div className="selected-count">
+              {t('scheduleMatch.selected')}: {formData.participants.length}
+            </div>
           </div>
-        </div>
+        )}
 
-        <button type="submit">Schedule Match</button>
+        <button type="submit">{t('scheduleMatch.submit')}</button>
       </form>
     </div>
   );

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -95,7 +95,57 @@
     "winner": "Sieger",
     "winners": "Sieger",
     "loser": "Verlierer",
-    "losers": "Verlierer"
+    "losers": "Verlierer",
+    "winningTeam": "Sieger-Team",
+    "losingTeam": "Verlierer-Team",
+    "losingTeams": "Verlierer-Teams"
+  },
+  "scheduleMatch": {
+    "title": "Kampf planen",
+    "dateTime": "Datum & Uhrzeit",
+    "matchType": "Kampftyp",
+    "matchTypes": {
+      "singles": "Einzel",
+      "tag": "Tag Team",
+      "tripleThread": "Triple Threat",
+      "fatal4Way": "Fatal 4-Way",
+      "sixPack": "Six Pack Challenge",
+      "battleRoyal": "Battle Royal"
+    },
+    "stipulation": "Stipulation (Optional)",
+    "stipulationPlaceholder": "z.B. Leiterkampf, Stahlkäfig, Hell in a Cell",
+    "participants": "Teilnehmer",
+    "selected": "Ausgewählt",
+    "submit": "Kampf planen",
+    "success": "Kampf erfolgreich geplant!",
+    "error": "Kampf konnte nicht geplant werden",
+    "minParticipantsError": "Bitte wählen Sie mindestens 2 Teilnehmer aus",
+    "tagTeam": {
+      "selectTeams": "Teams auswählen",
+      "team": "Team",
+      "addTeam": "Team hinzufügen",
+      "noMembers": "Keine Mitglieder ausgewählt",
+      "members": "Mitglieder",
+      "minTeamsError": "Bitte erstellen Sie mindestens 2 Teams mit je 2+ Mitgliedern"
+    }
+  },
+  "recordResult": {
+    "title": "Kampfergebnisse eintragen",
+    "scheduledMatches": "Geplante Kämpfe",
+    "recordResult": "Ergebnis eintragen",
+    "matchType": "Kampftyp",
+    "stipulation": "Stipulation",
+    "date": "Datum",
+    "selectWinners": "Sieger auswählen",
+    "selectWinningTeamTitle": "Sieger-Team auswählen",
+    "team": "Team",
+    "winner": "Sieger",
+    "selectWinner": "Bitte wählen Sie mindestens einen Sieger aus",
+    "selectWinningTeam": "Bitte wählen Sie das Sieger-Team aus",
+    "success": "Kampfergebnis erfolgreich eingetragen!",
+    "error": "Ergebnis konnte nicht eingetragen werden",
+    "selectMatch": "Wählen Sie einen Kampf aus, um das Ergebnis einzutragen",
+    "noScheduledMatches": "Keine geplanten Kämpfe zum Eintragen vorhanden."
   },
   "tournaments": {
     "title": "Turniere",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -95,7 +95,57 @@
     "winner": "Winner",
     "winners": "Winners",
     "loser": "Loser",
-    "losers": "Losers"
+    "losers": "Losers",
+    "winningTeam": "Winning Team",
+    "losingTeam": "Losing Team",
+    "losingTeams": "Losing Teams"
+  },
+  "scheduleMatch": {
+    "title": "Schedule Match",
+    "dateTime": "Date & Time",
+    "matchType": "Match Type",
+    "matchTypes": {
+      "singles": "Singles",
+      "tag": "Tag Team",
+      "tripleThread": "Triple Threat",
+      "fatal4Way": "Fatal 4-Way",
+      "sixPack": "Six Pack Challenge",
+      "battleRoyal": "Battle Royal"
+    },
+    "stipulation": "Stipulation (Optional)",
+    "stipulationPlaceholder": "e.g., Ladder Match, Steel Cage, Hell in a Cell",
+    "participants": "Participants",
+    "selected": "Selected",
+    "submit": "Schedule Match",
+    "success": "Match scheduled successfully!",
+    "error": "Failed to schedule match",
+    "minParticipantsError": "Please select at least 2 participants",
+    "tagTeam": {
+      "selectTeams": "Select Teams",
+      "team": "Team",
+      "addTeam": "Add Team",
+      "noMembers": "No members selected",
+      "members": "members",
+      "minTeamsError": "Please create at least 2 teams with 2+ members each"
+    }
+  },
+  "recordResult": {
+    "title": "Record Match Results",
+    "scheduledMatches": "Scheduled Matches",
+    "recordResult": "Record Result",
+    "matchType": "Match Type",
+    "stipulation": "Stipulation",
+    "date": "Date",
+    "selectWinners": "Select Winner(s)",
+    "selectWinningTeamTitle": "Select Winning Team",
+    "team": "Team",
+    "winner": "Winner",
+    "selectWinner": "Please select at least one winner",
+    "selectWinningTeam": "Please select the winning team",
+    "success": "Match result recorded successfully!",
+    "error": "Failed to record result",
+    "selectMatch": "Select a match to record its result",
+    "noScheduledMatches": "No scheduled matches to record results for."
   },
   "tournaments": {
     "title": "Tournaments",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -82,7 +82,7 @@ export const matchesApi = {
     });
   },
 
-  recordResult: async (matchId: string, result: { winners: string[], losers: string[] }): Promise<Match> => {
+  recordResult: async (matchId: string, result: { winners: string[], losers: string[], winningTeam?: number }): Promise<Match> => {
     return fetchWithAuth(`${API_BASE_URL}/matches/${matchId}/result`, {
       method: 'PUT',
       body: JSON.stringify(result),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,8 +17,10 @@ export interface Match {
   matchType: string; // "singles", "tag", "triple-threat", etc.
   stipulation?: string; // "ladder", "cage", "hell-in-a-cell", etc.
   participants: string[]; // playerIds
+  teams?: string[][]; // Array of teams, each team is an array of playerIds (for tag team matches)
   winners?: string[]; // playerIds
   losers?: string[]; // playerIds
+  winningTeam?: number; // Index of winning team (for tag team matches)
   isChampionship: boolean;
   championshipId?: string;
   tournamentId?: string;


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for tag team matches throughout the application, enabling users to schedule matches with multiple teams and record results on a team basis rather than individual players.

## Key Changes

### Match Scheduling (ScheduleMatch)
- Added tag team match type selection with dedicated UI for team composition
- Implemented team management: add/remove teams, add/remove team members
- Teams are mutually exclusive - players can only belong to one team
- Visual feedback showing team composition and validation status
- Minimum requirement: 2 teams with 2+ members each

### Match Results Recording (RecordResult)
- Added team-based result recording for tag team matches
- Displays teams as selectable units instead of individual players
- Winning team selection automatically marks all team members as winners
- Non-winning teams are marked as losers
- Maintains backward compatibility with standard match result recording

### Match Display (Matches)
- Enhanced match participants display to show team composition (Team 1 vs Team 2 format)
- Updated match results section to display winning/losing teams
- Added visual styling for team-based results with team member badges

### Data Model Updates
- Extended `Match` type with `teams` field (array of player ID arrays)
- Added `winningTeam` field to track winning team index
- Updated API contract for `recordResult` to accept optional `winningTeam` parameter

### Styling
- Added comprehensive CSS for tag team UI components
- Team selection cards with hover states and winner highlighting
- Team member tags with remove buttons
- Responsive grid layouts for team player selection
- Visual distinction between selected and unavailable players

### Internationalization
- Added German and English translations for all new UI elements
- Translations cover match types, team management, and result recording

## Implementation Details
- Tag team detection based on presence of `teams` array in match data
- Players can only be in one team at a time during scheduling
- Team-based results automatically populate winners/losers arrays
- Maintains full backward compatibility with existing singles/multi-person matches

https://claude.ai/code/session_01GREjuH3CoexYu3KmJao99j