### PR TITLE
Remove Admin group checks from Wrestler role logic

### DIFF
--- a/frontend/src/components/admin/ManageUsers.tsx
+++ b/frontend/src/components/admin/ManageUsers.tsx
@@ -92,7 +92,7 @@ export default function ManageUsers() {
   };
 
   const wrestlerRequests = users.filter(
-    (u) => u.wrestlerName && !u.groups.includes('Wrestler') && !u.groups.includes('Admin')
+    (u) => u.wrestlerName && !u.groups.includes('Wrestler')
   );
 
   const filteredUsers = (() => {
@@ -184,7 +184,7 @@ export default function ManageUsers() {
           </thead>
           <tbody>
             {filteredUsers.map((user) => (
-              <tr key={user.username} className={user.wrestlerName && !user.groups.includes('Wrestler') && !user.groups.includes('Admin') ? 'wrestler-request-row' : ''}>
+              <tr key={user.username} className={user.wrestlerName && !user.groups.includes('Wrestler') ? 'wrestler-request-row' : ''}>
                 <td>{user.email}</td>
                 <td>
                   {user.wrestlerName ? (
@@ -233,7 +233,7 @@ export default function ManageUsers() {
                     ) : (
                       <>
                         {/* Approve as Wrestler */}
-                        {user.wrestlerName && !user.groups.includes('Wrestler') && !user.groups.includes('Admin') && (
+                        {user.wrestlerName && !user.groups.includes('Wrestler') && (
                           <button
                             className="btn-action btn-approve"
                             onClick={() => handleRoleAction(user.username, 'Wrestler', 'promote')}
@@ -244,7 +244,7 @@ export default function ManageUsers() {
                         )}
 
                         {/* Promote to Wrestler (no wrestler name) */}
-                        {!user.groups.includes('Wrestler') && !user.groups.includes('Admin') && !user.wrestlerName && (
+                        {!user.groups.includes('Wrestler') && !user.wrestlerName && (
                           <button
                             className="btn-action btn-promote"
                             onClick={() => handleRoleAction(user.username, 'Wrestler', 'promote')}
@@ -255,7 +255,7 @@ export default function ManageUsers() {
                         )}
 
                         {/* Demote from Wrestler */}
-                        {user.groups.includes('Wrestler') && !user.groups.includes('Admin') && (
+                        {user.groups.includes('Wrestler') && (
                           <button
                             className="btn-action btn-demote"
                             onClick={() => handleRoleAction(user.username, 'Wrestler', 'demote')}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -43,9 +43,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const session = await cognitoAuth.refreshSession();
           const groups = session?.groups || cognitoAuth.getUserGroups();
 
-          // Fetch player profile if user is a wrestler
+          // Fetch player profile if user is in the Wrestler group
           let playerId: string | null = null;
-          if (groups.includes('Wrestler') || groups.includes('Admin')) {
+          if (groups.includes('Wrestler')) {
             try {
               const profile = await profileApi.getMyProfile();
               playerId = profile.playerId;
@@ -86,9 +86,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const handleSignIn = useCallback(async (email: string, password: string) => {
     const result = await cognitoAuth.signIn(email, password);
 
-    // Fetch player profile if user is a wrestler
+    // Fetch player profile if user is in the Wrestler group
     let playerId: string | null = null;
-    if (result.groups.includes('Wrestler') || result.groups.includes('Admin')) {
+    if (result.groups.includes('Wrestler')) {
       try {
         const profile = await profileApi.getMyProfile();
         playerId = profile.playerId;
@@ -147,7 +147,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     signOut: handleSignOut,
     refreshProfile,
     isAdmin: state.groups.includes('Admin'),
-    isWrestler: hasRole('Wrestler'),
+    isWrestler: state.groups.includes('Wrestler'),
     isFantasy: hasRole('Fantasy'),
     hasRole,
   };


### PR DESCRIPTION
## Summary
This PR removes unnecessary checks for the 'Admin' group from Wrestler-related role logic throughout the application. Admin users should not be treated as wrestlers, and the current logic was conflating these two separate roles.

## Key Changes

- **ManageUsers.tsx**: Removed `!u.groups.includes('Admin')` checks from:
  - Wrestler requests filter logic
  - Wrestler request row highlighting
  - Approve/promote/demote button visibility conditions

- **AuthContext.tsx**: Removed `groups.includes('Admin')` checks from:
  - Player profile fetching logic in `initializeAuth()` and `handleSignIn()`
  - Updated comments to clarify that profile fetching is for users in the Wrestler group only
  - Simplified `isWrestler` property to directly check for 'Wrestler' group membership instead of using the `hasRole()` helper

## Implementation Details

The changes ensure that:
- Admin users are no longer automatically treated as wrestlers
- Wrestler role management UI only shows actions for actual wrestlers
- Player profile data is only fetched for users with the Wrestler group
- Role checks are more explicit and maintainable

https://claude.ai/code/session_0173nVfHAzpYj4uwNZ3F65Ud