### PR TITLE
Change production deployment trigger from merged PRs to manual dispatch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,10 +1,7 @@
 name: Deploy to Production
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   AWS_REGION: us-east-1
@@ -14,8 +11,6 @@ jobs:
   deploy-prod:
     name: Deploy to Production Environment
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Modified the production deployment workflow to use manual trigger (`workflow_dispatch`) instead of automatically deploying when pull requests are merged to main. This provides more control over when production deployments occur.

## Key Changes
- Replaced `pull_request` event trigger (on closed/merged PRs to main) with `workflow_dispatch` for manual triggering
- Removed the conditional check `if: github.event.pull_request.merged == true` that was validating PR merge status
- Deployments to production now require explicit manual initiation rather than automatic triggering on PR merges

## Implementation Details
- The workflow can now be triggered manually via the GitHub Actions UI or API
- This change decouples the deployment process from the PR merge workflow, allowing for:
  - Additional validation or testing steps before deployment
  - Scheduled deployments at specific times
  - Deployment of specific commits without requiring a PR merge
  - Better control over production release cadence

https://claude.ai/code/session_01P22tTEJDWzpE1k4E2ZW6tB