### PR TITLE
feat(wiki): add client-side search on index page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "amazon-cognito-identity-js": "^6.3.7",
         "aws-amplify": "^6.16.0",
+        "fuse.js": "^7.1.0",
         "i18next": "^25.8.1",
         "i18next-browser-languagedetector": "^8.2.0",
         "react": "^18.2.0",
@@ -9103,6 +9104,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "amazon-cognito-identity-js": "^6.3.7",
     "aws-amplify": "^6.16.0",
+    "fuse.js": "^7.1.0",
     "i18next": "^25.8.1",
     "i18next-browser-languagedetector": "^8.2.0",
     "react": "^18.2.0",

--- a/frontend/src/components/Wiki.css
+++ b/frontend/src/components/Wiki.css
@@ -221,6 +221,36 @@
   border-bottom: 1px solid #333;
 }
 
+.wiki-search-label {
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.wiki-search-input {
+  width: 100%;
+  max-width: 320px;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.wiki-search-no-results {
+  color: #888;
+  font-style: italic;
+  margin: 0.5rem 0;
+}
+
 .wiki-index-list {
   list-style: none;
   padding: 0;

--- a/frontend/src/components/WikiIndex.tsx
+++ b/frontend/src/components/WikiIndex.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import Fuse from 'fuse.js';
 import './Wiki.css';
 
 interface WikiArticleEntry {
@@ -9,11 +10,16 @@ interface WikiArticleEntry {
   file: string;
 }
 
+interface SearchableEntry extends WikiArticleEntry {
+  title: string;
+}
+
 export default function WikiIndex() {
   const { t } = useTranslation();
   const [articles, setArticles] = useState<WikiArticleEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     fetch('/wiki/index.json')
@@ -32,6 +38,27 @@ export default function WikiIndex() {
       .finally(() => setLoading(false));
   }, []);
 
+  const searchableList = useMemo<SearchableEntry[]>(
+    () => articles.map((a) => ({ ...a, title: t(a.titleKey) })),
+    [articles, t]
+  );
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(searchableList, {
+        keys: ['title'],
+        threshold: 0.3,
+      }),
+    [searchableList]
+  );
+
+  const filteredArticles = useMemo(() => {
+    const q = query.trim();
+    if (!q) return articles;
+    const results = fuse.search(q);
+    return results.map((r) => r.item);
+  }, [query, articles, fuse]);
+
   if (loading) {
     return <p className="wiki-loading">{t('common.loading')}</p>;
   }
@@ -42,13 +69,32 @@ export default function WikiIndex() {
   return (
     <>
       <h2 className="wiki-index-title">{t('wiki.indexTitle')}</h2>
-      <ul className="wiki-index-list">
-        {articles.map((entry) => (
-          <li key={entry.slug}>
-            <Link to={`/guide/wiki/${entry.slug}`}>{t(entry.titleKey)}</Link>
-          </li>
-        ))}
-      </ul>
+      <label htmlFor="wiki-search" className="wiki-search-label">
+        <span className="visually-hidden">{t('wiki.searchPlaceholder')}</span>
+        <input
+          id="wiki-search"
+          type="search"
+          className="wiki-search-input"
+          placeholder={t('wiki.searchPlaceholder')}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label={t('wiki.searchPlaceholder')}
+          autoComplete="off"
+        />
+      </label>
+      {filteredArticles.length > 0 ? (
+        <ul className="wiki-index-list">
+          {filteredArticles.map((entry) => (
+            <li key={entry.slug}>
+              <Link to={`/guide/wiki/${entry.slug}`}>{t(entry.titleKey)}</Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="wiki-search-no-results" role="status">
+          {t('wiki.noResults')}
+        </p>
+      )}
     </>
   );
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -66,6 +66,8 @@
     "editThisPage": "Seite bearbeiten",
     "articlesLabel": "Artikel",
     "onThisPage": "Auf dieser Seite",
+    "searchPlaceholder": "Wiki durchsuchen",
+    "noResults": "Keine Ergebnisse",
     "breadcrumbNav": "Wiki-Breadcrumb-Navigation",
     "breadcrumb": {
       "help": "Hilfe",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -66,6 +66,8 @@
     "editThisPage": "Edit this page",
     "articlesLabel": "Articles",
     "onThisPage": "On this page",
+    "searchPlaceholder": "Search wiki",
+    "noResults": "No results",
     "breadcrumbNav": "Wiki breadcrumb navigation",
     "breadcrumb": {
       "help": "Help",


### PR DESCRIPTION
## Summary

Adds **client-side search** to the wiki index so users can find articles by title without leaving the wiki. Implements **#133**.

## Changes

- **fuse.js** added as dependency for fuzzy search on article titles.
- **WikiIndex.tsx**
  - Search input above the article list; state `query` drives filtering.
  - Build a searchable list with translated titles (`t(titleKey)`); Fuse searches the `title` field with threshold 0.3.
  - Empty/clear search shows full list; when no matches, show "No results" (role=status).
  - Accessible: label, aria-label on input, visually-hidden label for screen readers.
- **Wiki.css**: `.wiki-search-label`, `.wiki-search-input`, `.visually-hidden`, `.wiki-search-no-results`.
- **i18n**: `wiki.searchPlaceholder` ("Search wiki" / "Wiki durchsuchen"), `wiki.noResults` ("No results" / "Keine Ergebnisse").

## Testing

- Wiki test suite passes; `npx tsc --noEmit` passes.
- Manual: Open `/guide/wiki`, type in search — list filters by title; clear input to see full list again; non-matching query shows no results message.