### PR TITLE
feat(wiki): add breadcrumb navigation (Help > Wiki > Article)

### DIFF
--- a/frontend/src/components/Wiki.css
+++ b/frontend/src/components/Wiki.css
@@ -3,6 +3,53 @@
   margin: 0 auto;
 }
 
+.wiki-breadcrumbs {
+  margin-bottom: 0.75rem;
+}
+
+.wiki-breadcrumbs-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #888;
+}
+
+.wiki-breadcrumbs-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.wiki-breadcrumbs-list li:not(:last-child)::after {
+  content: "›";
+  margin-left: 0.25rem;
+  color: #666;
+}
+
+.wiki-breadcrumbs-list a {
+  color: #93c5fd;
+  text-decoration: none;
+}
+
+.wiki-breadcrumbs-list a:hover {
+  text-decoration: underline;
+}
+
+.wiki-breadcrumbs-list a:focus {
+  outline: 2px solid #d4af37;
+  outline-offset: 2px;
+}
+
+.wiki-breadcrumbs-current {
+  color: #d4af37;
+  font-weight: 500;
+}
+
 .wiki-back-link {
   display: inline-block;
   color: #93c5fd;

--- a/frontend/src/components/Wiki.tsx
+++ b/frontend/src/components/Wiki.tsx
@@ -1,11 +1,13 @@
 import { Link, Outlet } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import WikiBreadcrumbs from './WikiBreadcrumbs';
 import './Wiki.css';
 
 export function WikiLayout() {
   const { t } = useTranslation();
   return (
     <div className="wiki-layout">
+      <WikiBreadcrumbs />
       <Link to="/guide" className="wiki-back-link">
         {t('wiki.backToGuide')}
       </Link>

--- a/frontend/src/components/WikiBreadcrumbs.tsx
+++ b/frontend/src/components/WikiBreadcrumbs.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+import { Link, useParams, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+interface WikiArticleEntry {
+  slug: string;
+  titleKey: string;
+  file: string;
+}
+
+export default function WikiBreadcrumbs() {
+  const { slug } = useParams<{ slug: string }>();
+  const { pathname } = useLocation();
+  const { t } = useTranslation();
+  const [articleTitle, setArticleTitle] = useState<string | null>(null);
+
+  const isIndex = pathname === '/guide/wiki' || pathname === '/guide/wiki/';
+  const isArticle = Boolean(slug);
+
+  useEffect(() => {
+    if (!slug) {
+      setArticleTitle(null);
+      return;
+    }
+    fetch('/wiki/index.json')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: WikiArticleEntry[]) => {
+        const entry = Array.isArray(data)
+          ? data.find((e) => e.slug === slug)
+          : undefined;
+        setArticleTitle(entry ? t(entry.titleKey) : slug);
+      })
+      .catch(() => setArticleTitle(slug));
+  }, [slug, t]);
+
+  return (
+    <nav
+      className="wiki-breadcrumbs"
+      aria-label={t('wiki.breadcrumbNav')}
+    >
+      <ol className="wiki-breadcrumbs-list">
+        <li>
+          <Link to="/guide">{t('wiki.breadcrumb.help')}</Link>
+        </li>
+        <li>
+          {isIndex ? (
+            <span className="wiki-breadcrumbs-current" aria-current="page">
+              {t('wiki.breadcrumb.wiki')}
+            </span>
+          ) : (
+            <Link to="/guide/wiki">{t('wiki.breadcrumb.wiki')}</Link>
+          )}
+        </li>
+        {isArticle && (
+          <li>
+            <span className="wiki-breadcrumbs-current" aria-current="page">
+              {articleTitle ?? slug}
+            </span>
+          </li>
+        )}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/components/__tests__/Wiki.test.tsx
+++ b/frontend/src/components/__tests__/Wiki.test.tsx
@@ -42,12 +42,16 @@ describe('Wiki', () => {
     global.fetch = vi.fn();
   });
 
-  it('WikiLayout shows back-to-guide link', async () => {
+  it('WikiLayout shows breadcrumbs and back-to-guide link', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => [],
     });
     renderWikiRoutes();
+    const nav = screen.getByRole('navigation', { name: 'wiki.breadcrumbNav' });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'wiki.breadcrumb.help' })).toHaveAttribute('href', '/guide');
+    expect(screen.getByText('wiki.breadcrumb.wiki')).toBeInTheDocument();
     const backLink = await screen.findByRole('link', { name: 'wiki.backToGuide' });
     expect(backLink).toBeInTheDocument();
     expect(backLink).toHaveAttribute('href', '/guide');

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -59,6 +59,11 @@
     "title": "Wiki",
     "indexTitle": "Wiki-Artikel",
     "backToGuide": "Zurück zur Anleitung",
+    "breadcrumbNav": "Wiki-Breadcrumb-Navigation",
+    "breadcrumb": {
+      "help": "Hilfe",
+      "wiki": "Wiki"
+    },
     "articles": {
       "gettingStarted": "Erste Schritte",
       "faqs": "Häufige Fragen"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -59,6 +59,11 @@
     "title": "Wiki",
     "indexTitle": "Wiki Articles",
     "backToGuide": "Back to guide",
+    "breadcrumbNav": "Wiki breadcrumb navigation",
+    "breadcrumb": {
+      "help": "Help",
+      "wiki": "Wiki"
+    },
     "articles": {
       "gettingStarted": "Getting started",
       "faqs": "FAQs"


### PR DESCRIPTION
## Summary
Adds breadcrumb navigation to wiki pages so users see where they are (Help > Wiki > Article title) and can jump back to Help or the wiki index in one click.

Closes #135.

## Changes
- **WikiBreadcrumbs** component: Renders Help > Wiki on index; Help > Wiki > [Article title] on article view. Uses `index.json` to resolve slug to translated title. Accessible `<nav aria-label>` and `aria-current="page"` on current segment.
- **WikiLayout**: Renders breadcrumbs above the existing "Back to guide" link.
- **i18n**: `wiki.breadcrumbNav`, `wiki.breadcrumb.help`, `wiki.breadcrumb.wiki` in en and de.
- **Wiki.css**: Styles for breadcrumb list, separators (›), links, and current segment.
- **Tests**: Wiki layout test updated to assert breadcrumb nav, Help link, and Wiki current label.

## Verification
- Build and tests pass.
- Manual: `/guide/wiki` shows Help > Wiki; `/guide/wiki/getting-started` shows Help > Wiki > Getting started; links navigate correctly; locale switch updates labels.