### PR TITLE
Add feature toggles and Moderator role with enhanced admin controls

### DIFF
--- a/backend/functions/admin/clearAll.ts
+++ b/backend/functions/admin/clearAll.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { dynamoDb, TableNames } from '../../lib/dynamodb';
 import { success, serverError } from '../../lib/response';
+import { requireSuperAdmin } from '../../lib/auth';
 
 const deleteAllFromTable = async (
   tableName: string,
@@ -45,7 +46,10 @@ const deleteAllFromTable = async (
   return items.length;
 };
 
-export const handler: APIGatewayProxyHandler = async () => {
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const denied = requireSuperAdmin(event);
+  if (denied) return denied;
+
   try {
     const deletedCounts: Record<string, number> = {};
 

--- a/backend/functions/admin/getSiteConfig.ts
+++ b/backend/functions/admin/getSiteConfig.ts
@@ -1,0 +1,29 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, serverError } from '../../lib/response';
+
+const DEFAULT_CONFIG = {
+  fantasy: true,
+  challenges: true,
+  promos: true,
+  contenders: true,
+  statistics: true,
+};
+
+export const handler: APIGatewayProxyHandler = async () => {
+  try {
+    const result = await dynamoDb.get({
+      TableName: TableNames.SITE_CONFIG,
+      Key: { configKey: 'features' },
+    });
+
+    if (result.Item) {
+      return success({ features: result.Item.features || DEFAULT_CONFIG });
+    }
+
+    return success({ features: DEFAULT_CONFIG });
+  } catch (error) {
+    console.error('Get site config error:', error);
+    return serverError('Failed to get site configuration');
+  }
+};

--- a/backend/functions/admin/updateSiteConfig.ts
+++ b/backend/functions/admin/updateSiteConfig.ts
@@ -1,0 +1,65 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, badRequest, serverError } from '../../lib/response';
+import { requireRole } from '../../lib/auth';
+
+const VALID_FEATURES = ['fantasy', 'challenges', 'promos', 'contenders', 'statistics'];
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const denied = requireRole(event, 'Admin');
+  if (denied) return denied;
+
+  try {
+    if (!event.body) {
+      return badRequest('Request body is required');
+    }
+
+    const { features } = JSON.parse(event.body) as {
+      features: Record<string, boolean>;
+    };
+
+    if (!features || typeof features !== 'object') {
+      return badRequest('features object is required');
+    }
+
+    // Validate that only valid feature keys are provided
+    for (const key of Object.keys(features)) {
+      if (!VALID_FEATURES.includes(key)) {
+        return badRequest(`Invalid feature key: ${key}. Valid keys: ${VALID_FEATURES.join(', ')}`);
+      }
+      if (typeof features[key] !== 'boolean') {
+        return badRequest(`Feature value for ${key} must be a boolean`);
+      }
+    }
+
+    // Get existing config and merge
+    const existing = await dynamoDb.get({
+      TableName: TableNames.SITE_CONFIG,
+      Key: { configKey: 'features' },
+    });
+
+    const currentFeatures = existing.Item?.features || {
+      fantasy: true,
+      challenges: true,
+      promos: true,
+      contenders: true,
+      statistics: true,
+    };
+
+    const updatedFeatures = { ...currentFeatures, ...features };
+
+    await dynamoDb.put({
+      TableName: TableNames.SITE_CONFIG,
+      Item: {
+        configKey: 'features',
+        features: updatedFeatures,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    return success({ features: updatedFeatures });
+  } catch (error) {
+    console.error('Update site config error:', error);
+    return serverError('Failed to update site configuration');
+  }
+};

--- a/backend/functions/users/toggleUserEnabled.ts
+++ b/backend/functions/users/toggleUserEnabled.ts
@@ -1,0 +1,56 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import {
+  CognitoIdentityProviderClient,
+  AdminDisableUserCommand,
+  AdminEnableUserCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { success, badRequest, serverError } from '../../lib/response';
+import { requireRole } from '../../lib/auth';
+
+const cognitoClient = new CognitoIdentityProviderClient({});
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const denied = requireRole(event, 'Admin');
+  if (denied) return denied;
+
+  try {
+    if (!event.body) {
+      return badRequest('Request body is required');
+    }
+
+    const { username, enabled } = JSON.parse(event.body) as {
+      username: string;
+      enabled: boolean;
+    };
+
+    if (!username || typeof enabled !== 'boolean') {
+      return badRequest('username and enabled (boolean) are required');
+    }
+
+    if (enabled) {
+      await cognitoClient.send(
+        new AdminEnableUserCommand({
+          UserPoolId: USER_POOL_ID,
+          Username: username,
+        })
+      );
+    } else {
+      await cognitoClient.send(
+        new AdminDisableUserCommand({
+          UserPoolId: USER_POOL_ID,
+          Username: username,
+        })
+      );
+    }
+
+    return success({
+      message: `User ${username} has been ${enabled ? 'enabled' : 'disabled'}`,
+      username,
+      enabled,
+    });
+  } catch (error) {
+    console.error('Toggle user enabled error:', error);
+    return serverError('Failed to update user status');
+  }
+};

--- a/backend/functions/users/updateUserRole.ts
+++ b/backend/functions/users/updateUserRole.ts
@@ -7,14 +7,14 @@ import {
   AdminGetUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { v4 as uuidv4 } from 'uuid';
-import { success, badRequest, serverError } from '../../lib/response';
-import { requireRole } from '../../lib/auth';
+import { success, badRequest, forbidden, serverError } from '../../lib/response';
+import { requireRole, getAuthContext, isSuperAdmin } from '../../lib/auth';
 import { dynamoDb, TableNames } from '../../lib/dynamodb';
 
 const cognitoClient = new CognitoIdentityProviderClient({});
 const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
 
-const VALID_ROLES = ['Admin', 'Wrestler', 'Fantasy'] as const;
+const VALID_ROLES = ['Admin', 'Moderator', 'Wrestler', 'Fantasy'] as const;
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   const denied = requireRole(event, 'Admin');
@@ -41,6 +41,11 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     if (action !== 'promote' && action !== 'demote') {
       return badRequest('action must be "promote" or "demote"');
+    }
+
+    // Only full Admins can grant/remove Admin or Moderator roles
+    if ((role === 'Admin' || role === 'Moderator') && !isSuperAdmin(getAuthContext(event))) {
+      return forbidden('Only full Admins can manage Admin and Moderator roles');
     }
 
     if (action === 'promote') {

--- a/backend/lib/auth.ts
+++ b/backend/lib/auth.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { forbidden } from './response';
 
-export type UserRole = 'Admin' | 'Wrestler' | 'Fantasy';
+export type UserRole = 'Admin' | 'Moderator' | 'Wrestler' | 'Fantasy';
 
 export interface AuthContext {
   username: string;
@@ -31,11 +31,20 @@ export function getAuthContext(event: APIGatewayProxyEvent): AuthContext {
 
 /**
  * Check if user has at least one of the required roles.
- * Admin always has access to everything.
+ * Admin and Moderator have access to all standard admin features.
  */
 export function hasRole(context: AuthContext, ...requiredRoles: UserRole[]): boolean {
   if (context.groups.includes('Admin')) return true;
+  if (context.groups.includes('Moderator')) return true;
   return requiredRoles.some((role) => context.groups.includes(role));
+}
+
+/**
+ * Check if user is a super admin (full Admin role, not Moderator).
+ * Used for restricted operations like deleting all data or managing Admin/Moderator roles.
+ */
+export function isSuperAdmin(context: AuthContext): boolean {
+  return context.groups.includes('Admin');
 }
 
 /**
@@ -49,6 +58,20 @@ export function requireRole(
   const context = getAuthContext(event);
   if (!hasRole(context, ...requiredRoles)) {
     return forbidden('You do not have permission to perform this action');
+  }
+  return null;
+}
+
+/**
+ * Middleware-style check that requires full Admin role (not Moderator).
+ * Returns a 403 response if the user is not a super admin.
+ */
+export function requireSuperAdmin(
+  event: APIGatewayProxyEvent,
+): APIGatewayProxyResult | null {
+  const context = getAuthContext(event);
+  if (!isSuperAdmin(context)) {
+    return forbidden('This action requires full Admin privileges');
   }
   return null;
 }

--- a/backend/lib/dynamodb.ts
+++ b/backend/lib/dynamodb.ts
@@ -127,4 +127,5 @@ export const TableNames = {
   FANTASY_CONFIG: process.env.FANTASY_CONFIG_TABLE!,
   WRESTLER_COSTS: process.env.WRESTLER_COSTS_TABLE!,
   FANTASY_PICKS: process.env.FANTASY_PICKS_TABLE!,
+  SITE_CONFIG: process.env.SITE_CONFIG_TABLE!,
 };

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -23,6 +23,7 @@ provider:
     FANTASY_CONFIG_TABLE: ${self:service}-fantasy-config-${self:provider.stage}
     WRESTLER_COSTS_TABLE: ${self:service}-wrestler-costs-${self:provider.stage}
     FANTASY_PICKS_TABLE: ${self:service}-fantasy-picks-${self:provider.stage}
+    SITE_CONFIG_TABLE: ${self:service}-site-config-${self:provider.stage}
     COGNITO_USER_POOL_ID: !Ref LeagueUserPool
     COGNITO_CLIENT_ID: !Ref LeagueUserPoolClient
     ADMIN_SETUP_KEY: cd59a70bebb3a6ef2d42b921b546754fff1a8ade98c311c09c4f05da4570008b
@@ -59,6 +60,7 @@ provider:
             - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.WRESTLER_COSTS_TABLE}
             - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.FANTASY_PICKS_TABLE}
             - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.FANTASY_PICKS_TABLE}/index/*
+            - arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.SITE_CONFIG_TABLE}
         - Effect: Allow
           Action:
             - s3:PutObject
@@ -74,6 +76,8 @@ provider:
             - cognito-idp:AdminAddUserToGroup
             - cognito-idp:AdminRemoveUserFromGroup
             - cognito-idp:AdminListGroupsForUser
+            - cognito-idp:AdminDisableUser
+            - cognito-idp:AdminEnableUser
             - cognito-idp:ListUsers
             - cognito-idp:ListUsersInGroup
           Resource:
@@ -130,6 +134,33 @@ functions:
       - http:
           path: admin/users/role
           method: post
+          cors: true
+          authorizer: adminAuthorizer
+
+  toggleUserEnabled:
+    handler: functions/users/toggleUserEnabled.handler
+    events:
+      - http:
+          path: admin/users/toggle-enabled
+          method: post
+          cors: true
+          authorizer: adminAuthorizer
+
+  # Site Configuration (feature toggles)
+  getSiteConfig:
+    handler: functions/admin/getSiteConfig.handler
+    events:
+      - http:
+          path: site-config
+          method: get
+          cors: true
+
+  updateSiteConfig:
+    handler: functions/admin/updateSiteConfig.handler
+    events:
+      - http:
+          path: admin/site-config
+          method: put
           cors: true
           authorizer: adminAuthorizer
 
@@ -670,13 +701,21 @@ resources:
         Description: Full access to all features including user management
         Precedence: 0
 
+    ModeratorGroup:
+      Type: AWS::Cognito::UserPoolGroup
+      Properties:
+        GroupName: Moderator
+        UserPoolId: !Ref LeagueUserPool
+        Description: Admin-level access except cannot manage Admin/Moderator roles or delete all data
+        Precedence: 1
+
     WrestlerGroup:
       Type: AWS::Cognito::UserPoolGroup
       Properties:
         GroupName: Wrestler
         UserPoolId: !Ref LeagueUserPool
         Description: Access to wrestler features (challenges, promos) plus fantasy
-        Precedence: 1
+        Precedence: 2
 
     FantasyGroup:
       Type: AWS::Cognito::UserPoolGroup
@@ -684,7 +723,7 @@ resources:
         GroupName: Fantasy
         UserPoolId: !Ref LeagueUserPool
         Description: Access to fantasy features and public data
-        Precedence: 2
+        Precedence: 3
 
     LeagueUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
@@ -989,6 +1028,18 @@ resources:
                 KeyType: RANGE
             Projection:
               ProjectionType: ALL
+
+    SiteConfigTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.SITE_CONFIG_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: configKey
+            AttributeType: S
+        KeySchema:
+          - AttributeName: configKey
+            KeyType: HASH
 
     ImagesBucket:
       Type: AWS::S3::Bucket

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './i18n';
 import { AuthProvider } from './contexts/AuthContext';
+import { SiteConfigProvider } from './contexts/SiteConfigContext';
 import ErrorBoundary from './components/ErrorBoundary';
 import Sidebar from './components/Sidebar';
 import TopBar from './components/TopBar';
@@ -47,6 +48,7 @@ import EventResults from './components/events/EventResults';
 import WrestlerProfile from './components/profile/WrestlerProfile';
 // Route guard
 import ProtectedRoute from './components/ProtectedRoute';
+import FeatureRoute from './components/FeatureRoute';
 import './App.css';
 
 function App() {
@@ -54,6 +56,7 @@ function App() {
     <ErrorBoundary>
       <Router>
         <AuthProvider>
+        <SiteConfigProvider>
         <div className="App">
         <Sidebar />
         <TopBar />
@@ -81,93 +84,138 @@ function App() {
               </ProtectedRoute>
             } />
 
-            {/* Challenge Routes - Wrestler only */}
+            {/* Challenge Routes - Wrestler only, feature-gated */}
             <Route path="/challenges" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <ChallengeBoard />
-              </ProtectedRoute>
+              <FeatureRoute feature="challenges">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <ChallengeBoard />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/challenges/issue" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <IssueChallenge />
-              </ProtectedRoute>
+              <FeatureRoute feature="challenges">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <IssueChallenge />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/challenges/my" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <MyChallenges />
-              </ProtectedRoute>
+              <FeatureRoute feature="challenges">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <MyChallenges />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/challenges/:challengeId" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <ChallengeDetail />
-              </ProtectedRoute>
+              <FeatureRoute feature="challenges">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <ChallengeDetail />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
 
-            {/* Promo Routes - Wrestler only */}
+            {/* Promo Routes - Wrestler only, feature-gated */}
             <Route path="/promos" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <PromoFeed />
-              </ProtectedRoute>
+              <FeatureRoute feature="promos">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <PromoFeed />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/promos/new" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <PromoEditor />
-              </ProtectedRoute>
+              <FeatureRoute feature="promos">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <PromoEditor />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/promos/:promoId" element={
-              <ProtectedRoute requiredRole="Wrestler">
-                <PromoThread />
-              </ProtectedRoute>
+              <FeatureRoute feature="promos">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <PromoThread />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
 
-            {/* Statistics Routes - public */}
-            <Route path="/stats" element={<PlayerStats />} />
-            <Route path="/stats/player/:playerId" element={<PlayerStats />} />
-            <Route path="/stats/head-to-head" element={<HeadToHeadComparison />} />
-            <Route path="/stats/leaderboards" element={<Leaderboards />} />
-            <Route path="/stats/records" element={<RecordBook />} />
-            <Route path="/stats/tale-of-tape" element={<TaleOfTheTape />} />
-            <Route path="/stats/achievements" element={<Achievements />} />
+            {/* Statistics Routes - feature-gated */}
+            <Route path="/stats" element={
+              <FeatureRoute feature="statistics"><PlayerStats /></FeatureRoute>
+            } />
+            <Route path="/stats/player/:playerId" element={
+              <FeatureRoute feature="statistics"><PlayerStats /></FeatureRoute>
+            } />
+            <Route path="/stats/head-to-head" element={
+              <FeatureRoute feature="statistics"><HeadToHeadComparison /></FeatureRoute>
+            } />
+            <Route path="/stats/leaderboards" element={
+              <FeatureRoute feature="statistics"><Leaderboards /></FeatureRoute>
+            } />
+            <Route path="/stats/records" element={
+              <FeatureRoute feature="statistics"><RecordBook /></FeatureRoute>
+            } />
+            <Route path="/stats/tale-of-tape" element={
+              <FeatureRoute feature="statistics"><TaleOfTheTape /></FeatureRoute>
+            } />
+            <Route path="/stats/achievements" element={
+              <FeatureRoute feature="statistics"><Achievements /></FeatureRoute>
+            } />
 
             {/* Events Routes - public */}
             <Route path="/events" element={<EventsCalendar />} />
             <Route path="/events/:eventId" element={<EventDetail />} />
             <Route path="/events/:eventId/results" element={<EventResults />} />
 
-            {/* Contender Routes - public */}
-            <Route path="/contenders" element={<ContenderRankings />} />
-            <Route path="/contenders/my-status" element={<MyContenderStatus />} />
+            {/* Contender Routes - feature-gated */}
+            <Route path="/contenders" element={
+              <FeatureRoute feature="contenders"><ContenderRankings /></FeatureRoute>
+            } />
+            <Route path="/contenders/my-status" element={
+              <FeatureRoute feature="contenders"><MyContenderStatus /></FeatureRoute>
+            } />
 
-            {/* Fantasy Routes - Fantasy role required for interactive features */}
-            <Route path="/fantasy" element={<FantasyLanding />} />
+            {/* Fantasy Routes - feature-gated, Fantasy role required for interactive features */}
+            <Route path="/fantasy" element={
+              <FeatureRoute feature="fantasy"><FantasyLanding /></FeatureRoute>
+            } />
             <Route path="/fantasy/dashboard" element={
-              <ProtectedRoute requiredRole="Fantasy">
-                <FantasyDashboard />
-              </ProtectedRoute>
+              <FeatureRoute feature="fantasy">
+                <ProtectedRoute requiredRole="Fantasy">
+                  <FantasyDashboard />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/fantasy/picks/:eventId" element={
-              <ProtectedRoute requiredRole="Fantasy">
-                <MakePicks />
-              </ProtectedRoute>
+              <FeatureRoute feature="fantasy">
+                <ProtectedRoute requiredRole="Fantasy">
+                  <MakePicks />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/fantasy/leaderboard" element={
-              <ProtectedRoute requiredRole="Fantasy">
-                <FantasyLeaderboard />
-              </ProtectedRoute>
+              <FeatureRoute feature="fantasy">
+                <ProtectedRoute requiredRole="Fantasy">
+                  <FantasyLeaderboard />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/fantasy/costs" element={
-              <ProtectedRoute requiredRole="Fantasy">
-                <WrestlerCosts />
-              </ProtectedRoute>
+              <FeatureRoute feature="fantasy">
+                <ProtectedRoute requiredRole="Fantasy">
+                  <WrestlerCosts />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
             <Route path="/fantasy/events/:eventId/results" element={
-              <ProtectedRoute requiredRole="Fantasy">
-                <ShowResults />
-              </ProtectedRoute>
+              <FeatureRoute feature="fantasy">
+                <ProtectedRoute requiredRole="Fantasy">
+                  <ShowResults />
+                </ProtectedRoute>
+              </FeatureRoute>
             } />
           </Routes>
         </main>
         </div>
+        </SiteConfigProvider>
         </AuthProvider>
       </Router>
     </ErrorBoundary>

--- a/frontend/src/components/FeatureRoute.tsx
+++ b/frontend/src/components/FeatureRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router-dom';
+import { useSiteConfig } from '../contexts/SiteConfigContext';
+import type { SiteFeatures } from '../services/api';
+
+interface FeatureRouteProps {
+  children: React.ReactNode;
+  feature: keyof SiteFeatures;
+}
+
+export default function FeatureRoute({ children, feature }: FeatureRouteProps) {
+  const { features, isLoading } = useSiteConfig();
+
+  if (isLoading) {
+    return <div className="loading-screen">Loading...</div>;
+  }
+
+  if (!features[feature]) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,13 +2,15 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
+import { useSiteConfig } from '../contexts/SiteConfigContext';
 import LanguageSwitcher from './LanguageSwitcher';
 import './Sidebar.css';
 
 export default function Sidebar() {
   const { t } = useTranslation();
   const location = useLocation();
-  const { isAuthenticated, isAdmin, isWrestler, isFantasy, signOut } = useAuth();
+  const { isAuthenticated, isAdmin, isSuperAdmin, isWrestler, isFantasy, signOut } = useAuth();
+  const { features } = useSiteConfig();
   const [adminExpanded, setAdminExpanded] = useState(true);
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -97,9 +99,13 @@ export default function Sidebar() {
           <Link to="/tournaments" className={isActive('/tournaments') ? 'active' : ''}>
             {t('nav.tournaments')}
           </Link>
-          <Link to="/contenders" className={isActive('/contenders') || isActive('/contenders/my-status') ? 'active' : ''}>
-            {t('nav.contenders')}
-          </Link>
+
+          {/* Contenders - hidden when feature is disabled */}
+          {features.contenders && (
+            <Link to="/contenders" className={isActive('/contenders') || isActive('/contenders/my-status') ? 'active' : ''}>
+              {t('nav.contenders')}
+            </Link>
+          )}
 
           {/* Wrestler-only features (also visible to Admin) */}
           {isWrestler ? (
@@ -107,41 +113,55 @@ export default function Sidebar() {
               <Link to="/profile" className={isActive('/profile') ? 'active' : ''}>
                 {t('nav.profile')}
               </Link>
-              <span className="nav-disabled">
-                {t('nav.challenges')} <span className="coming-soon">Coming Soon</span>
-              </span>
-              <span className="nav-disabled">
-                {t('nav.promos')} <span className="coming-soon">Coming Soon</span>
-              </span>
+              {features.challenges ? (
+                <span className="nav-disabled">
+                  {t('nav.challenges')} <span className="coming-soon">Coming Soon</span>
+                </span>
+              ) : null}
+              {features.promos ? (
+                <span className="nav-disabled">
+                  {t('nav.promos')} <span className="coming-soon">Coming Soon</span>
+                </span>
+              ) : null}
             </>
           ) : (
             <>
               <span className="nav-disabled">
                 {t('nav.profile')} <span className="role-locked">Wrestler Only</span>
               </span>
-              <span className="nav-disabled">
-                {t('nav.challenges')} <span className="role-locked">Wrestler Only</span>
-              </span>
-              <span className="nav-disabled">
-                {t('nav.promos')} <span className="role-locked">Wrestler Only</span>
-              </span>
+              {features.challenges && (
+                <span className="nav-disabled">
+                  {t('nav.challenges')} <span className="role-locked">Wrestler Only</span>
+                </span>
+              )}
+              {features.promos && (
+                <span className="nav-disabled">
+                  {t('nav.promos')} <span className="role-locked">Wrestler Only</span>
+                </span>
+              )}
             </>
           )}
 
-          {/* Statistics - available to all authenticated */}
-          <span className="nav-disabled">
-            {t('nav.statistics')} <span className="coming-soon">Coming Soon</span>
-          </span>
-
-          {/* Fantasy - available to Fantasy role and above */}
-          {isFantasy ? (
-            <Link to="/fantasy" className={location.pathname.startsWith('/fantasy') ? 'active' : ''}>
-              {t('nav.fantasy')}
-            </Link>
-          ) : (
+          {/* Statistics - hidden when feature is disabled */}
+          {features.statistics && (
             <span className="nav-disabled">
-              {t('nav.fantasy')} <span className="coming-soon">Coming Soon</span>
+              {t('nav.statistics')} <span className="coming-soon">Coming Soon</span>
             </span>
+          )}
+
+          {/* Fantasy - hidden when feature is disabled */}
+          {features.fantasy && (
+            <>
+              {isFantasy ? (
+                <Link to="/fantasy" className={location.pathname.startsWith('/fantasy') ? 'active' : ''}>
+                  {t('nav.fantasy')}
+                </Link>
+              ) : (
+                <span className="nav-disabled">
+                  {t('nav.fantasy')} <span className="coming-soon">Coming Soon</span>
+                </span>
+              )}
+            </>
           )}
 
           <Link to="/guide" className={isActive('/guide') ? 'active' : ''}>
@@ -149,7 +169,7 @@ export default function Sidebar() {
           </Link>
         </div>
 
-        {/* Admin section - only for Admin role */}
+        {/* Admin section - for Admin and Moderator roles */}
         {isAdmin && (
           <div className="nav-section admin-section">
             <button
@@ -164,6 +184,9 @@ export default function Sidebar() {
               <div className="admin-nav-items">
                 <Link to="/admin/users" className={isActive('/admin/users') ? 'active' : ''}>
                   User Management
+                </Link>
+                <Link to="/admin/features" className={isActive('/admin/features') ? 'active' : ''}>
+                  Feature Management
                 </Link>
                 <Link to="/admin/schedule" className={isActive('/admin/schedule') ? 'active' : ''}>
                   {t('admin.panel.tabs.scheduleMatch')}
@@ -207,9 +230,12 @@ export default function Sidebar() {
                 <Link to="/admin/guide" className={isActive('/admin/guide') ? 'active' : ''}>
                   {t('admin.panel.tabs.help')}
                 </Link>
-                <Link to="/admin/danger" className={`danger-link ${isActive('/admin/danger') ? 'active' : ''}`}>
-                  {t('admin.panel.tabs.dangerZone')}
-                </Link>
+                {/* Danger zone only visible to super admins */}
+                {isSuperAdmin && (
+                  <Link to="/admin/danger" className={`danger-link ${isActive('/admin/danger') ? 'active' : ''}`}>
+                    {t('admin.panel.tabs.dangerZone')}
+                  </Link>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/admin/AdminPanel.tsx
+++ b/frontend/src/components/admin/AdminPanel.tsx
@@ -19,18 +19,19 @@ import AdminChallenges from './AdminChallenges';
 import AdminGuide from './AdminGuide';
 import ClearAllData from './ClearAllData';
 import ManageUsers from './ManageUsers';
+import ManageFeatures from './ManageFeatures';
 import './AdminPanel.css';
 
 import AdminContenderConfig from './AdminContenderConfig';
 
-type AdminTab = 'players' | 'divisions' | 'schedule' | 'results' | 'championships' | 'tournaments' | 'challenges' | 'promos' | 'seasons' | 'events' | 'fantasy-shows' | 'fantasy-config' | 'contender-config' | 'guide' | 'danger' | 'users';
+type AdminTab = 'players' | 'divisions' | 'schedule' | 'results' | 'championships' | 'tournaments' | 'challenges' | 'promos' | 'seasons' | 'events' | 'fantasy-shows' | 'fantasy-config' | 'contender-config' | 'guide' | 'danger' | 'users' | 'features';
 
-const VALID_TABS: AdminTab[] = ['players', 'divisions', 'schedule', 'results', 'championships', 'tournaments', 'challenges', 'promos', 'seasons', 'events', 'fantasy-shows', 'fantasy-config', 'contender-config', 'guide', 'danger', 'users'];
+const VALID_TABS: AdminTab[] = ['players', 'divisions', 'schedule', 'results', 'championships', 'tournaments', 'challenges', 'promos', 'seasons', 'events', 'fantasy-shows', 'fantasy-config', 'contender-config', 'guide', 'danger', 'users', 'features'];
 
 
 export default function AdminPanel() {
   const { tab } = useParams<{ tab: string }>();
-  const { isAuthenticated, isAdmin } = useAuth();
+  const { isAuthenticated, isAdmin, isSuperAdmin } = useAuth();
 
   const activeTab: AdminTab = (tab && VALID_TABS.includes(tab as AdminTab)) ? tab as AdminTab : 'players';
 
@@ -49,10 +50,23 @@ export default function AdminPanel() {
     );
   }
 
+  // Moderators cannot access danger zone
+  if (activeTab === 'danger' && !isSuperAdmin) {
+    return (
+      <div className="admin-panel">
+        <div className="access-denied">
+          <h2>Full Admin Access Required</h2>
+          <p>This action requires full Admin privileges.</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="admin-panel">
       <div className="admin-content">
         {activeTab === 'users' && <ManageUsers />}
+        {activeTab === 'features' && <ManageFeatures />}
         {activeTab === 'players' && <ManagePlayers />}
         {activeTab === 'divisions' && <ManageDivisions />}
         {activeTab === 'schedule' && <ScheduleMatch />}

--- a/frontend/src/components/admin/ManageFeatures.css
+++ b/frontend/src/components/admin/ManageFeatures.css
@@ -1,0 +1,94 @@
+.manage-features {
+  padding: 1rem;
+}
+
+.manage-features h2 {
+  margin: 0 0 0.5rem;
+  color: var(--text-primary, #fff);
+}
+
+.features-description {
+  color: var(--text-secondary, #aaa);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.features-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.feature-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.2rem;
+  background: var(--card-bg, #1a1a2e);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 8px;
+}
+
+.feature-info h3 {
+  margin: 0 0 0.25rem;
+  color: var(--text-primary, #fff);
+  font-size: 1rem;
+}
+
+.feature-info p {
+  margin: 0;
+  color: var(--text-secondary, #aaa);
+  font-size: 0.85rem;
+}
+
+.toggle-btn {
+  padding: 0.4rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-width: 100px;
+  transition: all 0.2s;
+}
+
+.toggle-btn.enabled {
+  background: rgba(76, 175, 80, 0.2);
+  border-color: rgba(76, 175, 80, 0.5);
+  color: #81c784;
+}
+
+.toggle-btn.enabled:hover {
+  background: rgba(76, 175, 80, 0.3);
+}
+
+.toggle-btn.disabled {
+  background: rgba(158, 158, 158, 0.15);
+  border-color: rgba(158, 158, 158, 0.4);
+  color: #bdbdbd;
+}
+
+.toggle-btn.disabled:hover {
+  background: rgba(158, 158, 158, 0.25);
+}
+
+.toggle-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .manage-features {
+    padding: 0;
+  }
+
+  .feature-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .feature-toggle {
+    align-self: flex-end;
+  }
+}

--- a/frontend/src/components/admin/ManageFeatures.tsx
+++ b/frontend/src/components/admin/ManageFeatures.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { siteConfigApi, type SiteFeatures } from '../../services/api';
+import { useSiteConfig } from '../../contexts/SiteConfigContext';
+import './ManageFeatures.css';
+
+const FEATURE_LABELS: Record<keyof SiteFeatures, { name: string; description: string }> = {
+  fantasy: {
+    name: 'Fantasy League',
+    description: 'Fantasy picks, leaderboards, wrestler costs, and dashboard',
+  },
+  challenges: {
+    name: 'Challenges',
+    description: 'Wrestler challenge board, issuing and managing challenges',
+  },
+  promos: {
+    name: 'Promos',
+    description: 'Promo feed, promo threads, and promo editor',
+  },
+  contenders: {
+    name: 'Contender Rankings',
+    description: 'Championship contender rankings and status tracking',
+  },
+  statistics: {
+    name: 'Statistics',
+    description: 'Player stats, head-to-head, leaderboards, records, and achievements',
+  },
+};
+
+export default function ManageFeatures() {
+  const { features, refreshConfig } = useSiteConfig();
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleToggle = async (feature: keyof SiteFeatures) => {
+    setSaving(feature);
+    setError(null);
+    try {
+      await siteConfigApi.updateFeatures({ [feature]: !features[feature] });
+      await refreshConfig();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update feature');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <div className="manage-features">
+      <h2>Feature Management</h2>
+      <p className="features-description">
+        Toggle site features on or off. Disabled features will be hidden from navigation
+        and inaccessible to users. Data continues to be collected while features are disabled.
+      </p>
+
+      {error && (
+        <div className="error-message" role="alert">
+          {error}
+          <button onClick={() => setError(null)} className="dismiss-btn">Dismiss</button>
+        </div>
+      )}
+
+      <div className="features-list">
+        {(Object.keys(FEATURE_LABELS) as Array<keyof SiteFeatures>).map((key) => (
+          <div key={key} className="feature-card">
+            <div className="feature-info">
+              <h3>{FEATURE_LABELS[key].name}</h3>
+              <p>{FEATURE_LABELS[key].description}</p>
+            </div>
+            <div className="feature-toggle">
+              <button
+                className={`toggle-btn ${features[key] ? 'enabled' : 'disabled'}`}
+                onClick={() => handleToggle(key)}
+                disabled={saving === key}
+                aria-label={`${features[key] ? 'Disable' : 'Enable'} ${FEATURE_LABELS[key].name}`}
+              >
+                {saving === key ? 'Saving...' : features[key] ? 'Enabled' : 'Disabled'}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/ManageUsers.css
+++ b/frontend/src/components/admin/ManageUsers.css
@@ -198,10 +198,43 @@
   color: #ff6b6b;
 }
 
+.btn-promote-moderator {
+  background: rgba(156, 39, 176, 0.2);
+  border-color: rgba(156, 39, 176, 0.5);
+  color: #ce93d8;
+}
+
+.btn-disable {
+  background: rgba(255, 152, 0, 0.15);
+  border-color: rgba(255, 152, 0, 0.4);
+  color: #ffb74d;
+}
+
+.btn-enable {
+  background: rgba(76, 175, 80, 0.2);
+  border-color: rgba(76, 175, 80, 0.5);
+  color: #81c784;
+}
+
 .btn-demote {
   background: rgba(158, 158, 158, 0.15);
   border-color: rgba(158, 158, 158, 0.4);
   color: #bdbdbd;
+}
+
+.role-moderator {
+  background: rgba(156, 39, 176, 0.2);
+  color: #ce93d8;
+  border: 1px solid rgba(156, 39, 176, 0.4);
+}
+
+.status-disabled {
+  background: rgba(229, 9, 20, 0.15);
+  color: #ff6b6b;
+}
+
+.disabled-user-row {
+  opacity: 0.6;
 }
 
 .action-loading {

--- a/frontend/src/components/admin/ManageUsers.tsx
+++ b/frontend/src/components/admin/ManageUsers.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { usersApi, playersApi, divisionsApi } from '../../services/api';
+import { useAuth } from '../../contexts/AuthContext';
 import type { Player, Division } from '../../types';
 import './ManageUsers.css';
 
@@ -15,9 +16,10 @@ interface CognitoUser {
   groups: string[];
 }
 
-type FilterTab = 'all' | 'wrestler-requests' | 'wrestlers' | 'admins';
+type FilterTab = 'all' | 'wrestler-requests' | 'wrestlers' | 'admins' | 'disabled';
 
 export default function ManageUsers() {
+  const { isSuperAdmin } = useAuth();
   const [users, setUsers] = useState<CognitoUser[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
   const [divisions, setDivisions] = useState<Division[]>([]);
@@ -91,9 +93,27 @@ export default function ManageUsers() {
     }
   };
 
+  const handleToggleEnabled = async (username: string, currentlyEnabled: boolean) => {
+    setActionLoading(username);
+    try {
+      const result = await usersApi.toggleEnabled(username, !currentlyEnabled);
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.username === username ? { ...u, enabled: result.enabled } : u
+        )
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update user status');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const wrestlerRequests = users.filter(
     (u) => u.wrestlerName && !u.groups.includes('Wrestler')
   );
+
+  const disabledUsers = users.filter((u) => !u.enabled);
 
   const filteredUsers = (() => {
     switch (activeFilter) {
@@ -102,7 +122,9 @@ export default function ManageUsers() {
       case 'wrestlers':
         return users.filter((u) => u.groups.includes('Wrestler'));
       case 'admins':
-        return users.filter((u) => u.groups.includes('Admin'));
+        return users.filter((u) => u.groups.includes('Admin') || u.groups.includes('Moderator'));
+      case 'disabled':
+        return disabledUsers;
       default:
         return users;
     }
@@ -167,6 +189,12 @@ export default function ManageUsers() {
         >
           Admins
         </button>
+        <button
+          className={activeFilter === 'disabled' ? 'active' : ''}
+          onClick={() => setActiveFilter('disabled')}
+        >
+          Disabled ({disabledUsers.length})
+        </button>
       </div>
 
       <div className="users-table-container">
@@ -184,7 +212,7 @@ export default function ManageUsers() {
           </thead>
           <tbody>
             {filteredUsers.map((user) => (
-              <tr key={user.username} className={user.wrestlerName && !user.groups.includes('Wrestler') ? 'wrestler-request-row' : ''}>
+              <tr key={user.username} className={`${user.wrestlerName && !user.groups.includes('Wrestler') ? 'wrestler-request-row' : ''} ${!user.enabled ? 'disabled-user-row' : ''}`}>
                 <td>{user.email}</td>
                 <td>
                   {user.wrestlerName ? (
@@ -221,8 +249,8 @@ export default function ManageUsers() {
                   })()}
                 </td>
                 <td>
-                  <span className={`status-badge status-${user.status?.toLowerCase()}`}>
-                    {user.status}
+                  <span className={`status-badge ${!user.enabled ? 'status-disabled' : `status-${user.status?.toLowerCase()}`}`}>
+                    {!user.enabled ? 'Disabled' : user.status}
                   </span>
                 </td>
                 <td>{user.created ? new Date(user.created).toLocaleDateString() : '-'}</td>
@@ -265,27 +293,63 @@ export default function ManageUsers() {
                           </button>
                         )}
 
-                        {/* Promote to Admin */}
-                        {!user.groups.includes('Admin') && (
-                          <button
-                            className="btn-action btn-promote-admin"
-                            onClick={() => handleRoleAction(user.username, 'Admin', 'promote')}
-                            title="Promote to Admin"
-                          >
-                            Make Admin
-                          </button>
+                        {/* Admin/Moderator management - Super Admin only */}
+                        {isSuperAdmin && (
+                          <>
+                            {/* Promote to Moderator */}
+                            {!user.groups.includes('Admin') && !user.groups.includes('Moderator') && (
+                              <button
+                                className="btn-action btn-promote-moderator"
+                                onClick={() => handleRoleAction(user.username, 'Moderator', 'promote')}
+                                title="Promote to Moderator"
+                              >
+                                Make Moderator
+                              </button>
+                            )}
+
+                            {/* Demote from Moderator */}
+                            {user.groups.includes('Moderator') && (
+                              <button
+                                className="btn-action btn-demote"
+                                onClick={() => handleRoleAction(user.username, 'Moderator', 'demote')}
+                                title="Remove Moderator role"
+                              >
+                                Remove Moderator
+                              </button>
+                            )}
+
+                            {/* Promote to Admin */}
+                            {!user.groups.includes('Admin') && (
+                              <button
+                                className="btn-action btn-promote-admin"
+                                onClick={() => handleRoleAction(user.username, 'Admin', 'promote')}
+                                title="Promote to Admin"
+                              >
+                                Make Admin
+                              </button>
+                            )}
+
+                            {/* Demote from Admin */}
+                            {user.groups.includes('Admin') && (
+                              <button
+                                className="btn-action btn-demote"
+                                onClick={() => handleRoleAction(user.username, 'Admin', 'demote')}
+                                title="Remove Admin role"
+                              >
+                                Remove Admin
+                              </button>
+                            )}
+                          </>
                         )}
 
-                        {/* Demote from Admin */}
-                        {user.groups.includes('Admin') && (
-                          <button
-                            className="btn-action btn-demote"
-                            onClick={() => handleRoleAction(user.username, 'Admin', 'demote')}
-                            title="Remove Admin role"
-                          >
-                            Remove Admin
-                          </button>
-                        )}
+                        {/* Enable/Disable user */}
+                        <button
+                          className={`btn-action ${user.enabled ? 'btn-disable' : 'btn-enable'}`}
+                          onClick={() => handleToggleEnabled(user.username, user.enabled)}
+                          title={user.enabled ? 'Disable user account' : 'Enable user account'}
+                        >
+                          {user.enabled ? 'Disable' : 'Enable'}
+                        </button>
                       </>
                     )}
                   </div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -17,6 +17,8 @@ interface AuthContextType extends AuthState {
   signOut: () => Promise<void>;
   refreshProfile: () => Promise<void>;
   isAdmin: boolean;
+  isSuperAdmin: boolean;
+  isModerator: boolean;
   isWrestler: boolean;
   isFantasy: boolean;
   hasRole: (role: UserRole) => boolean;
@@ -136,6 +138,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const hasRole = useCallback((role: UserRole): boolean => {
     if (state.groups.includes('Admin')) return true;
+    if (state.groups.includes('Moderator')) return true;
     return state.groups.includes(role);
   }, [state.groups]);
 
@@ -146,7 +149,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     confirmSignUp: handleConfirmSignUp,
     signOut: handleSignOut,
     refreshProfile,
-    isAdmin: state.groups.includes('Admin'),
+    isAdmin: state.groups.includes('Admin') || state.groups.includes('Moderator'),
+    isSuperAdmin: state.groups.includes('Admin'),
+    isModerator: state.groups.includes('Moderator'),
     isWrestler: state.groups.includes('Wrestler'),
     isFantasy: hasRole('Fantasy'),
     hasRole,

--- a/frontend/src/contexts/SiteConfigContext.tsx
+++ b/frontend/src/contexts/SiteConfigContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { siteConfigApi, type SiteFeatures } from '../services/api';
+
+interface SiteConfigContextType {
+  features: SiteFeatures;
+  isLoading: boolean;
+  refreshConfig: () => Promise<void>;
+}
+
+const DEFAULT_FEATURES: SiteFeatures = {
+  fantasy: true,
+  challenges: true,
+  promos: true,
+  contenders: true,
+  statistics: true,
+};
+
+const SiteConfigContext = createContext<SiteConfigContextType | undefined>(undefined);
+
+export function SiteConfigProvider({ children }: { children: ReactNode }) {
+  const [features, setFeatures] = useState<SiteFeatures>(DEFAULT_FEATURES);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      const result = await siteConfigApi.getFeatures();
+      setFeatures({ ...DEFAULT_FEATURES, ...result.features });
+    } catch {
+      // On error, default to all features enabled
+      setFeatures(DEFAULT_FEATURES);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const refreshConfig = useCallback(async () => {
+    await fetchConfig();
+  }, [fetchConfig]);
+
+  return (
+    <SiteConfigContext.Provider value={{ features, isLoading, refreshConfig }}>
+      {children}
+    </SiteConfigContext.Provider>
+  );
+}
+
+export function useSiteConfig(): SiteConfigContextType {
+  const context = useContext(SiteConfigContext);
+  if (context === undefined) {
+    throw new Error('useSiteConfig must be used within a SiteConfigProvider');
+  }
+  return context;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -391,6 +391,39 @@ export const usersApi = {
       body: JSON.stringify({ username, role, action }),
     });
   },
+
+  toggleEnabled: async (username: string, enabled: boolean): Promise<{
+    message: string;
+    username: string;
+    enabled: boolean;
+  }> => {
+    return fetchWithAuth(`${API_BASE_URL}/admin/users/toggle-enabled`, {
+      method: 'POST',
+      body: JSON.stringify({ username, enabled }),
+    });
+  },
+};
+
+// Site Configuration API
+export interface SiteFeatures {
+  fantasy: boolean;
+  challenges: boolean;
+  promos: boolean;
+  contenders: boolean;
+  statistics: boolean;
+}
+
+export const siteConfigApi = {
+  getFeatures: async (signal?: AbortSignal): Promise<{ features: SiteFeatures }> => {
+    return fetchWithAuth(`${API_BASE_URL}/site-config`, {}, signal);
+  },
+
+  updateFeatures: async (features: Partial<SiteFeatures>): Promise<{ features: SiteFeatures }> => {
+    return fetchWithAuth(`${API_BASE_URL}/admin/site-config`, {
+      method: 'PUT',
+      body: JSON.stringify({ features }),
+    });
+  },
 };
 
 // Auth API (uses Cognito via cognito.ts service)

--- a/frontend/src/services/cognito.ts
+++ b/frontend/src/services/cognito.ts
@@ -2,7 +2,7 @@ import { Amplify } from 'aws-amplify';
 import { signIn, signUp, signOut, confirmSignUp, fetchAuthSession, getCurrentUser } from 'aws-amplify/auth';
 import { logger } from '../utils/logger';
 
-export type UserRole = 'Admin' | 'Wrestler' | 'Fantasy';
+export type UserRole = 'Admin' | 'Moderator' | 'Wrestler' | 'Fantasy';
 
 // Cognito configuration from environment variables
 const cognitoConfig = {
@@ -55,7 +55,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
 export function getGroupsFromToken(accessToken: string): UserRole[] {
   const payload = decodeJwtPayload(accessToken);
   const groups = (payload['cognito:groups'] as string[]) || [];
-  return groups.filter((g): g is UserRole => ['Admin', 'Wrestler', 'Fantasy'].includes(g));
+  return groups.filter((g): g is UserRole => ['Admin', 'Moderator', 'Wrestler', 'Fantasy'].includes(g));
 }
 
 export const cognitoAuth = {
@@ -124,6 +124,10 @@ export const cognitoAuth = {
       if (error instanceof Error) {
         const cognitoError = error as Error & { name?: string };
         if (cognitoError.name === 'NotAuthorizedException') {
+          // Check if user is disabled (Cognito returns this for disabled users)
+          if (error.message?.toLowerCase().includes('disabled')) {
+            throw new Error('Your account is currently disabled. Please contact an administrator.');
+          }
           throw new Error('Invalid email or password');
         } else if (cognitoError.name === 'UserNotFoundException') {
           throw new Error('User not found');
@@ -279,6 +283,7 @@ export const cognitoAuth = {
   hasRole: (role: UserRole): boolean => {
     const groups = cognitoAuth.getUserGroups();
     if (groups.includes('Admin')) return true;
+    if (groups.includes('Moderator')) return true;
     return groups.includes(role);
   },
 


### PR DESCRIPTION
## Summary
This PR introduces a feature toggle system for site-wide functionality control and adds a new Moderator role to provide granular admin permissions. Admins can now enable/disable features (fantasy, challenges, promos, contenders, statistics) and manage user account status, while a new Moderator role allows delegation of standard admin tasks without granting access to destructive operations.

## Key Changes

### Feature Toggle System
- **New `SiteConfigContext`**: Manages site-wide feature flags with client-side caching
- **Feature Management UI**: New admin panel for toggling features on/off with descriptions
- **Feature-gated Routes**: Wrapped routes with `FeatureRoute` component that redirects when features are disabled
- **Dynamic Navigation**: Sidebar menu items conditionally render based on feature status
- **DynamoDB Table**: New `SITE_CONFIG` table stores feature configuration

### Role-Based Access Control
- **New Moderator Role**: Intermediate admin role with access to standard admin features
- **Super Admin Distinction**: Full Admins can manage Admin/Moderator roles and access danger zone; Moderators cannot
- **Enhanced Auth Context**: Added `isSuperAdmin` and `isModerator` flags to distinguish privilege levels
- **Role Validation**: `updateUserRole` now restricts Admin/Moderator role management to super admins only

### User Management Enhancements
- **User Enable/Disable**: New `toggleUserEnabled` function allows admins to disable user accounts via Cognito
- **Disabled Users Tab**: Filter view for disabled accounts in user management
- **Moderator Management UI**: Super admins can promote/demote users to/from Moderator role
- **Visual Indicators**: Disabled users shown with reduced opacity and status badge

### Backend Updates
- **New Lambda Functions**: 
  - `getSiteConfig`: Retrieves current feature configuration
  - `updateSiteConfig`: Updates feature flags with validation
  - `toggleUserEnabled`: Enables/disables user accounts in Cognito
- **Auth Middleware**: `requireSuperAdmin` middleware for operations requiring full admin privileges
- **IAM Permissions**: Added Cognito `AdminDisableUser` and `AdminEnableUser` permissions

### Frontend Updates
- **SiteConfigProvider**: Wraps app to provide feature state globally
- **FeatureRoute Component**: Guards routes based on feature availability
- **ManageFeatures Component**: Admin UI for toggling features with descriptions
- **Enhanced ManageUsers**: Shows Moderator role options and user enable/disable controls

## Implementation Details
- Features default to enabled if not configured, ensuring backward compatibility
- Feature configuration is fetched once on app load and can be refreshed from admin panel
- Moderators have full access to admin features except: managing Admin/Moderator roles, accessing danger zone, and clearing all data
- User disable/enable is non-destructive and preserves all user data
- All feature toggles are validated server-side to prevent invalid configurations

https://claude.ai/code/session_01XbVhR8LKoB1t4VF3LFYY1N