### PR TITLE
docs: Expand tech stack documentation with detailed tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,55 @@ A serverless web application for managing a WWE 2K league with player standings,
 ## Tech Stack
 
 ### Frontend
-- React 18 with TypeScript
-- Vite for build tooling
-- React Router for navigation
+
+| Technology | Version | Description |
+|------------|---------|-------------|
+| **React** | 18.2.0 | UI framework for building interactive, component-based user interfaces |
+| **TypeScript** | 5.2.2 | Typed superset of JavaScript providing compile-time type checking and IDE support |
+| **Vite** | 5.0.8 | Modern build tool with hot module replacement for fast development |
+| **React Router DOM** | 6.20.1 | Client-side routing for SPA navigation between pages (Standings, Championships, Matches, etc.) |
+| **i18next** | 25.8.1 | Internationalization framework supporting multiple languages (English and German) |
+| **react-i18next** | 16.5.4 | React bindings for i18next with hooks and components |
+| **AWS Amplify** | 6.16.0 | AWS integration library for authentication and cloud services |
+| **amazon-cognito-identity-js** | 6.3.7 | Cognito SDK for client-side user authentication |
+| **@aws-sdk/client-s3** | 3.981.0 | AWS SDK v3 for S3 operations (image uploads) |
+| **ESLint** | 8.55.0 | JavaScript/TypeScript linter with React Hooks and TypeScript plugins |
 
 ### Backend
-- AWS Lambda (Node.js 18)
-- API Gateway
-- DynamoDB
-- Serverless Framework
+
+| Technology | Version | Description |
+|------------|---------|-------------|
+| **Node.js** | 18.x | JavaScript runtime for serverless Lambda functions |
+| **TypeScript** | 5.3.3 | Type-safe backend code with compile-time checking |
+| **@aws-sdk/client-dynamodb** | 3.450.0 | AWS SDK v3 for DynamoDB database operations |
+| **@aws-sdk/lib-dynamodb** | 3.450.0 | High-level DynamoDB Document Client for simplified operations |
+| **@aws-sdk/client-s3** | 3.450.0 | S3 client for image storage and presigned URL generation |
+| **@aws-sdk/client-cognito-identity-provider** | 3.982.0 | Cognito IDP client for admin user management |
+| **aws-jwt-verify** | 5.1.1 | JWT verification library for validating Cognito tokens in Lambda authorizer |
+| **uuid** | 9.0.1 | UUID generation for unique entity identifiers |
+| **Serverless Framework** | 3.38.0 | Infrastructure as Code framework for deploying serverless applications |
+| **serverless-offline** | 13.3.0 | Local emulation of API Gateway and Lambda for development |
+
+### AWS Infrastructure
+
+| Service | Purpose |
+|---------|---------|
+| **AWS Lambda** | Serverless compute for API handlers (auth, players, matches, championships, tournaments, standings, seasons, divisions, images, admin) |
+| **API Gateway** | REST API with CORS support and custom JWT authorizer for admin endpoints |
+| **DynamoDB** | NoSQL database with on-demand billing for Players, Matches, Championships, Championship History, Tournaments, Seasons, Season Standings, and Divisions tables |
+| **Amazon S3** | Object storage for frontend static files and player/championship images with presigned URLs |
+| **CloudFront** | CDN for global content delivery with HTTPS enforcement and SPA routing support |
+| **AWS Cognito** | User pool for admin authentication with username-based sign-in and JWT tokens |
+| **AWS Certificate Manager** | SSL/TLS certificate management for HTTPS on custom domains |
+
+### CI/CD & DevOps
+
+| Technology | Description |
+|------------|-------------|
+| **GitHub Actions** | Automated CI/CD pipelines for deployment |
+| **deploy-dev.yml** | Triggered on pull requests to main - deploys to devtest stage |
+| **deploy-prod.yml** | Triggered on merged pull requests - deploys to production |
+| **Docker** | Used for running DynamoDB Local in development |
 
 ## Project Structure
 

--- a/claude.md
+++ b/claude.md
@@ -4,10 +4,67 @@
 A serverless web application for managing a WWE 2K league with player standings, championships, matches, and tournaments.
 
 ## Tech Stack
