### PR TITLE
Upgrade Node.js runtime from 20.x to 24.x

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
 
 jobs:
   deploy-dev:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
 
 jobs:
   deploy-prod:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A serverless web application for managing a WWE 2K league with player standings,
 
 | Technology | Version | Description |
 |------------|---------|-------------|
-| **Node.js** | 20.x | JavaScript runtime for serverless Lambda functions |
+| **Node.js** | 24.x | JavaScript runtime for serverless Lambda functions |
 | **TypeScript** | 5.3.3 | Type-safe backend code with compile-time checking |
 | **@aws-sdk/client-dynamodb** | 3.450.0 | AWS SDK v3 for DynamoDB database operations |
 | **@aws-sdk/lib-dynamodb** | 3.450.0 | High-level DynamoDB Document Client for simplified operations |
@@ -174,7 +174,7 @@ npm run clear-data
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 24+
 - AWS CLI configured with the `league-szn` profile
 
 ---
@@ -248,9 +248,9 @@ docker pull amazon/dynamodb-local
 # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
 ```
 
-2. Make sure you have Node.js installed (v20+):
+2. Make sure you have Node.js installed (v24+):
 ```bash
-node --version  # Should be 20 or higher
+node --version  # Should be 24 or higher
 ```
 
 ### Step-by-Step Local Setup

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: '3'
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs24.x
   region: us-east-1
   stage: ${opt:stage, 'dev'}
   environment:


### PR DESCRIPTION
## Summary
This pull request upgrades the Node.js runtime version from 20.x to 24.x across all deployment configurations and documentation.

## Key Changes
- Updated AWS Lambda runtime in `serverless.yml` from `nodejs20.x` to `nodejs24.x`
- Updated Node.js version in GitHub Actions workflows (`deploy-dev.yml` and `deploy-prod.yml`) from `'20'` to `'24'`
- Updated all documentation references in `README.md` to reflect the new Node.js 24.x requirement:
  - Technology stack table
  - Prerequisites section
  - Local setup instructions

## Implementation Details
- All changes are consistent across development and production environments
- The upgrade ensures the serverless application uses the latest stable Node.js LTS version
- Documentation has been updated to guide users on the new minimum Node.js version requirement (24+)
- No code logic changes were necessary; this is purely a runtime version bump

https://claude.ai/code/session_01KVv5PhGBL4mR4KdA3sjrap