### PR TITLE
feat(wiki): add Previous/Next article navigation

### DIFF
--- a/frontend/src/components/Wiki.css
+++ b/frontend/src/components/Wiki.css
@@ -159,6 +159,43 @@
   text-decoration: underline;
 }
 
+.wiki-article-nav {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #333;
+}
+
+.wiki-article-nav-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.wiki-article-nav-prev,
+.wiki-article-nav-next {
+  color: #93c5fd;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.wiki-article-nav-prev:hover,
+.wiki-article-nav-next:hover {
+  text-decoration: underline;
+}
+
+.wiki-article-nav-prev:focus,
+.wiki-article-nav-next:focus {
+  outline: 2px solid #d4af37;
+  outline-offset: 2px;
+}
+
+.wiki-article-nav-placeholder {
+  flex: 1;
+  min-width: 0;
+}
+
 .wiki-loading,
 .wiki-error {
   color: #ccc;

--- a/frontend/src/components/WikiArticle.tsx
+++ b/frontend/src/components/WikiArticle.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { Components } from 'react-markdown';
 import './Wiki.css';
+
+interface WikiArticleEntry {
+  slug: string;
+  titleKey: string;
+  file: string;
+}
 
 const wikiMarkdownComponents: Components = {
   code({ className, children, ...props }) {
@@ -35,6 +41,7 @@ export default function WikiArticle() {
   const { slug } = useParams<{ slug: string }>();
   const { t } = useTranslation();
   const [content, setContent] = useState<string | null>(null);
+  const [articles, setArticles] = useState<WikiArticleEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,18 +53,25 @@ export default function WikiArticle() {
     }
     setLoading(true);
     setError(null);
-    fetch(`/wiki/${slug}.md`)
+    const articlesPromise = fetch('/wiki/index.json')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: WikiArticleEntry[]) => (Array.isArray(data) ? data : []))
+      .catch(() => []);
+    const contentPromise = fetch(`/wiki/${slug}.md`)
       .then((res) => {
         if (!res.ok) throw new Error('Article not found');
         return res.text();
-      })
-      .then((text) => {
+      });
+    Promise.all([articlesPromise, contentPromise])
+      .then(([articleList, text]) => {
+        setArticles(articleList);
         setContent(text);
         setError(null);
       })
       .catch((err: Error) => {
         setError(err.message);
         setContent(null);
+        setArticles([]);
       })
       .finally(() => setLoading(false));
   }, [slug]);
@@ -69,11 +83,43 @@ export default function WikiArticle() {
     return <p className="wiki-error">{t('common.error')}: {error ?? 'No content'}</p>;
   }
 
+  const currentIndex = articles.findIndex((a) => a.slug === slug);
+  const prevEntry = currentIndex > 0 ? articles[currentIndex - 1] : null;
+  const nextEntry = currentIndex >= 0 && currentIndex < articles.length - 1 ? articles[currentIndex + 1] : null;
+
   return (
     <article className="wiki-article">
       <div className="wiki-content">
         <ReactMarkdown components={wikiMarkdownComponents}>{content}</ReactMarkdown>
       </div>
+      {(prevEntry || nextEntry) ? (
+        <nav className="wiki-article-nav" aria-label={t('wiki.articleNavLabel')}>
+          <div className="wiki-article-nav-inner">
+            {prevEntry ? (
+              <Link
+                to={`/guide/wiki/${prevEntry.slug}`}
+                className="wiki-article-nav-prev"
+                aria-label={t('wiki.previousArticle', { title: t(prevEntry.titleKey) })}
+              >
+                {t('wiki.previousArticle', { title: t(prevEntry.titleKey) })}
+              </Link>
+            ) : (
+              <span className="wiki-article-nav-placeholder" aria-hidden="true" />
+            )}
+            {nextEntry ? (
+              <Link
+                to={`/guide/wiki/${nextEntry.slug}`}
+                className="wiki-article-nav-next"
+                aria-label={t('wiki.nextArticle', { title: t(nextEntry.titleKey) })}
+              >
+                {t('wiki.nextArticle', { title: t(nextEntry.titleKey) })}
+              </Link>
+            ) : (
+              <span className="wiki-article-nav-placeholder" aria-hidden="true" />
+            )}
+          </div>
+        </nav>
+      ) : null}
     </article>
   );
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -59,6 +59,9 @@
     "title": "Wiki",
     "indexTitle": "Wiki-Artikel",
     "backToGuide": "Zurück zur Anleitung",
+    "previousArticle": "Zurück: {{title}}",
+    "nextArticle": "Weiter: {{title}}",
+    "articleNavLabel": "Vorheriger und nächster Artikel",
     "breadcrumbNav": "Wiki-Breadcrumb-Navigation",
     "breadcrumb": {
       "help": "Hilfe",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -59,6 +59,9 @@
     "title": "Wiki",
     "indexTitle": "Wiki Articles",
     "backToGuide": "Back to guide",
+    "previousArticle": "Previous: {{title}}",
+    "nextArticle": "Next: {{title}}",
+    "articleNavLabel": "Previous and next article",
     "breadcrumbNav": "Wiki breadcrumb navigation",
     "breadcrumb": {
       "help": "Help",


### PR DESCRIPTION
## Summary

Adds **Previous** and **Next** article links at the bottom of each wiki article so users can move through the wiki in index order without returning to the index. Implements **#137**.

## Changes

- **WikiArticle.tsx**
  - Fetches `/wiki/index.json` together with article content to get ordered article list.
  - Computes previous (index - 1) and next (index + 1) entries from current slug.
  - Renders a `<nav>` below the article with "Previous: [title]" and "Next: [title]" links when applicable. First article shows only Next; last article shows only Previous.
  - Uses translated titles via `titleKey` and i18n; `aria-label` on links for accessibility.
- **Wiki.css**
  - `.wiki-article-nav`, `.wiki-article-nav-inner`, `.wiki-article-nav-prev`, `.wiki-article-nav-next`, placeholder for flex layout (prev left, next right).
- **i18n (en.json, de.json)**
  - `wiki.previousArticle`: "Previous: {{title}}" / "Zurück: {{title}}"
  - `wiki.nextArticle`: "Next: {{title}}" / "Weiter: {{title}}"
  - `wiki.articleNavLabel`: "Previous and next article" / "Vorheriger und nächster Artikel"

## Testing

- Wiki test suite passes (3 tests).
- Manual: open `/guide/wiki/getting-started` — see "Next: FAQs" at bottom; open `/guide/wiki/faqs` — see "Previous: Getting started". First/last articles show only one link.