-- **Frontend**: React 18 + TypeScript, Vite, React Router
-- **Backend**: AWS Lambda (Node.js 18), API Gateway, DynamoDB
-- **Infrastructure**: Serverless Framework
-- **Local Development**: serverless-offline, DynamoDB Local (Docker)
+
+### Frontend Technologies
+
+| Technology | Version | How It's Used |
+|------------|---------|---------------|
+| **React** | 18.2.0 | Core UI framework - builds all components (Standings, Championships, Matches, Tournaments, Admin panels) |
+| **TypeScript** | 5.2.2 | Provides type safety across all frontend code; interfaces defined in `types/index.ts` |
+| **Vite** | 5.0.8 | Development server with HMR; production bundler with optimized builds |
+| **React Router DOM** | 6.20.1 | Client-side routing - handles navigation between all pages without full reloads |
+| **i18next** | 25.8.1 | Internationalization - supports English and German; auto-detects browser language |
+| **react-i18next** | 16.5.4 | React hooks (`useTranslation`) for i18next integration |
+| **AWS Amplify** | 6.16.0 | Configures and initializes AWS services (Cognito auth) |
+| **amazon-cognito-identity-js** | 6.3.7 | Handles admin login/logout with Cognito User Pool |
+| **@aws-sdk/client-s3** | 3.981.0 | Browser-side S3 uploads for player/championship images |
+| **@aws-sdk/lib-storage** | 3.981.0 | Multi-part upload support for larger images |
+| **ESLint** | 8.55.0 | Code quality with React Hooks and TypeScript rules |
+
+### Backend Technologies
+
+| Technology | Version | How It's Used |
+|------------|---------|---------------|
+| **Node.js** | 18.x | Lambda runtime - all API handlers run on Node.js 18 |
+| **TypeScript** | 5.3.3 | Type-safe Lambda functions; compiled to JS before deployment |
+| **@aws-sdk/client-dynamodb** | 3.450.0 | Low-level DynamoDB operations |
+| **@aws-sdk/lib-dynamodb** | 3.450.0 | Document Client for simplified DynamoDB CRUD operations |
+| **@aws-sdk/client-s3** | 3.450.0 | Generates presigned URLs for secure image uploads |
+| **@aws-sdk/s3-request-presigner** | 3.450.0 | Creates time-limited signed URLs for S3 |
+| **@aws-sdk/client-cognito-identity-provider** | 3.982.0 | Admin operations on Cognito users |
+| **aws-jwt-verify** | 5.1.1 | Validates Cognito JWT tokens in Lambda authorizer (`functions/auth/authorizer.ts`) |
+| **uuid** | 9.0.1 | Generates unique IDs for players, matches, championships, etc. |
+| **ts-node** | 10.9.2 | Runs TypeScript scripts directly (`seed-data.ts`, `clear-data.ts`) |
+| **Serverless Framework** | 3.38.0 | Deploys all infrastructure defined in `serverless.yml` |
+| **serverless-plugin-typescript** | 2.1.5 | Auto-compiles TypeScript during serverless deploy |
+| **serverless-offline** | 13.3.0 | Local API Gateway + Lambda emulation for development |
+| **serverless-s3-sync** | 3.5.1 | Syncs frontend build to S3 bucket |
+
+### AWS Infrastructure
+
+| Service | How It's Used |
+|---------|---------------|
+| **AWS Lambda** | Serverless functions for all API endpoints - organized by feature: `auth/`, `players/`, `matches/`, `championships/`, `tournaments/`, `standings/`, `seasons/`, `divisions/`, `images/`, `admin/` |
+| **API Gateway** | REST API exposing Lambda functions via HTTP; CORS configured for browser access; custom authorizer validates JWT tokens for admin routes |
+| **DynamoDB** | NoSQL database with 8 tables: Players, Matches (with TournamentIndex GSI), Championships, ChampionshipHistory, Tournaments, Seasons, SeasonStandings (with PlayerIndex GSI), Divisions - all use on-demand (PAY_PER_REQUEST) billing |
+| **Amazon S3** | Two purposes: (1) hosts frontend static files, (2) stores player/championship images with public read access and presigned URL uploads |
+| **CloudFront** | CDN in front of S3; custom error responses redirect 403/404 to /index.html for SPA routing; HTTPS enforced |
+| **AWS Cognito** | User Pool for admin authentication - username-based login (not email), 24hr access tokens, 30-day refresh tokens |
+| **ACM** | SSL/TLS certificates for CloudFront HTTPS |
+
+### CI/CD & DevOps
+
+| Technology | How It's Used |
+|------------|---------------|
+| **GitHub Actions** | Two workflows automate deployment |
+| **deploy-dev.yml** | Triggered on PRs to main - builds frontend with `.env.devtest`, deploys backend to `devtest` stage, syncs to dev S3 bucket |
+| **deploy-prod.yml** | Triggered on merged PRs - builds frontend with `.env.production`, deploys backend to `dev` stage (production), syncs to prod S3 bucket, invalidates CloudFront cache |
+| **Docker** | Runs DynamoDB Local (`amazon/dynamodb-local`) for offline development |
+
+### Local Development Stack
+- **DynamoDB Local**: Docker container on port 8000 for local database
+- **serverless-offline**: API Gateway + Lambda emulation on port 3001
+- **Vite dev server**: Frontend on port 3000 with HMR
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
Enhanced the README.md and claude.md documentation by converting the tech stack sections into comprehensive, well-organized tables that provide version numbers, descriptions, and usage details for all technologies used in the project.

## Key Changes

- **Restructured Frontend section**: Converted bullet points into a detailed table with React, TypeScript, Vite, React Router, i18next, AWS Amplify, Cognito, S3 SDK, and ESLint with specific versions and descriptions
- **Restructured Backend section**: Created a table documenting Node.js, TypeScript, AWS SDKs (DynamoDB, S3, Cognito), JWT verification, UUID generation, Serverless Framework, and related plugins with versions
- **Added AWS Infrastructure section**: New table breaking down Lambda, API Gateway, DynamoDB, S3, CloudFront, Cognito, and ACM with their specific purposes
- **Added CI/CD & DevOps section**: Documented GitHub Actions workflows (deploy-dev.yml, deploy-prod.yml) and Docker usage for local development
- **Enhanced claude.md**: Expanded with similar table-based documentation including "How It's Used" column for better context on each technology's role in the project
- **Added Local Development Stack section**: Clarified the development environment setup with DynamoDB Local, serverless-offline, and Vite dev server

## Notable Details

- All version numbers are now explicitly documented for reproducibility
- Each technology includes a clear description of its purpose and usage
- AWS services are organized by category (compute, database, storage, CDN, auth, certificates)
- CI/CD workflows are documented with their triggers and deployment targets
- Frontend and backend technologies are clearly separated with their specific versions (e.g., TypeScript 5.2.2 frontend vs 5.3.3 backend)

https://claude.ai/code/session_01Pok9e98YQE4dyPQ5Dtr3yD