### PR TITLE
Add championship vacate functionality for admins

### DIFF
--- a/backend/functions/championships/vacateChampionship.ts
+++ b/backend/functions/championships/vacateChampionship.ts
@@ -1,0 +1,93 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { TransactWriteCommandInput } from '@aws-sdk/lib-dynamodb';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const championshipId = event.pathParameters?.championshipId;
+
+    if (!championshipId) {
+      return badRequest('Championship ID is required');
+    }
+
+    // Get the championship
+    const existing = await dynamoDb.get({
+      TableName: TableNames.CHAMPIONSHIPS,
+      Key: { championshipId },
+    });
+
+    if (!existing.Item) {
+      return notFound('Championship not found');
+    }
+
+    const championship = existing.Item;
+
+    if (!championship.currentChampion) {
+      return badRequest('Championship is already vacant');
+    }
+
+    const transactItems: any[] = [];
+
+    // Remove current champion from the championship
+    transactItems.push({
+      Update: {
+        TableName: TableNames.CHAMPIONSHIPS,
+        Key: { championshipId },
+        UpdateExpression: 'REMOVE currentChampion SET updatedAt = :updatedAt, version = if_not_exists(version, :zero) + :one',
+        ExpressionAttributeValues: {
+          ':updatedAt': new Date().toISOString(),
+          ':zero': 0,
+          ':one': 1,
+        },
+      },
+    });
+
+    // Close the current reign in championship history
+    const historyResult = await dynamoDb.query({
+      TableName: TableNames.CHAMPIONSHIP_HISTORY,
+      KeyConditionExpression: 'championshipId = :championshipId',
+      FilterExpression: 'attribute_not_exists(lostDate)',
+      ExpressionAttributeValues: { ':championshipId': championshipId },
+      ScanIndexForward: false,
+      Limit: 1,
+    });
+
+    if (historyResult.Items && historyResult.Items.length > 0) {
+      const currentReign = historyResult.Items[0];
+      const wonDate = new Date(currentReign.wonDate as string);
+      const lostDate = new Date();
+      const daysHeld = Math.floor((lostDate.getTime() - wonDate.getTime()) / (1000 * 60 * 60 * 24));
+
+      transactItems.push({
+        Update: {
+          TableName: TableNames.CHAMPIONSHIP_HISTORY,
+          Key: {
+            championshipId: currentReign.championshipId,
+            wonDate: currentReign.wonDate,
+          },
+          UpdateExpression: 'SET lostDate = :lostDate, daysHeld = :daysHeld',
+          ExpressionAttributeValues: {
+            ':lostDate': lostDate.toISOString(),
+            ':daysHeld': daysHeld,
+          },
+        },
+      });
+    }
+
+    await dynamoDb.transactWrite({
+      TransactItems: transactItems,
+    } as TransactWriteCommandInput);
+
+    // Return the updated championship
+    const updated = await dynamoDb.get({
+      TableName: TableNames.CHAMPIONSHIPS,
+      Key: { championshipId },
+    });
+
+    return success(updated.Item);
+  } catch (err) {
+    console.error('Error vacating championship:', err);
+    return serverError('Failed to vacate championship');
+  }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -252,6 +252,15 @@ functions:
           cors: true
           authorizer: adminAuthorizer
 
+  vacateChampionship:
+    handler: functions/championships/vacateChampionship.handler
+    events:
+      - http:
+          path: championships/{championshipId}/vacate
+          method: post
+          cors: true
+          authorizer: adminAuthorizer
+
   # Tournaments
   getTournaments:
     handler: functions/tournaments/getTournaments.handler

--- a/frontend/src/components/admin/ManageChampionships.css
+++ b/frontend/src/components/admin/ManageChampionships.css
@@ -227,6 +227,23 @@ label.file-input-label:hover {
   background-color: #2563eb !important;
 }
 
+.championship-vacate-btn {
+  background-color: #78350f !important;
+  color: #fde68a;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  flex: 1;
+}
+
+.championship-vacate-btn:hover {
+  background-color: #92400e !important;
+}
+
+.championship-vacate-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .championship-delete-btn {
   background-color: #7f1d1d !important;
   color: #fecaca;

--- a/frontend/src/components/admin/ManageChampionships.tsx
+++ b/frontend/src/components/admin/ManageChampionships.tsx
@@ -16,6 +16,7 @@ export default function ManageChampionships() {
   const [submitting, setSubmitting] = useState(false);
   const [editingChampionship, setEditingChampionship] = useState<Championship | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [vacating, setVacating] = useState<string | null>(null);
 
   const [divisions, setDivisions] = useState<Division[]>([]);
 
@@ -230,6 +231,26 @@ export default function ManageChampionships() {
     }
   };
 
+  const handleVacate = async (championshipId: string, championshipName: string) => {
+    if (!confirm(`Are you sure you want to vacate "${championshipName}"? The current champion will be stripped of the title.`)) {
+      return;
+    }
+
+    setVacating(championshipId);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await championshipsApi.vacate(championshipId);
+      setSuccess('Championship vacated successfully!');
+      await loadChampionships();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to vacate championship');
+    } finally {
+      setVacating(null);
+    }
+  };
+
   if (loading) {
     return <div className="loading">Loading championships...</div>;
   }
@@ -371,6 +392,15 @@ export default function ManageChampionships() {
                   >
                     Edit
                   </button>
+                  {championship.currentChampion && (
+                    <button
+                      onClick={() => handleVacate(championship.championshipId, championship.name)}
+                      className="championship-vacate-btn"
+                      disabled={vacating === championship.championshipId}
+                    >
+                      {vacating === championship.championshipId ? 'Vacating...' : 'Vacate'}
+                    </button>
+                  )}
                   <button
                     onClick={() => handleDelete(championship.championshipId, championship.name)}
                     className="championship-delete-btn"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -127,6 +127,12 @@ export const championshipsApi = {
       method: 'DELETE',
     });
   },
+
+  vacate: async (championshipId: string): Promise<Championship> => {
+    return fetchWithAuth(`${API_BASE_URL}/championships/${championshipId}/vacate`, {
+      method: 'POST',
+    });
+  },
 };
 
 // Tournaments API


### PR DESCRIPTION
## Summary
This PR adds the ability for admins to vacate a championship title, removing the current champion and closing their reign in the championship history.

## Key Changes
- **Backend**: New Lambda function `vacateChampionship` that:
  - Validates the championship exists and has a current champion
  - Removes the current champion from the championship record
  - Closes the current reign in championship history by setting `lostDate` and calculating `daysHeld`
  - Uses transactional writes to ensure data consistency
  - Increments the championship version for optimistic locking

- **Frontend**: 
  - Added "Vacate" button to the ManageChampionships component (only visible when a champion exists)
  - Includes confirmation dialog before vacating
  - Shows loading state during the operation
  - Displays success/error messages and refreshes the championship list

- **API Integration**: New `vacate` method in `championshipsApi` service

- **Styling**: Added `.championship-vacate-btn` styles with brown color scheme to distinguish from other actions

## Implementation Details
- The vacate operation is restricted to admin users via the `adminAuthorizer`
- Championship history is properly maintained with accurate reign duration calculations
- The operation is atomic using DynamoDB transactional writes to prevent partial updates
- Version field is incremented to support optimistic concurrency control

https://claude.ai/code/session_01B2AgwT4p3mJkndaDvNyX9D