### PR TITLE
docs: update divisions wiki to use correct division types

### DIFF
--- a/frontend/public/wiki/de/divisions.md
+++ b/frontend/public/wiki/de/divisions.md
@@ -1,10 +1,10 @@
 # Divisionen
 
-Spieler können in Divisionen organisiert werden, ähnlich den Markenaufteilungen bei WWE.
+Spieler können in Divisionen organisiert werden, basierend auf Gewichtsklasse, Kartenposition oder Rolle.
 
 ## Was sind Divisionen?
 
-Divisionen sind Gruppen, denen Spieler zugeordnet werden können, z. B. „Raw“, „SmackDown“ oder „NXT“. Das hilft bei der Organisation des Kaders und kann für markenspezifische Wettbewerbe genutzt werden.
+Divisionen sind Gruppen, denen Spieler zugeordnet werden können, z. B. „Heavyweight", „Cruiserweight", „Main Event", „Mid Card" oder „Jobber". Das hilft bei der Organisation des Kaders und kann für divisionsspezifische Wettbewerbe und Titelkämpfe genutzt werden, wenn Divisionsbeschränkungen aktiviert sind.
 
 ## Spieler-Divisionen anzeigen
 

--- a/frontend/public/wiki/divisions.md
+++ b/frontend/public/wiki/divisions.md
@@ -1,10 +1,10 @@
 # Divisions
 
-Players may be organized into divisions, similar to WWE's brand splits.
+Players may be organized into divisions based on weight class, card position, or role.
 
 ## What Are Divisions?
 
-Divisions are groups that players can be assigned to, such as "Raw", "SmackDown", or "NXT". This helps organize the roster and can be used for brand-specific competitions.
+Divisions are groups that players can be assigned to, such as "Heavyweight", "Cruiserweight", "Main Event", "Mid Card", or "Jobber". This helps organize the roster and can be used for division-specific competitions and championship eligibility when division restrictions are enabled.
 
 ## Viewing Player Divisions
 


### PR DESCRIPTION
## Summary

Updates the Divisions wiki entry to use the correct division types used in the app instead of WWE brand names.

## Changes

- **`frontend/public/wiki/divisions.md`** — Replaced references to "Raw", "SmackDown", "NXT" with actual division types: Heavyweight, Cruiserweight, Main Event, Mid Card, Jobber
- **`frontend/public/wiki/de/divisions.md`** — Same updates applied to the German translation

## Before
> Divisions are groups that players can be assigned to, such as "Raw", "SmackDown", or "NXT". This helps organize the roster and can be used for brand-specific competitions.

## After
> Divisions are groups that players can be assigned to, such as "Heavyweight", "Cruiserweight", "Main Event", "Mid Card", or "Jobber". This helps organize the roster and can be used for division-specific competitions and championship eligibility when division restrictions are enabled.