### PR TITLE
feat(wiki): add sidebar with article list on article view

### DIFF
--- a/frontend/src/components/Wiki.css
+++ b/frontend/src/components/Wiki.css
@@ -94,6 +94,125 @@
   background: #444;
 }
 
+/* Sidebar on article view */
+.wiki-layout-with-sidebar {
+  max-width: none;
+}
+
+.wiki-layout-body {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.wiki-layout-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.wiki-sidebar-toggle {
+  display: none;
+  padding: 0.5rem 1rem;
+  font-size: 0.95rem;
+  background: #333;
+  color: #d4af37;
+  border: 1px solid #555;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.wiki-sidebar-toggle:hover {
+  background: #444;
+}
+
+.wiki-sidebar {
+  flex-shrink: 0;
+  width: 200px;
+  position: sticky;
+  top: 1rem;
+}
+
+.wiki-sidebar nav {
+  padding: 1rem;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 8px;
+}
+
+.wiki-sidebar-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.wiki-sidebar-list li {
+  margin-bottom: 0.5rem;
+}
+
+.wiki-sidebar-list a {
+  color: #93c5fd;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.wiki-sidebar-list a:hover {
+  text-decoration: underline;
+}
+
+.wiki-sidebar-list a.wiki-sidebar-current {
+  font-weight: 600;
+  color: #d4af37;
+}
+
+.wiki-sidebar-list a:focus {
+  outline: 2px solid #d4af37;
+  outline-offset: 2px;
+}
+
+.wiki-sidebar-overlay {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .wiki-sidebar-toggle {
+    display: inline-block;
+  }
+
+  .wiki-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 260px;
+    max-width: 85vw;
+    height: 100vh;
+    z-index: 100;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease-out;
+    background: #1a1a1a;
+    border: none;
+    border-radius: 0;
+  }
+
+  .wiki-sidebar.wiki-sidebar-open {
+    transform: translateX(0);
+  }
+
+  .wiki-sidebar nav {
+    border: none;
+    border-radius: 0;
+    padding-top: 2rem;
+  }
+
+  .wiki-sidebar-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 99;
+  }
+}
+
 .wiki-index-title {
   color: #d4af37;
   font-size: 1.5rem;
@@ -256,7 +375,9 @@
   .wiki-layout-header,
   .wiki-back-link,
   .wiki-print-btn,
-  .wiki-edit-link {
+  .wiki-edit-link,
+  .wiki-sidebar-toggle,
+  .wiki-sidebar {
     display: none !important;
   }
 

--- a/frontend/src/components/Wiki.tsx
+++ b/frontend/src/components/Wiki.tsx
@@ -1,12 +1,16 @@
-import { Link, Outlet } from 'react-router-dom';
+import { Link, Outlet, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import WikiBreadcrumbs from './WikiBreadcrumbs';
+import WikiSidebar from './WikiSidebar';
 import './Wiki.css';
 
 export function WikiLayout() {
   const { t } = useTranslation();
+  const { slug } = useParams<{ slug?: string }>();
+  const isArticleView = Boolean(slug);
+
   return (
-    <div className="wiki-layout">
+    <div className={`wiki-layout ${isArticleView ? 'wiki-layout-with-sidebar' : ''}`}>
       <WikiBreadcrumbs />
       <div className="wiki-layout-header">
         <Link to="/guide" className="wiki-back-link">
@@ -21,7 +25,16 @@ export function WikiLayout() {
           {t('common.print')}
         </button>
       </div>
-      <Outlet />
+      {isArticleView ? (
+        <div className="wiki-layout-body">
+          <WikiSidebar />
+          <div className="wiki-layout-main">
+            <Outlet />
+          </div>
+        </div>
+      ) : (
+        <Outlet />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/WikiSidebar.tsx
+++ b/frontend/src/components/WikiSidebar.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import './Wiki.css';
+
+interface WikiArticleEntry {
+  slug: string;
+  titleKey: string;
+  file: string;
+}
+
+export default function WikiSidebar() {
+  const { slug: currentSlug } = useParams<{ slug?: string }>();
+  const { t } = useTranslation();
+  const [articles, setArticles] = useState<WikiArticleEntry[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    fetch('/wiki/index.json')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: WikiArticleEntry[]) => setArticles(Array.isArray(data) ? data : []))
+      .catch(() => setArticles([]));
+  }, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="wiki-sidebar-toggle"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        aria-label={t('wiki.articlesLabel')}
+      >
+        {t('wiki.articlesLabel')}
+      </button>
+      <aside
+        className={`wiki-sidebar ${open ? 'wiki-sidebar-open' : ''}`}
+        aria-label={t('wiki.articlesLabel')}
+      >
+        <nav>
+          <ul className="wiki-sidebar-list">
+            {articles.map((entry) => (
+              <li key={entry.slug}>
+                <Link
+                  to={`/guide/wiki/${entry.slug}`}
+                  className={currentSlug === entry.slug ? 'wiki-sidebar-current' : ''}
+                  aria-current={currentSlug === entry.slug ? 'page' : undefined}
+                  onClick={() => setOpen(false)}
+                >
+                  {t(entry.titleKey)}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+      {open ? (
+        <div
+          className="wiki-sidebar-overlay"
+          role="button"
+          tabIndex={0}
+          aria-label={t('common.close')}
+          onClick={() => setOpen(false)}
+          onKeyDown={(e) => e.key === 'Escape' && setOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -64,6 +64,7 @@
     "nextArticle": "Weiter: {{title}}",
     "articleNavLabel": "Vorheriger und nächster Artikel",
     "editThisPage": "Seite bearbeiten",
+    "articlesLabel": "Artikel",
     "breadcrumbNav": "Wiki-Breadcrumb-Navigation",
     "breadcrumb": {
       "help": "Hilfe",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -64,6 +64,7 @@
     "nextArticle": "Next: {{title}}",
     "articleNavLabel": "Previous and next article",
     "editThisPage": "Edit this page",
+    "articlesLabel": "Articles",
     "breadcrumbNav": "Wiki breadcrumb navigation",
     "breadcrumb": {
       "help": "Help",


### PR DESCRIPTION
## Summary

Shows the **wiki article list in a sidebar** when viewing an article so users can jump to another article without going back to the index. Implements **#138**.

## Changes

- **WikiSidebar.tsx** (new): Fetches `/wiki/index.json`, renders nav list of links to each article. Current article is highlighted (`.wiki-sidebar-current`, `aria-current="page"`). On mobile, an "Articles" toggle button shows/hides the sidebar as a drawer; overlay and Escape close it.
- **Wiki.tsx**: Uses `useParams().slug` to detect article view. When on `/guide/wiki/:slug`, renders `.wiki-layout-body` with WikiSidebar + main content; index page stays full-width.
- **Wiki.css**: Two-column layout (sidebar 200px, sticky); mobile breakpoint (768px) turns sidebar into fixed drawer (260px, slide-in), toggle button visible, overlay for close.
- **i18n**: `wiki.articlesLabel` — "Articles" (en), "Artikel" (de).
- Sidebar and toggle hidden in `@media print`.

## Testing

- Wiki test suite passes.
- Manual: Open `/guide/wiki/getting-started` — sidebar with article list on the left; current article highlighted. Resize to mobile — "Articles" button toggles drawer. Index `/guide/wiki` unchanged (no sidebar).