### PR TITLE
refactor(auth): rename isAdmin to isAdminOrModerator in AuthContext

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ import './Sidebar.css';
 export default function Sidebar() {
   const { t } = useTranslation();
   const location = useLocation();
-  const { isAuthenticated, isAdmin, isSuperAdmin, isWrestler, isFantasy, signOut } = useAuth();
+  const { isAuthenticated, isAdminOrModerator, isSuperAdmin, isWrestler, isFantasy, signOut } = useAuth();
   const { features } = useSiteConfig();
   const [adminExpanded, setAdminExpanded] = useState(true);
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -167,7 +167,7 @@ export default function Sidebar() {
         </div>
 
         {/* Admin section - for Admin and Moderator roles */}
-        {isAdmin && (
+        {isAdminOrModerator && (
           <div className="nav-section admin-section">
             <button
               className={`nav-section-toggle ${adminExpanded ? 'expanded' : ''}`}

--- a/frontend/src/components/__tests__/App.test.tsx
+++ b/frontend/src/components/__tests__/App.test.tsx
@@ -95,7 +95,7 @@ function authenticatedAuth(overrides = {}) {
   return {
     isAuthenticated: true,
     isLoading: false,
-    isAdmin: true,
+    isAdminOrModerator: true,
     isSuperAdmin: false,
     isModerator: false,
     isWrestler: true,
@@ -116,7 +116,7 @@ function authenticatedAuth(overrides = {}) {
 function unauthenticatedAuth() {
   return authenticatedAuth({
     isAuthenticated: false,
-    isAdmin: false,
+    isAdminOrModerator: false,
     isSuperAdmin: false,
     isWrestler: false,
     isFantasy: false,

--- a/frontend/src/components/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/__tests__/Sidebar.test.tsx
@@ -49,7 +49,7 @@ const NO_FEATURES = {
 function baseAuth(overrides = {}) {
   return {
     isAuthenticated: false,
-    isAdmin: false,
+    isAdminOrModerator: false,
     isSuperAdmin: false,
     isWrestler: false,
     isFantasy: false,
@@ -90,7 +90,7 @@ describe('Sidebar', () => {
   it('shows admin section with all admin links when user is admin', () => {
     mockUseAuth.mockReturnValue(baseAuth({
       isAuthenticated: true,
-      isAdmin: true,
+      isAdminOrModerator: true,
       isSuperAdmin: false,
     }));
     renderSidebar('/admin/players');
@@ -109,7 +109,7 @@ describe('Sidebar', () => {
   it('shows danger zone link only for SuperAdmin', () => {
     mockUseAuth.mockReturnValue(baseAuth({
       isAuthenticated: true,
-      isAdmin: true,
+      isAdminOrModerator: true,
       isSuperAdmin: true,
     }));
     renderSidebar('/admin');
@@ -133,7 +133,7 @@ describe('Sidebar', () => {
     const user = userEvent.setup();
     mockUseAuth.mockReturnValue(baseAuth({
       isAuthenticated: true,
-      isAdmin: true,
+      isAdminOrModerator: true,
     }));
     renderSidebar('/admin');
 

--- a/frontend/src/components/admin/AdminPanel.tsx
+++ b/frontend/src/components/admin/AdminPanel.tsx
@@ -32,7 +32,7 @@ const VALID_TABS: AdminTab[] = ['players', 'divisions', 'match-types', 'schedule
 
 export default function AdminPanel() {
   const { tab } = useParams<{ tab: string }>();
-  const { isAuthenticated, isAdmin, isSuperAdmin } = useAuth();
+  const { isAuthenticated, isAdminOrModerator, isSuperAdmin } = useAuth();
 
   const activeTab: AdminTab = (tab && VALID_TABS.includes(tab as AdminTab)) ? tab as AdminTab : 'players';
 
@@ -40,7 +40,7 @@ export default function AdminPanel() {
     return <Navigate to="/login" replace />;
   }
 
-  if (!isAdmin) {
+  if (!isAdminOrModerator) {
     return (
       <div className="admin-panel">
         <div className="access-denied">

--- a/frontend/src/components/admin/__tests__/AdminPanel.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminPanel.test.tsx
@@ -65,7 +65,7 @@ describe('AdminPanel', () => {
   it('renders the correct tab component based on URL parameter', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
-      isAdmin: true,
+      isAdminOrModerator: true,
       isSuperAdmin: false,
     });
 
@@ -77,7 +77,7 @@ describe('AdminPanel', () => {
   it('defaults to players tab when no tab parameter', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
-      isAdmin: true,
+      isAdminOrModerator: true,
       isSuperAdmin: false,
     });
 
@@ -88,7 +88,7 @@ describe('AdminPanel', () => {
   it('redirects to login when not authenticated', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
-      isAdmin: false,
+      isAdminOrModerator: false,
       isSuperAdmin: false,
     });
 
@@ -99,7 +99,7 @@ describe('AdminPanel', () => {
   it('shows access denied for non-admin authenticated users', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
-      isAdmin: false,
+      isAdminOrModerator: false,
       isSuperAdmin: false,
     });
 
@@ -111,7 +111,7 @@ describe('AdminPanel', () => {
   it('blocks non-SuperAdmin from danger zone tab', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
-      isAdmin: true,
+      isAdminOrModerator: true,
       isSuperAdmin: false,
     });
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ interface AuthContextType extends AuthState {
   signOut: () => Promise<void>;
   refreshProfile: () => Promise<void>;
   devSignIn?: (player: { playerId: string; name: string }) => void;
-  isAdmin: boolean;
+  isAdminOrModerator: boolean;
   isSuperAdmin: boolean;
   isModerator: boolean;
   isWrestler: boolean;
@@ -200,7 +200,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     signOut: handleSignOut,
     refreshProfile,
     ...(import.meta.env.DEV ? { devSignIn } : {}),
-    isAdmin: state.groups.includes('Admin') || state.groups.includes('Moderator'),
+    isAdminOrModerator: state.groups.includes('Admin') || state.groups.includes('Moderator'),
     isSuperAdmin: state.groups.includes('Admin'),
     isModerator: state.groups.includes('Moderator'),
     isWrestler: state.groups.includes('Wrestler'),

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -167,21 +167,21 @@ describe('AuthContext', () => {
   // P0: Role helpers
   // ===========================================================================
   describe('role helpers', () => {
-    it('isAdmin is true for Admin group', async () => {
+    it('isAdminOrModerator is true for Admin group', async () => {
       mockAuthenticatedUser(['Admin']);
       const { result } = renderHook(() => useAuth(), { wrapper });
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.isAdmin).toBe(true);
+      expect(result.current.isAdminOrModerator).toBe(true);
       expect(result.current.isSuperAdmin).toBe(true);
     });
 
-    it('isAdmin is true for Moderator, but isSuperAdmin is false', async () => {
+    it('isAdminOrModerator is true for Moderator, but isSuperAdmin is false', async () => {
       mockAuthenticatedUser(['Moderator']);
       const { result } = renderHook(() => useAuth(), { wrapper });
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.isAdmin).toBe(true);
+      expect(result.current.isAdminOrModerator).toBe(true);
       expect(result.current.isSuperAdmin).toBe(false);
       expect(result.current.isModerator).toBe(true);
     });
@@ -193,7 +193,7 @@ describe('AuthContext', () => {
 
       expect(result.current.isWrestler).toBe(true);
       expect(result.current.isFantasy).toBe(false);
-      expect(result.current.isAdmin).toBe(false);
+      expect(result.current.isAdminOrModerator).toBe(false);
       expect(result.current.isModerator).toBe(false);
     });
 


### PR DESCRIPTION
The AuthContext `isAdmin` property returned true for both Admin and Moderator groups, which was misleading since `cognitoAuth.isAdmin()` only checks for Admin. Rename to `isAdminOrModerator` to accurately reflect the behavior and avoid confusion.