### PR TITLE
feat(wiki): print-friendly styles and Print button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -93,3 +93,28 @@ tr:hover {
     padding: 0.5rem 0.375rem;
   }
 }
+
+/* Print: hide app chrome so wiki and other content print cleanly */
+@media print {
+  .sidebar,
+  .hamburger-btn,
+  .sidebar-overlay,
+  .top-bar,
+  .topnav,
+  .topnav-bar,
+  .topnav-overlay {
+    display: none !important;
+  }
+
+  .App {
+    background: #fff;
+  }
+
+  main {
+    margin-left: 0;
+    margin-right: 0;
+    padding: 0.5in;
+    padding-top: 0.5in;
+    max-width: none;
+  }
+}

--- a/frontend/src/components/Wiki.css
+++ b/frontend/src/components/Wiki.css
@@ -67,6 +67,33 @@
   outline-offset: 2px;
 }
 
+.wiki-layout-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.wiki-layout-header .wiki-back-link {
+  margin-bottom: 0;
+}
+
+.wiki-print-btn {
+  margin-left: auto;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  background: #333;
+  color: #d4af37;
+  border: 1px solid #555;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.wiki-print-btn:hover {
+  background: #444;
+}
+
 .wiki-index-title {
   color: #d4af37;
   font-size: 1.5rem;
@@ -204,4 +231,75 @@
 
 .wiki-error {
   color: #f87171;
+}
+
+/* Print-friendly wiki: minimal chrome, readable article content */
+@media print {
+  .wiki-breadcrumbs,
+  .wiki-layout-header,
+  .wiki-back-link,
+  .wiki-print-btn {
+    display: none !important;
+  }
+
+  .wiki-layout {
+    max-width: none;
+    margin: 0;
+  }
+
+  .wiki-index-title {
+    color: #000;
+    border-bottom-color: #333;
+  }
+
+  .wiki-index-list a {
+    color: #000;
+  }
+
+  .wiki-article {
+    background: #fff;
+    border: 1px solid #ccc;
+    box-shadow: none;
+  }
+
+  .wiki-article .wiki-content,
+  .wiki-article .wiki-content p,
+  .wiki-article .wiki-content li {
+    color: #000;
+  }
+
+  .wiki-article .wiki-content h1,
+  .wiki-article .wiki-content h2,
+  .wiki-article .wiki-content h3 {
+    color: #000;
+    border-bottom-color: #333;
+  }
+
+  .wiki-article .wiki-content a {
+    color: #00f;
+  }
+
+  .wiki-article .wiki-content strong {
+    color: #000;
+  }
+
+  .wiki-article .wiki-content pre,
+  .wiki-article .wiki-content code {
+    background: #f5f5f5;
+    color: #000;
+    border: 1px solid #ddd;
+  }
+
+  .wiki-article-nav {
+    border-top-color: #333;
+  }
+
+  .wiki-article-nav-prev,
+  .wiki-article-nav-next {
+    color: #00f;
+  }
+
+  .wiki-article .wiki-content pre {
+    break-inside: avoid;
+  }
 }

--- a/frontend/src/components/Wiki.tsx
+++ b/frontend/src/components/Wiki.tsx
@@ -8,9 +8,19 @@ export function WikiLayout() {
   return (
     <div className="wiki-layout">
       <WikiBreadcrumbs />
-      <Link to="/guide" className="wiki-back-link">
-        {t('wiki.backToGuide')}
-      </Link>
+      <div className="wiki-layout-header">
+        <Link to="/guide" className="wiki-back-link">
+          {t('wiki.backToGuide')}
+        </Link>
+        <button
+          type="button"
+          className="wiki-print-btn"
+          onClick={() => window.print()}
+          aria-label={t('common.print')}
+        >
+          {t('common.print')}
+        </button>
+      </div>
       <Outlet />
     </div>
   );

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -28,7 +28,8 @@
     "previous": "Zurück",
     "next": "Weiter",
     "submitting": "Wird eingereicht...",
-    "loading": "Wird geladen..."
+    "loading": "Wird geladen...",
+    "print": "Drucken"
   },
   "nav": {
     "standings": "Tabelle",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -28,7 +28,8 @@
     "previous": "Previous",
     "next": "Next",
     "submitting": "Submitting...",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "print": "Print"
   },
   "nav": {
     "standings": "Standings",


### PR DESCRIPTION
## Summary

Makes wiki pages **print-friendly** and adds a **Print** button for discoverability. Implements **#139**.

## Changes

### Print styles (no app chrome)
- **App.css** `@media print`: Hide sidebar, hamburger, top-bar, topnav and overlays so only main content prints. Main gets full width and 0.5in padding. App background set to white for print.
- **Wiki.css** `@media print`: Hide breadcrumbs, back link, and Print button. Wiki layout full width. Article content: white background, black text, readable contrast; links blue; code blocks light gray bg with `break-inside: avoid`. Prev/Next nav uses print-safe colors.

### Print button
- **WikiLayout**: Added a "Print" button that calls `window.print()`, placed next to "Back to guide" (flex layout, button on the right). Hidden when printing via `@media print`.
- **i18n**: `common.print` — "Print" (en), "Drucken" (de).

## Testing

- Wiki test suite passes.
- Manual: Open `/guide/wiki` or `/guide/wiki/faqs`, click Print or Ctrl+P / Cmd+P — only wiki content (and index list or article) should print, without sidebar/top bar. Article text and code blocks readable on paper.