### PR TITLE
feat(wiki): add in-article table of contents

### DIFF
--- a/frontend/src/components/Wiki.css
+++ b/frontend/src/components/Wiki.css
@@ -270,6 +270,80 @@
   outline-offset: 2px;
 }
 
+.wiki-toc {
+  margin-bottom: 1rem;
+}
+
+.wiki-toc-toggle {
+  display: none;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: left;
+  background: #252525;
+  color: #d4af37;
+  border: 1px solid #333;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.wiki-toc-toggle:hover {
+  background: #2a2a2a;
+}
+
+.wiki-toc-list-wrap {
+  padding: 0.75rem 1rem;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+}
+
+.wiki-toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.wiki-toc-list li {
+  margin-bottom: 0.35rem;
+}
+
+.wiki-toc-list li.wiki-toc-level-3 {
+  padding-left: 1rem;
+}
+
+.wiki-toc-list a {
+  color: #93c5fd;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.wiki-toc-list a:hover {
+  text-decoration: underline;
+}
+
+.wiki-toc-list a:focus {
+  outline: 2px solid #d4af37;
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .wiki-toc-toggle {
+    display: block;
+  }
+
+  .wiki-toc-list-wrap {
+    display: none;
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+  }
+
+  .wiki-toc-list-wrap.wiki-toc-open {
+    display: block;
+  }
+}
+
 .wiki-article .wiki-content {
   color: #ccc;
   line-height: 1.6;
@@ -377,7 +451,8 @@
   .wiki-print-btn,
   .wiki-edit-link,
   .wiki-sidebar-toggle,
-  .wiki-sidebar {
+  .wiki-sidebar,
+  .wiki-toc {
     display: none !important;
   }
 

--- a/frontend/src/components/WikiArticle.tsx
+++ b/frontend/src/components/WikiArticle.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -14,7 +14,45 @@ interface WikiArticleEntry {
   file: string;
 }
 
-const wikiMarkdownComponents: Components = {
+interface TocItem {
+  level: 2 | 3;
+  text: string;
+  id: string;
+}
+
+function slugify(text: string): string {
+  return String(text)
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+}
+
+function parseHeadings(markdown: string): TocItem[] {
+  const items: TocItem[] = [];
+  const idCount: Record<string, number> = {};
+  const lines = markdown.split('\n');
+  for (const line of lines) {
+    const h2 = /^##\s+(.+)$/.exec(line);
+    const h3 = /^###\s+(.+)$/.exec(line);
+    if (h2?.[1]) {
+      const text = h2[1].trim();
+      const baseId = slugify(text) || 'section';
+      idCount[baseId] = (idCount[baseId] ?? 0) + 1;
+      const id = idCount[baseId]! > 1 ? `${baseId}-${idCount[baseId]}` : baseId;
+      items.push({ level: 2, text, id });
+    } else if (h3?.[1]) {
+      const text = h3[1].trim();
+      const baseId = slugify(text) || 'section';
+      idCount[baseId] = (idCount[baseId] ?? 0) + 1;
+      const id = idCount[baseId]! > 1 ? `${baseId}-${idCount[baseId]}` : baseId;
+      items.push({ level: 3, text, id });
+    }
+  }
+  return items;
+}
+
+const baseMarkdownComponents: Components = {
   code({ className, children, ...props }) {
     const match = /language-(\w+)/.exec(className ?? '');
     if (match) {
@@ -46,6 +84,27 @@ export default function WikiArticle() {
   const [articles, setArticles] = useState<WikiArticleEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tocOpen, setTocOpen] = useState(false);
+  const headingIndexRef = useRef(0);
+  const tocItems = useMemo(() => (content ? parseHeadings(content) : []), [content]);
+  const showToc = tocItems.length >= 2;
+  if (content) headingIndexRef.current = 0;
+  const wikiMarkdownComponents = useMemo(
+    (): Components => ({
+      ...baseMarkdownComponents,
+      h2: ({ children }) => {
+        const id = tocItems[headingIndexRef.current]?.id ?? slugify(String(children));
+        headingIndexRef.current += 1;
+        return <h2 id={id}>{children}</h2>;
+      },
+      h3: ({ children }) => {
+        const id = tocItems[headingIndexRef.current]?.id ?? slugify(String(children));
+        headingIndexRef.current += 1;
+        return <h3 id={id}>{children}</h3>;
+      },
+    }),
+    [tocItems]
+  );
 
   useEffect(() => {
     if (!slug) {
@@ -108,6 +167,29 @@ export default function WikiArticle() {
         >
           {t('wiki.editThisPage')}
         </a>
+      ) : null}
+      {showToc ? (
+        <nav className="wiki-toc" aria-label={t('wiki.onThisPage')}>
+          <button
+            type="button"
+            className="wiki-toc-toggle"
+            onClick={() => setTocOpen((prev) => !prev)}
+            aria-expanded={tocOpen}
+          >
+            {t('wiki.onThisPage')}
+          </button>
+          <div className={`wiki-toc-list-wrap ${tocOpen ? 'wiki-toc-open' : ''}`}>
+            <ul className="wiki-toc-list">
+              {tocItems.map((item) => (
+                <li key={item.id} className={`wiki-toc-level-${item.level}`}>
+                  <a href={`#${item.id}`} onClick={() => setTocOpen(false)}>
+                    {item.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </nav>
       ) : null}
       <div className="wiki-content">
         <ReactMarkdown components={wikiMarkdownComponents}>{content}</ReactMarkdown>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -65,6 +65,7 @@
     "articleNavLabel": "Vorheriger und nächster Artikel",
     "editThisPage": "Seite bearbeiten",
     "articlesLabel": "Artikel",
+    "onThisPage": "Auf dieser Seite",
     "breadcrumbNav": "Wiki-Breadcrumb-Navigation",
     "breadcrumb": {
       "help": "Hilfe",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -65,6 +65,7 @@
     "articleNavLabel": "Previous and next article",
     "editThisPage": "Edit this page",
     "articlesLabel": "Articles",
+    "onThisPage": "On this page",
     "breadcrumbNav": "Wiki breadcrumb navigation",
     "breadcrumb": {
       "help": "Help",


### PR DESCRIPTION
## Summary

Adds an **in-article table of contents (TOC)** for wiki articles so long pages show a list of H2/H3 headings that users can click to jump to sections. Implements **#134**.

## Changes

- **WikiArticle.tsx**
  - `parseHeadings(markdown)`: parses `##` and `###` lines, returns `{ level, text, id }[]` with slugified ids (duplicates get `-2`, `-3`).
  - Custom `h2`/`h3` in ReactMarkdown assign `id` from the parsed list so headings are linkable.
  - TOC shown only when `tocItems.length >= 2`.
  - "On this page" nav: list of links to `#id`; on mobile a toggle button expands/collapses the list; clicking a link closes the list.
- **Wiki.css**
  - `.wiki-toc`, `.wiki-toc-toggle`, `.wiki-toc-list-wrap`, `.wiki-toc-list`; mobile breakpoint: toggle visible, list hidden until `.wiki-toc-open`.
  - TOC hidden in print.
- **i18n**: `wiki.onThisPage` — "On this page" (en), "Auf dieser Seite" (de).

## Testing

- Wiki test suite passes; `npx tsc --noEmit` passes.
- Manual: Open an article with multiple headings (e.g. FAQs) — TOC appears above content; links scroll to headings; on narrow viewport "On this page" toggles the list.