### PR TITLE
chore: add newIssue command, MCP docs, and plan template

### DIFF
--- a/.claude/commands/newIssue.md
+++ b/.claude/commands/newIssue.md
@@ -1,0 +1,116 @@
+Create a GitHub issue and an execution plan for the user's request. The plan includes which skills and agents to use and how to run work in parallel.
+
+## Arguments
+
+The user provides the request as: `$ARGUMENTS`
+
+Example: `newIssue Add dark mode toggle to settings` or `newIssue Support tag team matches in the frontend`
+
+## Step 1: Create the GitHub issue
+
+Create an issue in the repository **jpDxsolo/league_szn**:
+
+- **Title**: Short, clear summary of the request (e.g. "Add dark mode toggle to settings").
+- **Body**: Expand the user's request into a proper issue description:
+  - **Summary**: What we want to achieve.
+  - **Acceptance criteria** (bullets): What "done" looks like.
+  - **Context**: Any relevant scope (e.g. frontend only, backend API, both).
+  - **Notes**: Optional constraints, links, or follow-ups.
+
+Use the GitHub MCP tool `issue_write` with `method: create`, `owner: jpDxsolo`, `repo: league_szn`.
+
+After creating, note the **issue number** for the plan.
+
+## Step 2: Research and draft the plan
+
+Using the same request and the issue body:
+
+1. **Scope the work**: Identify which parts of the codebase are affected (frontend, backend, docs, tests).
+2. **List relevant skills**: From the project's available skills, choose which apply and when:
+   - **api-documenter**: API or endpoint changes.
+   - **code-reviewer**: After implementation or for refactors.
+   - **dependency-auditor**: If adding or changing dependencies.
+   - **git-commit-helper**: When committing the change.
+   - **readme-updater**: If setup, structure, or features change.
+   - **secret-scanner**: If touching auth, env, or credentials.
+   - **security-auditor**: Auth, permissions, or security-sensitive code.
+   - **test-generator**: New or changed behavior that needs tests.
+3. **Identify parallel work**: Group tasks that have no dependency on each other (e.g. backend types + frontend types, or unrelated components) so they can be run in parallel by agents.
+
+## Step 3: Write plan.md
+
+Create a single plan file at **docs/plans/plan.md** (overwriting any existing plan there) with this structure so it works with the **execute-plan** command and with skills/agents:
+
+```markdown
+# Plan: <Short title from the issue>
+
+**GitHub issue:** #<issue_number> — [title](https://github.com/jpDxsolo/league_szn/issues/<issue_number>)
+
+## Context
+
+Brief summary of the request and why it matters. One or two sentences.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review changed files |
+| Before commit | git-commit-helper | Conventional commit message |
+| If API changed | api-documenter | Update API docs |
+| … | … | … |
+
+Only include skills that actually apply to this request.
+
+## Agents and parallel work
+
+- **Suggested order**: List steps that can run in parallel with `+`, and order with `->`. Example: `Steps 1+2 -> Step 3 -> Steps 4+5`.
+- **Agent types**: For each step or group, suggest agent type (e.g. `general-purpose`, `test-engineer`, `security-auditor`) per the execute-plan rules.
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `path/to/file` | Modify / Create / Delete | What changes and why |
+
+Include every file that likely needs changes; add "TBD" where discovery is needed.
+
+## Implementation steps
+
+Numbered steps with enough detail for an agent (or human) to implement without extra context. Each step should:
+- Reference specific file paths (and line numbers if known).
+- Say what to change and why.
+- Follow existing project patterns (see CLAUDE.md).
+
+Use subsections if helpful, e.g. `### Step 1: …`, `### Step 2: …`.
+
+## Dependencies and order
+
+- Which steps depend on others.
+- **Suggested order**: Same as in "Agents and parallel work", e.g. `Steps 1+2 -> Step 3 -> Steps 4+5`.
+- This format is used by execute-plan to build waves of parallel agents.
+
+## Testing and verification
+
+- What to test manually.
+- What existing tests might be affected.
+- What new tests to add (and consider using **test-generator** skill).
+
+## Risks and edge cases
+
+Backward compatibility, config/env, or edge cases to watch for.
+```
+
+## Step 4: Report back
+
+Tell the user:
+
+1. **Issue**: Link to the new issue (e.g. `https://github.com/jpDxsolo/league_szn/issues/<number>`).
+2. **Plan**: Path to the plan file (`docs/plans/plan.md`).
+3. **Next step**: "Run the **execute-plan** command with this plan to implement it with parallel agents, or edit `docs/plans/plan.md` first and then run execute-plan."
+
+## Important rules
+
+- **Always create both** the GitHub issue and the plan file.
+- **Owner/repo**: Use `owner: jpDxsolo`, `repo: league_szn` for all GitHub MCP calls.
+- **Plan format**: Keep "Implementation steps", "Files to modify", "Dependencies and order", and "Suggested order" so execute-plan and agents can use it.
+- **Skills and agents**: Only recommend skills and agent types that fit the request; use parallel work (e.g. `Steps 1+2 -> Step 3`) where steps are independent.

--- a/.cursor/rules/newIssue.mdc
+++ b/.cursor/rules/newIssue.mdc
@@ -1,0 +1,17 @@
+---
+description: When user invokes newIssue, create a GitHub issue and a plan.md using skills and parallel agents
+alwaysApply: true
+---
+
+# newIssue command
+
+When the user says **newIssue** (or "new issue") and provides a request or task description, run the **newIssue** workflow:
+
+1. **Create a GitHub issue** in **jpDxsolo/league_szn** with a clear title and body (summary, acceptance criteria, context).
+2. **Create docs/plans/plan.md** with:
+   - Link to the new issue
+   - **Skills to use**: Which available skills apply (api-documenter, code-reviewer, dependency-auditor, git-commit-helper, readme-updater, secret-scanner, security-auditor, test-generator) and when to use them
+   - **Agents and parallel work**: Suggested order (e.g. `Steps 1+2 -> Step 3`) and agent types so execute-plan can run steps in parallel where appropriate
+   - Implementation steps, files to modify, dependencies, testing, risks
+
+Follow the full instructions in **.claude/commands/newIssue.md** (read that file and execute each step). The plan format must be compatible with the **execute-plan** command so the user can run it next.

