### PR TITLE
docs(wiki): document wiki content location and how to add articles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,16 @@ wwe-2k-league/
 └── README.md
 ```
 
+## Help and Wiki
+
+- **Help** is the User Guide at `/guide` (`UserGuide.tsx`), linked from nav as "Help". It includes a link to the **Wiki**.
+- **Wiki** is at `/guide/wiki` (index) and `/guide/wiki/:slug` (article). Components: `Wiki.tsx` (layout), `WikiIndex.tsx`, `WikiArticle.tsx`, `WikiBreadcrumbs.tsx`.
+- **Wiki content** lives in the repo as static files; there is no admin UI for editing. All editing is done by changing files and redeploying.
+  - **Location**: `frontend/public/wiki/`
+  - **Index**: `frontend/public/wiki/index.json` — JSON array of `{ "slug": string, "titleKey": string, "file": string }`. The app fetches this to build the wiki index page.
+  - **Articles**: Markdown files in `frontend/public/wiki/*.md` (e.g. `getting-started.md`, `faqs.md`). Each article is loaded at runtime by slug via `fetch(\`/wiki/${slug}.md\`)`.
+- **To add a wiki article**: (1) Add a new `.md` file under `frontend/public/wiki/`. (2) Append an entry to `frontend/public/wiki/index.json` with `slug` (URL segment), `titleKey` (e.g. `wiki.articles.myTopic`), and `file` (e.g. `my-topic.md`). (3) Add the `titleKey` translation in `frontend/src/i18n/locales/en.json` and `frontend/src/i18n/locales/de.json` under `wiki.articles`.
+
 ## Data Model
 
 ### Players Table

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A serverless web application for managing a WWE 2K league with standings, champi
 | **Promos** | View wrestler promos with emoji reactions |
 | **Contender Rankings** | Automatic #1 contender tracking per championship based on recent performance |
 | **Challenges** | View open and completed match challenges between wrestlers |
-| **User Guide** | Built-in help documentation covering all features |
+| **User Guide & Wiki** | Built-in help at `/guide` and wiki articles at `/guide/wiki`. Wiki content lives in `frontend/public/wiki/` (markdown + `index.json`); see CLAUDE.md for how to add articles. |
 | **Internationalization** | Full English and German language support |
 
 ### Wrestler Features (Wrestler Auth Required)


### PR DESCRIPTION
## Summary

Documents where wiki content lives and how to add articles, as the follow-up from the plan for **#128** (Add site wiki and surface it in the Help section). Issue #128 is already closed; this completes the plan item: *"Document in README or CLAUDE.md where wiki content lives and how to add articles."*

## Changes

- **CLAUDE.md**: Added **Help and Wiki** section describing:
  - Help at `/guide`, wiki at `/guide/wiki` and `/guide/wiki/:slug`
  - Wiki content location: `frontend/public/wiki/`
  - Index format: `index.json` with `slug`, `titleKey`, `file`
  - Steps to add a new article (add `.md`, update `index.json`, add i18n keys)
- **README.md**: Updated User Guide row to mention the wiki and point to CLAUDE.md for adding articles.

## Testing

- No code or behavior changes; documentation only.