### PR TITLE
Convert sidebar from toggle to permanent fixed layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -17,6 +17,7 @@ header {
   display: flex;
   align-items: center;
   gap: 1rem;
+  margin-left: 300px;
 }
 
 header h1 {
@@ -28,7 +29,7 @@ header h1 {
 main {
   padding: 2rem;
   max-width: 1200px;
-  margin: 0 auto;
+  margin-left: 300px;
 }
 
 h2 {
@@ -86,4 +87,14 @@ th {
 
 tr:hover {
   background-color: #1a1a1a;
+}
+
+@media (max-width: 768px) {
+  header {
+    margin-left: 280px;
+  }
+
+  main {
+    margin-left: 280px;
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import './i18n';
@@ -46,17 +45,13 @@ import './App.css';
 
 function App() {
   const { t } = useTranslation();
-  const [sidebarOpen, setSidebarOpen] = useState(true);
 
   return (
     <ErrorBoundary>
       <Router>
         <div className="App">
-        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+        <Sidebar />
         <header>
-          <button className="hamburger-btn" onClick={() => setSidebarOpen(true)} aria-label="Open menu">
-            &#9776;
-          </button>
           <h1>{t('header.title')}</h1>
         </header>
         <main>

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,17 +1,7 @@
-.sidebar-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  z-index: 998;
-}
-
 .sidebar {
   position: fixed;
   top: 0;
-  left: -300px;
+  left: 0;
   width: 300px;
   height: 100vh;
   background-color: #111;
@@ -19,12 +9,7 @@
   z-index: 999;
   display: flex;
   flex-direction: column;
-  transition: left 0.3s ease;
   overflow-y: auto;
-}
-
-.sidebar.open {
-  left: 0;
 }
 
 .sidebar-header {
@@ -39,21 +24,6 @@
   color: #d4af37;
   font-size: 1.25rem;
   margin: 0;
-}
-
-.sidebar-close {
-  background: none !important;
-  border: none;
-  color: #888;
-  font-size: 1.25rem;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  line-height: 1;
-}
-
-.sidebar-close:hover {
-  color: #fff;
-  background: none !important;
 }
 
 .sidebar-nav {
@@ -202,27 +172,8 @@
   border-top: 1px solid #222;
 }
 
-/* Hamburger button */
-.hamburger-btn {
-  background: none !important;
-  border: none;
-  color: #fff;
-  font-size: 1.5rem;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-}
-
-.hamburger-btn:hover {
-  color: #d4af37;
-  background: none !important;
-}
-
 @media (max-width: 768px) {
   .sidebar {
     width: 280px;
-    left: -280px;
   }
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { authApi } from '../services/api';
@@ -6,22 +6,16 @@ import { cognitoAuth } from '../services/cognito';
 import LanguageSwitcher from './LanguageSwitcher';
 import './Sidebar.css';
 
-interface SidebarProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export default function Sidebar({ isOpen, onClose }: SidebarProps) {
+export default function Sidebar() {
   const { t } = useTranslation();
   const location = useLocation();
-  const sidebarRef = useRef<HTMLDivElement>(null);
   const [isAdmin, setIsAdmin] = useState(authApi.isAuthenticated());
   const [adminExpanded, setAdminExpanded] = useState(true);
 
   // Keep admin auth state in sync
   useEffect(() => {
     setIsAdmin(authApi.isAuthenticated());
-  }, [isOpen]);
+  }, [location.pathname]);
 
   // Auto-expand admin section when navigating to admin routes
   useEffect(() => {
@@ -30,157 +24,134 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
     }
   }, [location.pathname]);
 
-  // Close sidebar when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (isOpen && sidebarRef.current && !sidebarRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen, onClose]);
-
-  // Close sidebar on route change
-  useEffect(() => {
-    onClose();
-  }, [location.pathname]);// eslint-disable-line react-hooks/exhaustive-deps
-
   const handleLogout = async () => {
     await cognitoAuth.signOut();
     authApi.clearToken();
     setIsAdmin(false);
-    onClose();
   };
 
   const isActive = (path: string) => location.pathname === path;
 
   return (
-    <>
-      {isOpen && <div className="sidebar-overlay" />}
-      <aside ref={sidebarRef} className={`sidebar ${isOpen ? 'open' : ''}`}>
-        <div className="sidebar-header">
-          <h2>{t('header.title')}</h2>
-          <button className="sidebar-close" onClick={onClose} aria-label="Close menu">
-            ✕
-          </button>
+    <aside className="sidebar">
+      <div className="sidebar-header">
+        <h2>{t('header.title')}</h2>
+      </div>
+
+      <nav className="sidebar-nav">
+        <div className="nav-section">
+          <Link to="/" className={isActive('/') ? 'active' : ''}>
+            {t('nav.standings')}
+          </Link>
+          <Link to="/championships" className={isActive('/championships') ? 'active' : ''}>
+            {t('nav.championships')}
+          </Link>
+          <Link to="/matches" className={isActive('/matches') ? 'active' : ''}>
+            {t('nav.matches')}
+          </Link>
+          <Link to="/events" className={isActive('/events') || location.pathname.startsWith('/events/') ? 'active' : ''}>
+            {t('nav.events')}
+          </Link>
+          <Link to="/tournaments" className={isActive('/tournaments') ? 'active' : ''}>
+            {t('nav.tournaments')}
+          </Link>
+          <Link to="/contenders" className={isActive('/contenders') || isActive('/contenders/my-status') ? 'active' : ''}>
+            {t('nav.contenders')}
+          </Link>
+          <span className="nav-disabled">
+            {t('nav.challenges')} <span className="coming-soon">Coming Soon</span>
+          </span>
+          <span className="nav-disabled">
+            {t('nav.promos')} <span className="coming-soon">Coming Soon</span>
+          </span>
+          <span className="nav-disabled">
+            {t('nav.statistics')} <span className="coming-soon">Coming Soon</span>
+          </span>
+          <span className="nav-disabled">
+            {t('nav.fantasy')} <span className="coming-soon">Coming Soon</span>
+          </span>
+          <Link to="/guide" className={isActive('/guide') ? 'active' : ''}>
+            {t('nav.help')}
+          </Link>
         </div>
 
-        <nav className="sidebar-nav">
+        {isAdmin && (
+          <div className="nav-section admin-section">
+            <button
+              className={`nav-section-toggle ${adminExpanded ? 'expanded' : ''}`}
+              onClick={() => setAdminExpanded(!adminExpanded)}
+            >
+              <span>{t('nav.admin')}</span>
+              <span className="toggle-arrow">{adminExpanded ? '\u25B2' : '\u25BC'}</span>
+            </button>
+
+            {adminExpanded && (
+              <div className="admin-nav-items">
+                <Link to="/admin/schedule" className={isActive('/admin/schedule') ? 'active' : ''}>
+                  {t('admin.panel.tabs.scheduleMatch')}
+                </Link>
+                <Link to="/admin/results" className={isActive('/admin/results') ? 'active' : ''}>
+                  {t('admin.panel.tabs.recordResults')}
+                </Link>
+                <Link to="/admin/events" className={isActive('/admin/events') ? 'active' : ''}>
+                  {t('admin.panel.tabs.events')}
+                </Link>
+                <Link to="/admin/seasons" className={isActive('/admin/seasons') ? 'active' : ''}>
+                  {t('admin.panel.tabs.seasons')}
+                </Link>
+                <Link to="/admin/players" className={isActive('/admin/players') ? 'active' : ''}>
+                  {t('admin.panel.tabs.managePlayers')}
+                </Link>
+                <Link to="/admin/divisions" className={isActive('/admin/divisions') ? 'active' : ''}>
+                  {t('admin.panel.tabs.divisions')}
+                </Link>
+                <Link to="/admin/championships" className={isActive('/admin/championships') ? 'active' : ''}>
+                  {t('admin.panel.tabs.championships')}
+                </Link>
+                <Link to="/admin/tournaments" className={isActive('/admin/tournaments') ? 'active' : ''}>
+                  {t('admin.panel.tabs.tournaments')}
+                </Link>
+                <span className="nav-disabled admin-disabled">
+                  {t('admin.panel.tabs.challenges')}
+                </span>
+                <span className="nav-disabled admin-disabled">
+                  {t('admin.panel.tabs.promos')}
+                </span>
+                <Link to="/admin/contender-config" className={isActive('/admin/contender-config') ? 'active' : ''}>
+                  {t('admin.panel.tabs.contenderConfig')}
+                </Link>
+                <span className="nav-disabled admin-disabled">
+                  {t('admin.panel.tabs.fantasyShows')}
+                </span>
+                <span className="nav-disabled admin-disabled">
+                  {t('admin.panel.tabs.fantasyConfig')}
+                </span>
+                <Link to="/admin/guide" className={isActive('/admin/guide') ? 'active' : ''}>
+                  {t('admin.panel.tabs.help')}
+                </Link>
+                <Link to="/admin/danger" className={`danger-link ${isActive('/admin/danger') ? 'active' : ''}`}>
+                  {t('admin.panel.tabs.dangerZone')}
+                </Link>
+                <button className="sidebar-logout" onClick={handleLogout}>
+                  {t('common.logout')}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {!isAdmin && (
           <div className="nav-section">
-            <Link to="/" className={isActive('/') ? 'active' : ''}>
-              {t('nav.standings')}
-            </Link>
-            <Link to="/championships" className={isActive('/championships') ? 'active' : ''}>
-              {t('nav.championships')}
-            </Link>
-            <Link to="/matches" className={isActive('/matches') ? 'active' : ''}>
-              {t('nav.matches')}
-            </Link>
-            <Link to="/events" className={isActive('/events') || location.pathname.startsWith('/events/') ? 'active' : ''}>
-              {t('nav.events')}
-            </Link>
-            <Link to="/tournaments" className={isActive('/tournaments') ? 'active' : ''}>
-              {t('nav.tournaments')}
-            </Link>
-            <Link to="/contenders" className={isActive('/contenders') || isActive('/contenders/my-status') ? 'active' : ''}>
-              {t('nav.contenders')}
-            </Link>
-            <span className="nav-disabled">
-              {t('nav.challenges')} <span className="coming-soon">Coming Soon</span>
-            </span>
-            <span className="nav-disabled">
-              {t('nav.promos')} <span className="coming-soon">Coming Soon</span>
-            </span>
-            <span className="nav-disabled">
-              {t('nav.statistics')} <span className="coming-soon">Coming Soon</span>
-            </span>
-            <span className="nav-disabled">
-              {t('nav.fantasy')} <span className="coming-soon">Coming Soon</span>
-            </span>
-            <Link to="/guide" className={isActive('/guide') ? 'active' : ''}>
-              {t('nav.help')}
+            <Link to="/admin" className={isActive('/admin') ? 'active' : ''}>
+              {t('nav.admin')}
             </Link>
           </div>
+        )}
+      </nav>
 
-          {isAdmin && (
-            <div className="nav-section admin-section">
-              <button
-                className={`nav-section-toggle ${adminExpanded ? 'expanded' : ''}`}
-                onClick={() => setAdminExpanded(!adminExpanded)}
-              >
-                <span>{t('nav.admin')}</span>
-                <span className="toggle-arrow">{adminExpanded ? '\u25B2' : '\u25BC'}</span>
-              </button>
-
-              {adminExpanded && (
-                <div className="admin-nav-items">
-                  <Link to="/admin/schedule" className={isActive('/admin/schedule') ? 'active' : ''}>
-                    {t('admin.panel.tabs.scheduleMatch')}
-                  </Link>
-                  <Link to="/admin/results" className={isActive('/admin/results') ? 'active' : ''}>
-                    {t('admin.panel.tabs.recordResults')}
-                  </Link>
-                  <Link to="/admin/events" className={isActive('/admin/events') ? 'active' : ''}>
-                    {t('admin.panel.tabs.events')}
-                  </Link>
-                  <Link to="/admin/seasons" className={isActive('/admin/seasons') ? 'active' : ''}>
-                    {t('admin.panel.tabs.seasons')}
-                  </Link>
-                  <Link to="/admin/players" className={isActive('/admin/players') ? 'active' : ''}>
-                    {t('admin.panel.tabs.managePlayers')}
-                  </Link>
-                  <Link to="/admin/divisions" className={isActive('/admin/divisions') ? 'active' : ''}>
-                    {t('admin.panel.tabs.divisions')}
-                  </Link>
-                  <Link to="/admin/championships" className={isActive('/admin/championships') ? 'active' : ''}>
-                    {t('admin.panel.tabs.championships')}
-                  </Link>
-                  <Link to="/admin/tournaments" className={isActive('/admin/tournaments') ? 'active' : ''}>
-                    {t('admin.panel.tabs.tournaments')}
-                  </Link>
-                  <span className="nav-disabled admin-disabled">
-                    {t('admin.panel.tabs.challenges')}
-                  </span>
-                  <span className="nav-disabled admin-disabled">
-                    {t('admin.panel.tabs.promos')}
-                  </span>
-                  <Link to="/admin/contender-config" className={isActive('/admin/contender-config') ? 'active' : ''}>
-                    {t('admin.panel.tabs.contenderConfig')}
-                  </Link>
-                  <span className="nav-disabled admin-disabled">
-                    {t('admin.panel.tabs.fantasyShows')}
-                  </span>
-                  <span className="nav-disabled admin-disabled">
-                    {t('admin.panel.tabs.fantasyConfig')}
-                  </span>
-                  <Link to="/admin/guide" className={isActive('/admin/guide') ? 'active' : ''}>
-                    {t('admin.panel.tabs.help')}
-                  </Link>
-                  <Link to="/admin/danger" className={`danger-link ${isActive('/admin/danger') ? 'active' : ''}`}>
-                    {t('admin.panel.tabs.dangerZone')}
-                  </Link>
-                  <button className="sidebar-logout" onClick={handleLogout}>
-                    {t('common.logout')}
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {!isAdmin && (
-            <div className="nav-section">
-              <Link to="/admin" className={isActive('/admin') ? 'active' : ''}>
-                {t('nav.admin')}
-              </Link>
-            </div>
-          )}
-        </nav>
-
-        <div className="sidebar-footer">
-          <LanguageSwitcher />
-        </div>
-      </aside>
-    </>
+      <div className="sidebar-footer">
+        <LanguageSwitcher />
+      </div>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the sidebar from a collapsible toggle-based component to a permanent fixed sidebar that's always visible. This simplifies the navigation experience and removes the need for hamburger menu interactions.

## Key Changes

- **Sidebar Layout**: Changed sidebar from `left: -300px` (hidden) with toggle animation to `left: 0` (always visible)
- **Removed Toggle Logic**: Eliminated `useState` for sidebar open/close state and all related event handlers
  - Removed hamburger button from header
  - Removed close button from sidebar header
  - Removed sidebar overlay
  - Removed click-outside detection logic
  
- **Simplified Component Props**: Removed `isOpen` and `onClose` props from Sidebar component - it now renders without any state management from parent
  
- **Updated Layout Spacing**: Adjusted main content area to accommodate permanent sidebar
  - Added `margin-left: 300px` to header and main elements
  - Removed `margin: 0 auto` centering from main
  
- **Responsive Design**: Added media query for tablets (max-width: 768px) to adjust sidebar width to 280px with corresponding margin adjustments

- **Cleanup**: Removed unused imports (`useState` from App.tsx, `useRef` from Sidebar.tsx) and simplified dependency arrays in useEffect hooks

## Implementation Details
The sidebar now maintains a constant presence in the layout, improving navigation accessibility and reducing interaction complexity. The permanent layout eliminates the need for overlay management and click-outside detection, resulting in cleaner, more maintainable code.

https://claude.ai/code/session_01Ts9pWnnScGHLPT5JqbTFRS