--- a/docs/how-i-built-my-developer-portfolio-vite-react-bun.md
+++ b/docs/how-i-built-my-developer-portfolio-vite-react-bun.md
@@ -1,0 +1,247 @@
+# How I Built My Developer Portfolio with Vite, React, and Bun — Fast, Modern & Fully Customizable
+
+**Author:** Dainy Jose  
+**Posted:** Nov 2, 2025 (Edited Jan 31)  
+**Tags:** #react #vite #portfolio #webdev
+
+_A lightweight, modular portfolio built with Vite + React + TypeScript + Bun, designed to showcase projects, blogs, and achievements — built from scratch with simplicity and speed in mind._
+
+---
+
+## Why I Built It
+
+As developers, our portfolios are often the first impression we make — so I wanted mine to be **clean, fast, and easy to maintain**.
+
+I experimented with several static site tools before finding the perfect trio: **Vite, React**, and **Bun**.  
+This stack offered everything I wanted — modern development, instant reloads, and a minimal setup that just works.
+
+- **Live Demo:** <https://dainyjose.github.io/my-portfolio/>
+- **Source Code:** <https://github.com/dainyjose/my-portfolio>
+
+---
+
+## Tech Stack
+
+| Tool                   | Purpose                                       |
+| ---------------------- | --------------------------------------------- |
+| **Vite**               | Lightning-fast build tool with instant HMR    |
+| **React + TypeScript** | Component-based architecture with type safety |
+| **Bun**                | Fast JavaScript runtime & package manager     |
+| **CSS Modules**        | Clean and scoped component styling            |
+| **GitHub Pages**       | Simple and free static site hosting           |
+
+---
+
+## Setting Up the Project
+
+Vite and Bun make setting up a React + TypeScript project almost instant.
+
+```bash
+# Create a new Vite + React + TypeScript project
+bun create vite my-portfolio --template react-ts
+
+cd my-portfolio
+
+# Install dependencies (super fast!)
+bun install
+
+# Start the dev server
+bun run dev
+```
+
+Within seconds, the project is live with hot reload and TypeScript support.
+
+---
+
+## Project Structure
+
+Here's how I organized my portfolio for clarity and scalability:
+
+```
+my-portfolio/
+┣ src/
+┃ ┣ components/
+┃ ┣ pages/
+┃ ┣ data/
+┃ ┣ assets/
+┃ ┗ App.tsx
+┣ public/
+┣ index.html
+┣ vite.config.ts
+┗ bun.lockb
+```
+
+**Highlights:**
+
+- `components/` → Reusable UI elements (Header, Footer, ProjectCard, etc.)
+- `pages/` → Sections like Home, About, Projects, and Contact
+- `data/` → Static project data and links
+- `assets/` → Images and icons
+
+---
+
+## Designing the UI
+
+I went for a **simple, professional design** — no UI frameworks or heavy styling libraries, just clean **CSS Modules** for scoped styles.
+
+**Header component:**
+
+```tsx
+// src/components/Header.tsx
+import styles from "./header.css";
+
+export const Header = () => (
+  <header className={styles.header}>
+    <h1 className={styles.title}>Dainy Jose</h1>
+    <nav className={styles.nav}>
+      <a href="#projects">Projects</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+);
+```
+
+**Header styles:**
+
+```css
+/* src/components/header.css */
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #eaeaea;
+}
+
+.title {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #222;
+}
+
+.nav a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: #007bff;
+  transition: color 0.2s;
+}
+
+.nav a:hover {
+  color: #0056b3;
+}
+```
+
+This gives full control over the look while keeping the CSS lightweight and maintainable.
+
+---
+
+## Adding Projects & Blogs
+
+To make it easy to update, I store all portfolio items in a single `data/projects.ts` file:
+
+```ts
+// src/data/projects.ts
+export const projects = [
+  {
+    name: "My Resume App",
+    description: "Created using React + Vite.",
+    link: "https://dainyjose.github.io/my-resume/",
+  },
+];
+```
+
+And render them dynamically:
+
+```tsx
+// src/components/Projects.tsx
+import { projects } from "../data/projects";
+
+export const Projects = () => (
+  <section id="projects">
+    <h2>Projects</h2>
+    {projects.map((p) => (
+      <a key={p.name} href={p.link} target="_blank" rel="noopener noreferrer">
+        <h3>{p.name}</h3>
+        <p>{p.description}</p>
+      </a>
+    ))}
+  </section>
+);
+```
+
+This makes adding new projects as easy as editing one file.
+
+---
+
+## Optimizing for Performance
+
+To keep the site fast:
+
+- Compressed images manually before adding to `assets/`
+- Leveraged Vite's built-in minification and bundling
+- Bun handled builds incredibly fast
+
+Every rebuild or deploy took only a few seconds.
+
+---
+
+## Deployment
+
+I hosted the portfolio on **GitHub Pages** using a simple build + deploy command:
+
+```json
+"scripts": {
+  "dev": "vite",
+  "build": "vite build",
+  "preview": "vite preview",
+  "deploy": "gh-pages -d dist"
+}
+```
+
+Then deployed with:
+
+```bash
+bun run build
+bun run deploy
+```
+
+In just a few seconds, the site was live:  
+➡️ <https://dainyjose.github.io/my-portfolio>
+
+---
+
+## Lessons Learned
+
+- **Bun + Vite make development effortless** — The build and dev speed is unbeatable.
+- **TypeScript ensures long-term scalability** — Strong typing helps maintain clean code.
+- **CSS Modules keep styling simple and scoped** — Easy to maintain and modify as the portfolio grows.
+- **GitHub Pages = quick deployment** — Perfect for personal projects and static sites.
+
+---
+
+## What's Next
+
+I plan to enhance the portfolio with:
+
+- Dark mode toggle
+- GitHub API integration to auto-fetch repositories
+- Dev.to API integration for displaying latest blog posts
+
+---
+
+## Final Thoughts
+
+This project reminded me that **simplicity is powerful**.  
+You don't need complex tools or heavy UI frameworks to create something elegant and efficient.
+
+If you're building your portfolio, I highly recommend giving **Vite + React + Bun** a try — you'll be surprised by how smooth the workflow is.
+
+- **Repo:** <https://github.com/dainyjose/my-portfolio>
+- **Live:** <https://dainyjose.github.io/my-portfolio/>
+
+---
+
+**Source:** [How I Built My Developer Portfolio with Vite, React, and Bun](https://dev.to/dainyjose/how-i-built-my-developer-portfolio-with-vite-react-and-bun-fast-modern-fully-customizable-410b) on DEV Community
+
+**About the author:** Dainy Jose — React Native Mobile Application Developer with 3+ years of experience building cross-platform mobile apps using **React Native (Expo, TypeScript, Redux)**. Currently expanding backend knowledge through the **MERN Stack** to create more efficient, full-stack mobile experiences.

--- a/docs/mcp-reference/AWS-MCP-Tutorial.md
+++ b/docs/mcp-reference/AWS-MCP-Tutorial.md
@@ -1,0 +1,180 @@
+# AWS MCP Server – Tutorial & Reference
+
+This guide covers the **AWS MCP** server you configured in Cursor. It lets you run AWS CLI commands, search AWS docs, list regions, and follow AWS SOPs (Standard Operating Procedures) from the editor.
+
+## Your configuration (from `mcp.json`)
+
+```json
+"AWS": {
+  "command": "uvx mcp-proxy-for-aws@latest https://aws-mcp.us-east-1.api.aws/mcp --metadata AWS_REGION=us-west-2",
+  "env": {
+    "AWS_REGION": "us-east-1"
+  },
+  "args": []
+}
+```
+
+- **Runtime**: `uvx` (Python/uv)
+- **Region**: `us-east-1` (env overrides metadata)
+- **Endpoint**: AWS MCP proxy at `https://aws-mcp.us-east-1.api.aws/mcp`
+
+---
+
+## What the AWS MCP can do
+
+| Capability | Use case |
+|------------|----------|
+| **Run AWS CLI** | Run any `aws ...` command (no pipes/shell operators). |
+| **Search AWS docs** | Find reference, troubleshooting, CDK, Amplify, CloudFormation. |
+| **Read AWS docs** | Fetch a docs page and get markdown. |
+| **List regions** | Get all region IDs and names. |
+| **Regional availability** | Check if a product/API/CF resource is available in a region. |
+| **Suggest commands** | Get CLI command suggestions from a natural-language description. |
+| **SOPs** | Follow step-by-step AWS procedures (e.g. Lambda + API Gateway, secure S3). |
+
+---
+
+## 1. Running AWS CLI commands
+
+**Tool**: Execute a single AWS CLI command (validated, no shell syntax).
+
+**Rules:**
+
+- Command must start with `aws`.
+- No `|`, `>`, `$()`, or environment variables.
+- For local file paths (e.g. `aws s3 cp` with local files), the MCP server may not have filesystem access; use the terminal for those.
+
+**Examples (ask the AI to run these):**
+
+```text
+# List Lambda functions in us-east-1
+aws lambda list-functions --region us-east-1
+
+# Describe an S3 bucket
+aws s3api get-bucket-location --bucket YOUR_BUCKET_NAME
+
+# List Cognito User Pools
+aws cognito-idp list-user-pools --max-results 10
+
+# Get stack outputs (e.g. API Gateway URL)
+aws cloudformation describe-stacks --stack-name wwe-2k-league-api-dev --query "Stacks[0].Outputs"
+```
+
+**In Cursor:** Describe what you want in natural language (e.g. “list my Lambda functions in us-east-1”). The AI will use the AWS MCP to run the right `aws` command.
+
+---
+
+## 2. Searching AWS documentation
+
+**Tool**: Search AWS docs by topic (reference, troubleshooting, CDK, Amplify, CloudFormation, etc.).
+
+**Example prompts:**
+
+- “Search AWS docs for Lambda environment variables and timeouts.”
+- “How do I fix AccessDenied on S3?”
+- “CDK Lambda function TypeScript example.”
+- “Amplify Auth with React.”
+
+**Topics you can use:**
+
+- `reference_documentation` – API, SDK, CLI
+- `troubleshooting` – errors, debugging
+- `general` – architecture, best practices
+- `cdk_docs` / `cdk_constructs` – CDK
+- `amplify_docs` – Amplify
+- `cloudformation` – CloudFormation/SAM
+
+---
+
+## 3. Reading a specific AWS docs page
+
+**Tool**: Fetch an AWS documentation URL and get markdown (with optional truncation).
+
+**Example URLs:**
+
+- `https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html`
+- `https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html`
+
+**In Cursor:** Ask e.g. “Read the Lambda environment variables docs from docs.aws.amazon.com” and share the URL if needed.
+
+---
+
+## 4. Listing AWS regions
+
+**Tool**: Get all AWS regions (e.g. for deployment or validation).
+
+Useful when you need region codes (e.g. `us-east-1`, `eu-west-1`) for CLI or infrastructure.
+
+---
+
+## 5. Checking regional availability
+
+**Tool**: Check if a product, API, or CloudFormation resource is available in a region.
+
+**Example filters:**
+
+- **Products**: `['AWS Lambda', 'Amazon S3']`
+- **APIs**: `['Lambda+Invoke', 'EC2']`
+- **CloudFormation**: `['AWS::Lambda::Function']`
+
+**In Cursor:** Ask e.g. “Is AWS Lambda available in eu-west-1?” or “Which regions support this CloudFormation resource?”
+
+---
+
+## 6. Getting AWS CLI suggestions
+
+**Tool**: Get suggested AWS CLI commands from a short description (when you’re not sure of the exact command).
+
+**Example prompts:**
+
+- “List all running EC2 instances in us-east-1.”
+- “Create an S3 bucket with versioning and encryption.”
+- “Get the size of my S3 bucket named my-backup-bucket.”
+
+The AI can use this tool first, then run the chosen command with the “run AWS CLI” tool.
+
+---
+
+## 7. Using AWS SOPs (procedures)
+
+**Tool**: Retrieve step-by-step execution plans for common AWS tasks.
+
+**Some built-in SOPs:**
+
+- `lambda-gateway-api` – REST API Gateway + Lambda
+- `secure-s3-buckets` – S3 security best practices
+- `launch-ec2-instance-with-best-practices` – EC2 launch
+- `create-secrets-using-best-practices` – Secrets Manager
+- `amplify-deployment-guide` – Amplify Gen2 deployment
+- Others for VPC, EFS, CloudTrail, etc.
+
+**In Cursor:** Ask e.g. “Follow the AWS SOP for securing S3 buckets” or “What’s the procedure for API Gateway and Lambda?”
+
+---
+
+## Quick reference: “Ask in Cursor” examples
+
+| Goal | What to say |
+|------|-------------|
+| Run CLI | “List my Lambda functions in us-east-1” or “Describe stack wwe-2k-league-api-dev” |
+| Find docs | “Search AWS docs for Lambda timeout troubleshooting” |
+| Read a page | “Read this AWS doc: [URL]” |
+| Regions | “List AWS regions” or “Is Lambda in ap-south-1?” |
+| CLI help | “What’s the AWS CLI command to list EC2 instances?” |
+| Procedure | “Get the AWS SOP for API Gateway and Lambda” |
+
+---
+
+## Troubleshooting
+
+- **“Command must start with aws”** – Only raw `aws ...` commands are allowed; use the terminal for shell scripts.
+- **File operations** – Commands that need local files (e.g. `aws s3 cp ./file s3://bucket/`) may need to be run in your terminal; the MCP server often has no local filesystem.
+- **Region** – Your config uses `AWS_REGION=us-east-1`; for other regions, say “in eu-west-1” (or the right region) so the AI can add `--region eu-west-1`.
+- **Auth** – The MCP uses your existing AWS credentials (e.g. profile or env). Ensure `league-szn` (or default) is configured if you rely on it.
+
+---
+
+## Links
+
+- [AWS MCP](https://github.com/aws/aws-mcp) (if available)
+- [AWS CLI reference](https://docs.aws.amazon.com/cli/latest/reference/)

--- a/docs/mcp-reference/Fetch-MCP-Tutorial.md
+++ b/docs/mcp-reference/Fetch-MCP-Tutorial.md
@@ -1,0 +1,120 @@
+# Fetch MCP Server – Tutorial & Reference
+
+This guide covers the **Fetch MCP** server you configured in Cursor. It fetches URLs from the internet and can return the content as markdown, so you can pull in docs, articles, or API responses without leaving the editor.
+
+## Your configuration (from `mcp.json`)
+
+```json
+"fetch": {
+  "command": "uvx",
+  "args": ["mcp-server-fetch"]
+}
+```
+
+- **Runtime**: `uvx` (runs the `mcp-server-fetch` package).
+- **No env or URL allowlist** in your snippet; the server may apply its own rules (e.g. allowed hosts or size limits).
+
+---
+
+## What the Fetch MCP can do
+
+| Capability | Description |
+|------------|-------------|
+| **Fetch URL** | HTTP GET a URL and return the response. |
+| **As markdown** | Convert HTML (or other content) to readable markdown. |
+| **Control length** | Limit response size with `max_length` (default often ~5000 chars). |
+| **Resume long docs** | Use `start_index` to get the next chunk after a truncated response. |
+
+---
+
+## Parameters (typical)
+
+| Parameter     | Type    | Default | Description |
+|--------------|---------|---------|-------------|
+| `url`        | string  | required | Full URL to fetch (e.g. `https://example.com/page`). |
+| `max_length` | integer | 5000    | Max characters to return. Increase for long pages. |
+| `start_index`| integer | 0       | Character index to start from (for pagination/continuation). |
+| `raw`        | boolean | false   | If true, return raw HTML instead of simplified markdown. |
+
+---
+
+## Example use cases
+
+### 1. Read a documentation page
+
+**Goal:** Get the content of a docs page as markdown.
+
+**In Cursor:** “Fetch this URL and give me the content as markdown: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html”
+
+**Typical flow:** The AI calls the fetch tool with `url` and optionally `max_length`. You get a markdown summary of the page.
+
+---
+
+### 2. Get an API’s public description
+
+**Goal:** Pull the “what is this API?” section from a public API doc.
+
+**In Cursor:** “Fetch https://developer.github.com/v3/ and summarize the main sections.”
+
+---
+
+### 3. Read a long article in chunks
+
+**Goal:** Page through a long document.
+
+- First request: `url`, `max_length` (e.g. 10000).
+- If the response says “truncated” or gives a character count, second request: same `url`, `start_index` = previous length, same `max_length`.
+
+**In Cursor:** “Fetch this long doc; if it’s truncated, continue from where it left off.”
+
+---
+
+### 4. Check a changelog or release note
+
+**Goal:** Get the text of a release page or changelog.
+
+**In Cursor:** “Fetch the content of https://github.com/org/repo/releases/tag/v1.2.0”
+
+---
+
+## Example “prompts” to use in Cursor
+
+| You want to… | Say… |
+|--------------|------|
+| Get a page as markdown | “Fetch https://example.com/doc and return the content as markdown.” |
+| Get more of a long page | “Continue fetching that URL from character index 5000.” |
+| Get raw HTML | “Fetch this URL and return the raw HTML: [url].” |
+| Stay within size limit | “Fetch this URL but limit the response to 3000 characters.” |
+
+---
+
+## Tips
+
+- **HTTPS:** Prefer `https://` URLs; some servers or MCP configs may block or restrict `http://`.
+- **Length:** For long pages, use a larger `max_length` or multiple requests with `start_index`.
+- **Rate limits / politeness:** Avoid asking for many different URLs in a tight loop; the server may rate-limit or the site may block.
+- **Auth:** This MCP is for **public** URLs. It does not send cookies or auth headers; use other tools or the browser for logged-in content.
+
+---
+
+## Troubleshooting
+
+| Issue | What to try |
+|-------|-------------|
+| Empty or short response | Increase `max_length` or ask to “continue from index X”. |
+| “URL not allowed” or error | Server or tool may restrict to certain domains; try a different URL or use the browser MCP for that site. |
+| Wrong encoding or garbled text | Ask for “raw” and then “convert to markdown” or try a different page. |
+| Timeout | URL might be slow or blocking automated requests; try again or use a different source. |
+
+---
+
+## Comparison with other MCPs
+
+| Need | Prefer |
+|------|--------|
+| Public URL → markdown/text | **Fetch MCP** |
+| Interact with a page (click, type, form) | Browser MCP (e.g. cursor-ide-browser) |
+| AWS docs only | **AWS MCP** “search/read documentation” |
+| GitHub repo/API data | **GitHub MCP** |
+
+Use Fetch when you want to **pull in content from an arbitrary public URL** and work with it in the chat or in code.

--- a/docs/mcp-reference/GitHub-MCP-Tutorial.md
+++ b/docs/mcp-reference/GitHub-MCP-Tutorial.md
@@ -1,0 +1,221 @@
+# GitHub MCP Server – Tutorial & Reference
+
+This guide covers the **GitHub MCP** server you configured in Cursor. It talks to GitHub (repos, issues, PRs, files, search) so you can query and manage your project without leaving the editor.
+
+## Your configuration (from `mcp.json`)
+
+```json
+"GitHub": {
+  "command": "docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server",
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."
+  },
+  "args": []
+}
+```
+
+- **Runtime**: Docker image `ghcr.io/github/github-mcp-server`.
+- **Auth**: Token passed via `GITHUB_PERSONAL_ACCESS_TOKEN` (classic PAT or fine-grained).
+- **Security:** Store the token in env or a secrets manager; do not commit it. Rotate if exposed.
+
+---
+
+## What the GitHub MCP can do
+
+| Category | Examples |
+|----------|----------|
+| **Repos** | List branches, get file/dir contents, create/update/delete files, create repo. |
+| **Issues** | List, create, update, read, search issues; add/remove labels; sub-issues. |
+| **Pull requests** | List, create, update, get diff/status/files; reviews and review comments; merge; update branch. |
+| **Search** | Search code, issues, PRs, repos, users. |
+| **Commits & history** | List commits, get commit details (with optional diff). |
+| **Releases & tags** | List releases, get release by tag; list tags, get tag. |
+| **Collaboration** | Request Copilot review; assign Copilot to an issue; add PR/issue comments. |
+
+---
+
+## 1. Repository and file operations
+
+### Get file or directory contents
+
+- **Get a file:** From default branch or a specific `ref` (branch/tag/SHA).
+- **Get a directory:** List contents of a path.
+
+**Example prompts:**
+
+- “Get the contents of `README.md` in jpDxsolo/league_szn.”
+- “List files in the `backend/functions` directory of jpDxsolo/league_szn on branch feat/seedAdmin.”
+
+**Typical parameters:** `owner`, `repo`, `path`, optional `ref` or `sha`.
+
+---
+
+### Create or update a file
+
+- **Create:** Provide branch, path, content, message.
+- **Update:** Same, plus **SHA** of the current file (from `git ls-tree HEAD <path>` or API).
+
+**Example prompts:**
+
+- “Create a file `docs/contributing.md` in jpDxsolo/league_szn on branch main with content ‘# Contributing …’.”
+- “Update `serverless.yml` in jpDxsolo/league_szn: add this environment variable …”
+
+---
+
+### Push multiple files (single commit)
+
+- **Tool:** Push an array of `{ path, content }` in one commit.
+
+**Example:** “Push these 3 files to branch `feat/docs` in jpDxsolo/league_szn: …”
+
+---
+
+## 2. Branches
+
+- **List branches:** Paginated list for a repo.
+- **Create branch:** From default or a given `from_branch`.
+
+**Example:** “List branches in jpDxsolo/league_szn” or “Create branch `fix/auth` from `main` in jpDxsolo/league_szn.”
+
+---
+
+## 3. Issues
+
+- **List issues:** By state (open/closed), labels, sort, pagination.
+- **Search issues:** Full search syntax (e.g. `is:issue author:me label:bug`).
+- **Create / update:** Create with title, body, labels, assignees; update state, labels, etc.
+- **Read:** Get issue, comments, sub-issues, labels.
+- **Sub-issues:** Add, remove, reprioritize sub-issues.
+
+**Example prompts:**
+
+- “List open issues in jpDxsolo/league_szn.”
+- “Create an issue in jpDxsolo/league_szn: title ‘Add API docs’, body ‘We need OpenAPI docs’.”
+- “Search issues in jpDxsolo/league_szn: ‘label:bug is:open’.”
+
+---
+
+## 4. Pull requests
+
+- **List PRs:** By state (open/closed), base/head, sort.
+- **Search PRs:** e.g. `is:pr author:me`.
+- **Create PR:** Base branch, head branch, title, body, draft, maintainer_can_modify.
+- **Read:** Get PR, diff, status, files changed, review comments, reviews, general comments.
+- **Update:** Title, body, base, draft, state, reviewers.
+- **Review:** Create review (approve / request changes / comment), add line comments to pending review, submit or delete pending review.
+- **Merge:** Merge with optional method (merge/squash/rebase), commit title/body.
+- **Update branch:** Rebase/merge base into PR branch (optional `expectedHeadSha`).
+
+**Example prompts:**
+
+- “List open PRs in jpDxsolo/league_szn.”
+- “Create a PR in jpDxsolo/league_szn: head `feat/seedAdmin`, base `main`, title ‘Seed admin script’.”
+- “Get the diff for PR #42 in jpDxsolo/league_szn.”
+- “Add a review comment on PR #42, file `backend/package.json`, line 10: ‘Consider pinning this dependency’.”
+- “Merge PR #42 in jpDxsolo/league_szn with squash.”
+
+---
+
+## 5. Search
+
+- **Code:** Query across repos (e.g. `repo:jpDxsolo/league_szn language:TypeScript createMatch`).
+- **Issues:** e.g. `repo:jpDxsolo/league_szn is:issue label:enhancement`.
+- **PRs:** e.g. `repo:jpDxsolo/league_szn is:pr is:open`.
+- **Repositories:** e.g. `user:jpDxsolo language:TypeScript`.
+- **Users:** e.g. `followers:>100 location:seattle`.
+
+**Example prompts:**
+
+- “Search code in jpDxsolo/league_szn for ‘authorizer’.”
+- “Search open PRs in jpDxsolo/league_szn.”
+
+---
+
+## 6. Commits and history
+
+- **List commits:** By branch/SHA, optional author, pagination.
+- **Get commit:** Details with optional diff and file stats.
+
+**Example:** “List last 10 commits on main in jpDxsolo/league_szn” or “Get commit abc123 in jpDxsolo/league_szn with diff.”
+
+---
+
+## 7. Releases and tags
+
+- **List releases:** Paginated.
+- **Get release:** By tag or “latest.”
+- **List tags** / **Get tag:** Inspect tags.
+
+**Example:** “Get the latest release in jpDxsolo/league_szn.”
+
+---
+
+## 8. Collaboration (Copilot, reviews, comments)
+
+- **Request Copilot review:** On a PR.
+- **Assign Copilot to issue:** Optional base ref and custom instructions.
+- **Add issue/PR comment:** General comment (e.g. “LGTM” on an issue or PR).
+- **Add review comment:** On a specific line (or range) of the PR diff; requires a pending review, then submit.
+
+**Example:** “Request a Copilot review on PR #42 in jpDxsolo/league_szn.”
+
+---
+
+## Quick reference: “Ask in Cursor” examples
+
+| Goal | What to say |
+|------|-------------|
+| Read file | “Get contents of `backend/serverless.yml` in jpDxsolo/league_szn.” |
+| List dir | “List files in `frontend/src` in jpDxsolo/league_szn.” |
+| Create file | “Create `docs/API.md` on branch `main` in jpDxsolo/league_szn with ….” |
+| List issues | “List open issues in jpDxsolo/league_szn.” |
+| Create issue | “Create an issue in jpDxsolo/league_szn: title ‘…’, body ‘…’.” |
+| List PRs | “List open pull requests in jpDxsolo/league_szn.” |
+| Create PR | “Create a PR from feat/seedAdmin to main in jpDxsolo/league_szn.” |
+| PR diff | “Get the diff for PR #X in jpDxsolo/league_szn.” |
+| Review PR | “Add a review comment on PR #X on file Y, line Z: ‘…’.” |
+| Merge PR | “Merge PR #X in jpDxsolo/league_szn (squash).” |
+| Search code | “Search jpDxsolo/league_szn for ‘DynamoDB’.” |
+| My user | “Get my GitHub user (for permissions/context).” |
+
+---
+
+## Permissions and token scope
+
+Your PAT must have scopes that match what you do:
+
+- **Repo (code, issues, PRs):** `repo` (or fine-grained: Contents, Pull requests, Issues, etc.).
+- **Workflows (if you use them via API):** `workflow`.
+- **Optional:** `read:org`, `user` for org and profile.
+
+If the AI gets 403 or “resource not accessible,” check token scopes and repo permissions. Use **get_me** to confirm the authenticated user.
+
+---
+
+## Best practices
+
+1. **Repo/owner:** Always specify `owner` and `repo` (e.g. `jpDxsolo`, `league_szn`).
+2. **PR review comments:** Create a pending review, add line comments, then submit the review.
+3. **Update file:** Use the blob SHA of the current file when updating to avoid overwriting others’ changes.
+4. **Search:** Use `search_*` for targeted queries; use `list_*` for “all” with filters/pagination.
+5. **Templates:** Check for `.github/PULL_REQUEST_TEMPLATE.md` (or similar) when creating PRs and use it in the body.
+
+---
+
+## Troubleshooting
+
+| Issue | What to check |
+|-------|----------------|
+| 401 Unauthorized | Token valid, not expired, and passed correctly in `env`. |
+| 403 Forbidden | Token scopes and repo access (org/repo permissions). |
+| 404 Not found | Correct owner/repo, branch/ref, and path. |
+| “Resource not accessible” | Fine-grained token repository access and permissions. |
+| Review submission fails | Pending review must exist before submitting; use the same user that started the review. |
+
+---
+
+## Links
+
+- [GitHub MCP Server](https://github.com/github/github-mcp-server) (or official docs)
+- [GitHub REST API](https://docs.github.com/en/rest)
+- [Search syntax](https://docs.github.com/en/search-github)

--- a/docs/mcp-reference/README.md
+++ b/docs/mcp-reference/README.md
@@ -1,0 +1,34 @@
+# MCP Server Tutorials & Reference
+
+This folder contains tutorials and reference docs for the **MCP (Model Context Protocol) servers** configured in your Cursor `mcp.json`.
+
+## Your setup
+
+Config file: **`~/.cursor/mcp.json`** (or project-level `.cursor/mcp.json`).
+
+| Server    | Purpose |
+|----------|--------|
+| **AWS**  | Run AWS CLI, search/read AWS docs, list regions, check availability, follow AWS SOPs. |
+| **Fetch**| Fetch public URLs and get content as markdown. |
+| **GitHub** | Repos, issues, PRs, search, file ops, reviews, merge. |
+
+*(You also have `browsermcp` configured for browser automation; these docs focus on AWS, Fetch, and GitHub.)*
+
+## Tutorials
+
+| File | Description |
+|------|-------------|
+| [AWS-MCP-Tutorial.md](./AWS-MCP-Tutorial.md) | AWS CLI, docs search, regions, availability, SOPs, and example prompts. |
+| [Fetch-MCP-Tutorial.md](./Fetch-MCP-Tutorial.md) | Fetching URLs, markdown conversion, length and pagination. |
+| [GitHub-MCP-Tutorial.md](./GitHub-MCP-Tutorial.md) | Repos, files, issues, PRs, search, reviews, and permissions. |
+
+## How to use these in Cursor
+
+1. Open the tutorial for the server you care about (AWS, Fetch, or GitHub).
+2. Use the **“Ask in Cursor”** / **Quick reference** tables to phrase prompts.
+3. The AI will call the right MCP tools and show you results or next steps.
+
+## Security note
+
+- **GitHub:** Your `GITHUB_PERSONAL_ACCESS_TOKEN` in `mcp.json` should be in env or a secrets manager, not committed. Rotate the token if it was ever exposed.
+- **AWS:** The AWS MCP uses your existing AWS credentials (e.g. `league-szn` profile); no secrets are stored in these docs.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,8 @@
+# Execution plans
+
+Plans created by the **newIssue** command are written to `plan.md` in this directory.
+
+- **newIssue**: Creates a GitHub issue and `docs/plans/plan.md` with skills, agents, and parallel work.
+- **execute-plan**: Runs a plan by executing implementation steps in waves (parallel agents where the plan allows).
+
+Edit `plan.md` as needed, then run the execute-plan command to implement.

--- a/docs/plans/plan.md
+++ b/docs/plans/plan.md
@@ -1,0 +1,97 @@
+# Plan: Toggle between sidebar (hamburger) and horizontal top navigation
+
+**GitHub issue:** [#124](https://github.com/jpDxsolo/league_szn/issues/124) — Toggle between sidebar (hamburger) and horizontal top navigation
+
+## Context
+
+Users want to choose between the current sidebar (hamburger) navigation and a traditional horizontal top menu. The app already has grouped sub-menus; both layouts should reuse the same structure with only the presentation changing. Preference should persist across sessions.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review changed/new components and layout |
+| Before commit | git-commit-helper | Conventional commit message |
+| When adding tests | test-generator | Scaffold tests for nav layout toggle and TopNav |
+
+Only include skills that actually apply to this request.
+
+## Agents and parallel work
+
+- **Suggested order**: Step 1 (preference state + key) → Steps 2+3 in parallel (shared nav config + TopNav component) → Step 4 (integrate layout + toggle in App/TopBar) → Step 5 (tests).
+- **Agent types**: `general-purpose` for Steps 1–4; `test-engineer` or `general-purpose` for Step 5.
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/contexts/NavLayoutContext.tsx` | Create | Hold layout mode (sidebar | topnav) and setter; read/write preference from localStorage |
+| `frontend/src/config/navConfig.ts` (or under `components/`) | Create | Single source of truth for nav groups, labels, and routes (used by Sidebar and TopNav) |
+| `frontend/src/components/Sidebar.tsx` | Modify | Consume nav config (if extracted); optionally show layout toggle in footer; respect layout mode (hide when topnav is active) |
+| `frontend/src/components/TopNav.tsx` | Create | Horizontal nav bar: top-level groups as items, sub-menus as dropdowns/flyouts; same groups as Sidebar |
+| `frontend/src/components/TopNav.css` | Create | Styles for horizontal bar and dropdowns |
+| `frontend/src/components/TopBar.tsx` | Modify | Add layout toggle (sidebar vs topnav icon/button); when topnav mode, ensure TopNav is visible (e.g. below TopBar or integrated) |
+| `frontend/src/App.tsx` | Modify | Wrap with NavLayoutProvider; conditionally render Sidebar or TopNav based on preference; adjust main layout class for topnav (e.g. no sidebar offset) |
+| `frontend/src/App.css` | Modify | Layout classes for topnav mode (e.g. `.App.topnav-layout` with no sidebar column) |
+| `frontend/src/components/Sidebar.css` | Modify | No structural change if Sidebar is simply not rendered in topnav mode; optional tweaks for toggle placement |
+| `frontend/src/components/__tests__/Sidebar.test.tsx` | Modify | Mock NavLayoutContext; ensure Sidebar still renders and behaves when in sidebar mode |
+| `frontend/src/components/__tests__/TopNav.test.tsx` | Create | Render TopNav with mock auth/config; assert groups and links |
+| `frontend/src/components/__tests__/App.test.tsx` | Modify | Mock NavLayoutContext; assert both layouts can be shown based on context |
+
+## Implementation steps
+
+### Step 1: Preference state and persistence
+
+- Create `frontend/src/contexts/NavLayoutContext.tsx`.
+- State: `layoutMode: 'sidebar' | 'topnav'`, setter `setLayoutMode`.
+- On mount, read from `localStorage` (e.g. key `league_szn_nav_layout`); default `'sidebar'`.
+- When `setLayoutMode` is called, update state and write to localStorage.
+- Export `NavLayoutProvider` and `useNavLayout()`.
+
+### Step 2: Shared nav config (single source of truth)
+
+- Add `frontend/src/config/navConfig.ts` (or `frontend/src/components/nav/navConfig.ts`).
+- Define structure: public groups (e.g. Core with routes, Wrestler with routes, Help), admin groups (Match ops, League setup, etc.), and which routes belong to which group. Structure should be easy to consume by both Sidebar and TopNav (e.g. array of groups, each with `key`, `labelKey`, `items: { to, labelKey }[]`, and optional `adminOnly` / feature flags).
+- Refactor `Sidebar.tsx` to use this config for rendering groups and links (optional in same step or Step 4). If refactor is large, Step 2 can just add the config and Step 4 can switch Sidebar to use it when integrating.
+
+### Step 3: TopNav component (horizontal bar)
+
+- Create `frontend/src/components/TopNav.tsx`: horizontal bar that renders the same groups as Sidebar.
+- Each top-level group is a button or link; click opens a dropdown/flyout with the same sub-items as in Sidebar. Use the same nav config as Sidebar (from Step 2).
+- Handle auth: hide admin group when not admin; show Wrestler group only when applicable (reuse same logic as Sidebar from AuthContext / SiteConfig).
+- Accessibility: aria-expanded, focus trap or focus management in dropdown, Escape to close.
+- Create `TopNav.css` for layout and dropdown styling. Ensure it works below TopBar (or integrated) and doesn’t break on small screens (define behavior: e.g. collapse to a single “Menu” that opens the same structure in a sheet/modal).
+
+### Step 4: Layout integration and toggle
+
+- In `App.tsx`: wrap app with `NavLayoutProvider`. When `layoutMode === 'sidebar'`, render `Sidebar` as today; when `layoutMode === 'topnav'`, render `TopNav` (e.g. below TopBar or in a dedicated slot) and do not render Sidebar. Apply a layout class to the app container for topnav (e.g. `App topnav-layout`) so main content doesn’t reserve sidebar space.
+- In `TopBar.tsx`: add a layout toggle control (e.g. two icons: “sidebar” and “horizontal menu”). On click, call `setLayoutMode('sidebar')` or `setLayoutMode('topnav')`. Ensure the toggle is visible in both layouts (so users can switch back).
+- Update `App.css`: for `.App.topnav-layout`, set layout so main content is full-width (no sidebar column). Ensure TopNav has a clear visual home (e.g. full-width bar under TopBar).
+
+### Step 5: Tests and cleanup
+
+- **Sidebar.test.tsx**: Provide a mock `NavLayoutContext` with `layoutMode: 'sidebar'` so existing tests still pass. Optionally add a test that Sidebar is not rendered when layout is topnav (if that’s asserted in App).
+- **TopNav.test.tsx**: New file. Render TopNav with mocked auth and nav config; assert presence of expected groups and links; optionally assert dropdown open/close.
+- **App.test.tsx**: Mock NavLayoutContext; assert that for `layoutMode === 'sidebar'` the sidebar is present and for `layoutMode === 'topnav'` the top nav is present (and sidebar absent). May need to adjust existing sidebar mock.
+- Run existing tests and fix any regressions.
+
+## Dependencies and order
+
+- Step 1 must be done first (context and persistence).
+- Steps 2 and 3 can be done in parallel once Step 1 exists (nav config is independent; TopNav can use a temporary inline config then switch to shared config in Step 4).
+- Step 4 depends on Steps 1, 2, and 3 (integrate context, config, Sidebar refactor if any, TopNav, and toggle).
+- Step 5 depends on Step 4.
+
+**Suggested order**: Step 1 → Steps 2+3 → Step 4 → Step 5.
+
+## Testing and verification
+
+- **Manual**: Toggle between sidebar and topnav; refresh and confirm preference persists. Navigate from both layouts; verify admin and wrestler sections show/hide correctly. Test keyboard and dropdown close on Escape. Test narrow viewport for both layouts.
+- **Existing tests**: Sidebar and App tests may need NavLayoutContext mocks; update as above.
+- **New tests**: TopNav rendering and optional layout toggle behavior; consider using **test-generator** for TopNav and context tests.
+
+## Risks and edge cases
+
+- **Backward compatibility**: First load has no localStorage key; default to sidebar so current behavior is unchanged.
+- **Mobile**: Define whether topnav mode on mobile collapses to one menu button; ensure touch targets and overflow are acceptable.
+- **i18n**: Nav config should use the same translation keys as Sidebar (`t('nav.standings')`, etc.) so both layouts stay in sync with translations.


### PR DESCRIPTION
## Summary
- Add **newIssue** command and Cursor rule: create GitHub issue + `docs/plans/plan.md` from a task description (compatible with execute-plan).
- Add **docs/mcp-reference/** with tutorials for AWS, GitHub, and Fetch MCP.
- Add **docs/plans/** (README + plan template).
- Add **docs/how-i-built-my-developer-portfolio-vite-react-bun.md**.
- Remove outdated **backend/serverless-phase2-branch.yml** (main already uses consolidated handlers).

## Changes
- `.claude/commands/newIssue.md` – newIssue workflow steps
- `.cursor/rules/newIssue.mdc` – rule that triggers the workflow
- `docs/mcp-reference/README.md`, `AWS-MCP-Tutorial.md`, `GitHub-MCP-Tutorial.md`, `Fetch-MCP-Tutorial.md`
- `docs/plans/README.md`, `docs/plans/plan.md`
- `docs/how-i-built-my-developer-portfolio-vite-react-bun.md`
- Deleted: `backend/serverless-phase2-branch.yml`