### PR TITLE
Implements #166 — Rivalry Tracker

### DIFF
--- a/backend/functions/rivalries/getRivalries.ts
+++ b/backend/functions/rivalries/getRivalries.ts
@@ -1,0 +1,150 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, serverError } from '../../lib/response';
+
+const MIN_MATCHES_FOR_RIVALRY = 3;
+const MAX_RIVALRIES_RETURNED = 20;
+
+interface MatchRecord {
+  matchId: string;
+  date: string;
+  participants: string[];
+  winners?: string[];
+  losers?: string[];
+  isChampionship?: boolean;
+  status: string;
+  seasonId?: string;
+}
+
+interface PlayerRecord {
+  playerId: string;
+  name: string;
+  currentWrestler: string;
+  imageUrl?: string;
+}
+
+interface RivalryAgg {
+  player1Id: string;
+  player2Id: string;
+  player1Wins: number;
+  player2Wins: number;
+  draws: number;
+  matchCount: number;
+  lastMatchDate: string;
+  championshipMatches: number;
+  recentMatchIds: string[];
+}
+
+function pairKey(id1: string, id2: string): string {
+  return [id1, id2].sort().join('|');
+}
+
+function intensityBadge(matchCount: number): 'heatingUp' | 'intense' | 'historic' {
+  if (matchCount >= 8) return 'historic';
+  if (matchCount >= 5) return 'intense';
+  return 'heatingUp';
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const seasonId = event.queryStringParameters?.seasonId;
+
+    const [playersResult, matchesResult] = await Promise.all([
+      dynamoDb.scanAll({ TableName: TableNames.PLAYERS }),
+      dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
+    ]);
+
+    const players = playersResult as unknown as PlayerRecord[];
+    const allMatches = matchesResult as unknown as MatchRecord[];
+    let completed = allMatches.filter((m) => m.status === 'completed');
+    if (seasonId) {
+      completed = completed.filter((m) => m.seasonId === seasonId);
+    }
+
+    const playerMap = new Map(players.map((p) => [p.playerId, p]));
+
+    const aggMap = new Map<string, RivalryAgg>();
+
+    for (const match of completed) {
+      const participants = match.participants || [];
+      if (participants.length !== 2) continue;
+      const [a, b] = participants;
+      const key = pairKey(a, b);
+      const existing = aggMap.get(key);
+      const p1Won = match.winners?.includes(a);
+      const p2Won = match.winners?.includes(b);
+      const isDraw = !p1Won && !p2Won;
+
+      if (!existing) {
+        aggMap.set(key, {
+          player1Id: a,
+          player2Id: b,
+          player1Wins: p1Won ? 1 : 0,
+          player2Wins: p2Won ? 1 : 0,
+          draws: isDraw ? 1 : 0,
+          matchCount: 1,
+          lastMatchDate: match.date,
+          championshipMatches: match.isChampionship ? 1 : 0,
+          recentMatchIds: [match.matchId],
+        });
+      } else {
+        existing.player1Wins += p1Won ? 1 : 0;
+        existing.player2Wins += p2Won ? 1 : 0;
+        existing.draws += isDraw ? 1 : 0;
+        existing.matchCount += 1;
+        if (new Date(match.date) > new Date(existing.lastMatchDate)) {
+          existing.lastMatchDate = match.date;
+        }
+        if (match.isChampionship) existing.championshipMatches += 1;
+        existing.recentMatchIds.push(match.matchId);
+      }
+    }
+
+    let rivalries = Array.from(aggMap.values())
+      .filter((r) => r.matchCount >= MIN_MATCHES_FOR_RIVALRY)
+      .map((r) => {
+        const sorted = [...r.recentMatchIds].sort(
+          (id1, id2) => {
+            const m1 = completed.find((m) => m.matchId === id1);
+            const m2 = completed.find((m) => m.matchId === id2);
+            const d1 = m1 ? new Date(m1.date).getTime() : 0;
+            const d2 = m2 ? new Date(m2.date).getTime() : 0;
+            return d2 - d1;
+          }
+        );
+        return {
+          ...r,
+          recentMatchIds: sorted.slice(0, 5),
+        };
+      })
+      .sort((a, b) => {
+        const scoreA = a.matchCount * 2 + (a.championshipMatches > 0 ? 3 : 0) + new Date(a.lastMatchDate).getTime() / 1e12;
+        const scoreB = b.matchCount * 2 + (b.championshipMatches > 0 ? 3 : 0) + new Date(b.lastMatchDate).getTime() / 1e12;
+        return scoreB - scoreA;
+      })
+      .slice(0, MAX_RIVALRIES_RETURNED)
+      .map((r) => {
+        const p1 = playerMap.get(r.player1Id);
+        const p2 = playerMap.get(r.player2Id);
+        return {
+          player1Id: r.player1Id,
+          player2Id: r.player2Id,
+          player1: p1 ? { playerId: p1.playerId, name: p1.name, wrestlerName: p1.currentWrestler, imageUrl: p1.imageUrl } : undefined,
+          player2: p2 ? { playerId: p2.playerId, name: p2.name, wrestlerName: p2.currentWrestler, imageUrl: p2.imageUrl } : undefined,
+          player1Wins: r.player1Wins,
+          player2Wins: r.player2Wins,
+          draws: r.draws,
+          matchCount: r.matchCount,
+          lastMatchDate: r.lastMatchDate,
+          championshipMatches: r.championshipMatches,
+          recentMatchIds: r.recentMatchIds,
+          intensityBadge: intensityBadge(r.matchCount),
+        };
+      });
+
+    return success({ rivalries });
+  } catch (err) {
+    console.error('Error computing rivalries:', err);
+    return serverError('Failed to load rivalries');
+  }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -510,6 +510,15 @@ functions:
           method: get
           cors: *corsConfig
 
+  getRivalries:
+    handler: functions/rivalries/getRivalries.handler
+    timeout: 15
+    events:
+      - http:
+          path: rivalries
+          method: get
+          cors: *corsConfig
+
   # Fantasy (Phase 3 consolidated: all 12 fantasy handlers)
   fantasy:
     handler: functions/fantasy/handler.handler

--- a/docs/plans/plan-issue-166-rivalry-tracker.md
+++ b/docs/plans/plan-issue-166-rivalry-tracker.md
@@ -1,0 +1,82 @@
+# Plan: Rivalry Tracker
+
+**GitHub issue:** [#166](https://github.com/jpDxsolo/league_szn/issues/166) — feat: Rivalry Tracker
+
+## Context
+
+Wrestling is built on rivalries, but the app has no way to surface them. Head-to-head exists in Statistics but users must pick two players. This feature automatically detects and displays active rivalries from match history: repeated pairings, series records, and intensity (match count, recency, championship involvement, challenges). A "Rivalries" section shows rivalry cards with both players, series record, recent matches, and intensity badges (Heating Up / Intense / Historic).
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review new endpoint and Rivalries UI |
+| Before commit | git-commit-helper | Conventional commit message |
+| If API changed | api-documenter | Update OpenAPI for GET /rivalries |
+| New components | test-generator | Tests for rivalries API and Rivalries.tsx |
+
+## Agents and parallel work
+
+- **Suggested order**: Step 1 (backend GET /rivalries) → Step 2 (frontend API + Rivalries page + route) → Step 3 (i18n + nav).
+- **Agent types**: Step 1 `general-purpose` (backend); Step 2 `general-purpose` (frontend); Step 3 `general-purpose` with i18n focus.
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `backend/serverless.yml` | Modify | Add GET /rivalries event and rivalries function |
+| New: `backend/functions/rivalries/getRivalries.ts` | Create | Lambda: scan Matches/Players/Championships/Challenges, compute pairings, intensity, return list |
+| `frontend/src/services/api/rivalries.api.ts` (or add to existing) | Create/Modify | getRivalries() calling GET /rivalries |
+| New: `frontend/src/components/statistics/Rivalries.tsx` | Create | Rivalry cards: both players, series record, recent matches, intensity badge |
+| New: `frontend/src/components/statistics/Rivalries.css` | Create | Styles for rivalry cards |
+| `frontend/src/App.tsx` | Modify | Add route /stats/rivalries → Rivalries (feature statistics) |
+| `frontend/src/config/navConfig.ts` | Modify | Add rivalries under stats if needed (or link from stats index) |
+| `frontend/src/i18n/locales/en.json` | Modify | rivalry.* keys (title, intensity badges, series format) |
+| `frontend/src/i18n/locales/de.json` | Modify | Same keys, German |
+| `backend/docs/openapi.yaml` | Modify | Document GET /rivalries (or run api-documenter after) |
+
+## Implementation steps
+
+### Step 1: Backend GET /rivalries
+
+- Add a new Lambda `rivalries` in `backend/functions/rivalries/getRivalries.ts`.
+- In serverless.yml: new function `rivalries` with handler `functions/rivalries/getRivalries.handler`, HTTP GET `rivalries` (public, no auth).
+- Handler logic:
+  - Scan Matches (completed only), Players, optionally Championships and Challenges (read-only).
+  - Build pairings: for each completed match with exactly two participants (or two “sides”), normalize pair key (e.g. sorted playerIds) and aggregate: match count, wins per player, last match date, championship flag.
+  - Filter to rivalries meeting a threshold (e.g. ≥3 matches in current season or all-time; configurable).
+  - Score “intensity”: match count, recency, championship involvement, active challenges. Assign badge: Heating Up (e.g. 3–4 matches), Intense (5–7), Historic (8+).
+  - Return sorted list: `{ rivalries: [{ player1Id, player2Id, player1Wins, player2Wins, matchCount, lastMatchDate, intensityBadge, recentMatchIds?, championshipAtStake? }] }`. Include player summary (name, imageUrl) from Players for each side.
+- Use existing `dynamoDb`, `TableNames`, `success`/`badRequest`/`serverError` from backend libs.
+
+### Step 2: Frontend API and Rivalries page
+
+- Add `frontend/src/services/api/rivalries.api.ts`: `getRivalries(seasonId?: string)` → GET `/rivalries` with optional `seasonId` query. Export from `services/api/index.ts`.
+- Create `Rivalries.tsx`: fetch rivalries on mount; display a list of rivalry cards. Each card: both players (image + name), series record (e.g. “Player A leads 3–2”), recent matches (links or list), intensity badge (Heating Up 🔥 / Intense 💥 / Historic 👑). Optional: expandable section for full match history.
+- Add route in App.tsx: `/stats/rivalries` → `<FeatureRoute feature="statistics"><Rivalries /></FeatureRoute>`.
+- Add Rivalries.css for card layout and badges. Follow existing statistics page patterns (PlayerStats, HeadToHeadComparison).
+
+### Step 3: i18n and nav
+
+- Add i18n keys: `rivalries.title`, `rivalries.seriesRecord`, `rivalries.leads`, `rivalries.recentMatches`, `rivalries.intensity.heatingUp`, `rivalries.intensity.intense`, `rivalries.intensity.historic`, `rivalries.noRivalries`. Add to en.json and de.json.
+- Ensure Statistics nav (e.g. in PlayerStats or shared stats nav) includes a link to `/stats/rivalries` (e.g. “Rivalries”). Update navConfig or stats subnav if the project uses a stats menu.
+
+## Dependencies and order
+
+- Step 1 must be done first (API contract and data shape).
+- Step 2 depends on Step 1 (frontend calls GET /rivalries).
+- Step 3 can be done after or in parallel with Step 2; i18n keys are needed for Rivalries.tsx labels.
+
+**Suggested order**: Step 1 → Step 2 → Step 3.
+
+## Testing and verification
+
+- **Manual**: Call GET /rivalries (with and without seasonId); confirm list and intensity. Open /stats/rivalries; confirm cards and series text; switch locale.
+- **Existing tests**: No regression on other stats routes.
+- **New tests**: Consider unit test for getRivalries aggregation logic; frontend test for Rivalries rendering with mock rivalries (test-generator skill).
+
+## Risks and edge cases
+
+- **Pairing key**: Matches with >2 participants (tag teams): define “rivalry” as between two sides (e.g. team A vs team B) or only singles; document in handler.
+- **Performance**: Scan Matches/Players can be heavy; optional seasonId filter and limit (e.g. top 20) recommended.
+- **Empty state**: When no rivalries meet threshold, return empty array; frontend shows “No rivalries yet” (i18n).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import PlayerStats from './components/statistics/PlayerStats';
 import HeadToHeadComparison from './components/statistics/HeadToHeadComparison';
 import Leaderboards from './components/statistics/Leaderboards';
 import RecordBook from './components/statistics/RecordBook';
+import Rivalries from './components/statistics/Rivalries';
 import TaleOfTheTape from './components/statistics/TaleOfTheTape';
 import Achievements from './components/statistics/Achievements';
 // Contender components
@@ -168,6 +169,9 @@ function AppLayout() {
             } />
             <Route path="/stats/records" element={
               <FeatureRoute feature="statistics"><RecordBook /></FeatureRoute>
+            } />
+            <Route path="/stats/rivalries" element={
+              <FeatureRoute feature="statistics"><Rivalries /></FeatureRoute>
             } />
             <Route path="/stats/tale-of-tape" element={
               <FeatureRoute feature="statistics"><TaleOfTheTape /></FeatureRoute>

--- a/frontend/src/components/statistics/PlayerStats.tsx
+++ b/frontend/src/components/statistics/PlayerStats.tsx
@@ -78,6 +78,7 @@ function PlayerStats() {
         <div className="ps-nav-links">
           <Link to="/stats/head-to-head">{t('statistics.nav.headToHead')}</Link>
           <Link to="/stats/leaderboards">{t('statistics.nav.leaderboards')}</Link>
+          <Link to="/stats/rivalries">{t('statistics.nav.rivalries')}</Link>
           <Link to="/stats/tale-of-tape">{t('statistics.nav.taleOfTape')}</Link>
           <Link to="/stats/records">{t('statistics.nav.records')}</Link>
           <Link to="/stats/achievements">{t('statistics.nav.achievements')}</Link>

--- a/frontend/src/components/statistics/Rivalries.css
+++ b/frontend/src/components/statistics/Rivalries.css
@@ -1,0 +1,144 @@
+.rivalries {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.rivalries-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.rivalries-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.rivalries-nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.rivalries-nav-links a {
+  color: var(--link-color, #0066cc);
+  text-decoration: none;
+}
+
+.rivalries-nav-links a:hover {
+  text-decoration: underline;
+}
+
+.rivalries-error,
+.rivalries-empty {
+  color: var(--text-muted, #666);
+  margin-top: 1rem;
+}
+
+.rivalries-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.rivalry-card {
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--card-bg, #fff);
+}
+
+.rivalry-card-players {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.rivalry-player {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+}
+
+.rivalry-player-img,
+.rivalry-player-placeholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.rivalry-player-placeholder {
+  background: var(--bg-muted, #eee);
+}
+
+.rivalry-player-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-top: 0.25rem;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100px;
+}
+
+.rivalry-vs {
+  font-size: 0.75rem;
+  color: var(--text-muted, #666);
+  font-weight: 600;
+}
+
+.rivalry-series {
+  font-size: 0.95rem;
+  margin: 0 0 0.5rem;
+  font-weight: 500;
+}
+
+.rivalry-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted, #666);
+  margin: 0 0 0.5rem;
+}
+
+.rivalry-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.rivalry-badge-heatingUp {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.rivalry-badge-intense {
+  background: #fce4ec;
+  color: #c2185b;
+}
+
+.rivalry-badge-historic {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.rivalry-link {
+  display: inline-block;
+  font-size: 0.85rem;
+  color: var(--link-color, #0066cc);
+  text-decoration: none;
+  margin-top: 0.25rem;
+}
+
+.rivalry-link:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/components/statistics/Rivalries.tsx
+++ b/frontend/src/components/statistics/Rivalries.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { rivalriesApi, seasonsApi } from '../../services/api';
+import type { Rivalry } from '../../services/api/rivalries.api';
+import type { Season } from '../../types';
+import SeasonSelector from './SeasonSelector';
+import './Rivalries.css';
+
+function Rivalries() {
+  const { t } = useTranslation();
+  const [rivalries, setRivalries] = useState<Rivalry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [selectedSeasonId, setSelectedSeasonId] = useState('');
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    seasonsApi.getAll(abortController.signal)
+      .then(setSeasons)
+      .catch(() => {});
+    return () => abortController.abort();
+  }, []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const fetchRivalries = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await rivalriesApi.getRivalries(
+          selectedSeasonId || undefined,
+          abortController.signal
+        );
+        setRivalries(result.rivalries);
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          setError(err.message);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRivalries();
+    return () => abortController.abort();
+  }, [selectedSeasonId]);
+
+  function seriesRecordText(r: Rivalry): string {
+    const p1W = r.player1Wins;
+    const p2W = r.player2Wins;
+    const d = r.draws;
+    const p1 = r.player1?.wrestlerName ?? r.player1Id;
+    const p2 = r.player2?.wrestlerName ?? r.player2Id;
+    if (p1W > p2W) return t('rivalries.leads', { name: p1, wins: p1W, losses: p2W });
+    if (p2W > p1W) return t('rivalries.leads', { name: p2, wins: p2W, losses: p1W });
+    return t('rivalries.tied', { count: p1W });
+  }
+
+  function intensityLabel(badge: 'heatingUp' | 'intense' | 'historic'): string {
+    switch (badge) {
+      case 'heatingUp': return t('rivalries.intensity.heatingUp');
+      case 'intense': return t('rivalries.intensity.intense');
+      case 'historic': return t('rivalries.intensity.historic');
+      default: return '';
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="rivalries">
+        <h2>{t('rivalries.title')}</h2>
+        <p>{t('common.loading', 'Loading...')}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rivalries">
+        <h2>{t('rivalries.title')}</h2>
+        <p className="rivalries-error">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rivalries">
+      <div className="rivalries-header">
+        <h2>{t('rivalries.title')}</h2>
+        <div className="rivalries-nav-links">
+          <Link to="/stats">{t('statistics.nav.playerStats')}</Link>
+          <Link to="/stats/head-to-head">{t('statistics.nav.headToHead')}</Link>
+          <Link to="/stats/leaderboards">{t('statistics.nav.leaderboards')}</Link>
+          <Link to="/stats/tale-of-tape">{t('statistics.nav.taleOfTape')}</Link>
+          <Link to="/stats/records">{t('statistics.nav.records')}</Link>
+          <Link to="/stats/achievements">{t('statistics.nav.achievements')}</Link>
+        </div>
+      </div>
+
+      <SeasonSelector
+        seasons={seasons}
+        selectedSeasonId={selectedSeasonId}
+        onSeasonChange={setSelectedSeasonId}
+      />
+
+      {rivalries.length === 0 ? (
+        <p className="rivalries-empty">{t('rivalries.noRivalries')}</p>
+      ) : (
+        <div className="rivalries-grid">
+          {rivalries.map((r) => (
+            <div key={`${r.player1Id}-${r.player2Id}`} className="rivalry-card">
+              <div className="rivalry-card-players">
+                <div className="rivalry-player">
+                  {r.player1?.imageUrl ? (
+                    <img src={r.player1.imageUrl} alt="" className="rivalry-player-img" />
+                  ) : (
+                    <div className="rivalry-player-placeholder" />
+                  )}
+                  <span className="rivalry-player-name">{r.player1?.wrestlerName ?? r.player1Id}</span>
+                </div>
+                <span className="rivalry-vs">vs</span>
+                <div className="rivalry-player">
+                  {r.player2?.imageUrl ? (
+                    <img src={r.player2.imageUrl} alt="" className="rivalry-player-img" />
+                  ) : (
+                    <div className="rivalry-player-placeholder" />
+                  )}
+                  <span className="rivalry-player-name">{r.player2?.wrestlerName ?? r.player2Id}</span>
+                </div>
+              </div>
+              <p className="rivalry-series">{seriesRecordText(r)}</p>
+              <p className="rivalry-meta">
+                {t('rivalries.recentMatches')}: {r.matchCount}
+                {r.championshipMatches > 0 && ` · ${t('rivalries.championshipAtStake')}`}
+              </p>
+              <span className={`rivalry-badge rivalry-badge-${r.intensityBadge}`}>
+                {intensityLabel(r.intensityBadge)}
+              </span>
+              <Link
+                to={`/stats/head-to-head?player1Id=${r.player1Id}&player2Id=${r.player2Id}`}
+                className="rivalry-link"
+              >
+                {t('rivalries.viewHeadToHead')}
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Rivalries;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -365,6 +365,7 @@
       "headToHead": "Direktvergleich",
       "leaderboards": "Ranglisten",
       "records": "Rekordbuch",
+      "rivalries": "Rivalitäten",
       "taleOfTape": "Tale of the Tape",
       "achievements": "Erfolge"
     },
@@ -475,6 +476,20 @@
         "special": "Spezial"
       }
     }
+  },
+  "rivalries": {
+    "title": "Rivalitäten",
+    "leads": "{{name}} führt {{wins}}-{{losses}}",
+    "tied": "Unentschieden {{count}}-{{count}}",
+    "recentMatches": "Kämpfe",
+    "championshipAtStake": "Titel auf dem Spiel",
+    "intensity": {
+      "heatingUp": "Heiß gelaufen 🔥",
+      "intense": "Intensiv 💥",
+      "historic": "Historisch 👑"
+    },
+    "noRivalries": "Noch keine Rivalitäten. Rivalitäten erscheinen, wenn zwei Spieler mindestens 3 Mal gegeneinander angetreten sind.",
+    "viewHeadToHead": "Direktvergleich anzeigen"
   },
   "events": {
     "title": "Veranstaltungen & PPV",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -365,6 +365,7 @@
       "headToHead": "Head-to-Head",
       "leaderboards": "Leaderboards",
       "records": "Record Book",
+      "rivalries": "Rivalries",
       "taleOfTape": "Tale of the Tape",
       "achievements": "Achievements"
     },
@@ -475,6 +476,20 @@
         "special": "Special"
       }
     }
+  },
+  "rivalries": {
+    "title": "Rivalries",
+    "leads": "{{name}} leads {{wins}}-{{losses}}",
+    "tied": "Tied {{count}}-{{count}}",
+    "recentMatches": "Matches",
+    "championshipAtStake": "Championship at stake",
+    "intensity": {
+      "heatingUp": "Heating Up 🔥",
+      "intense": "Intense 💥",
+      "historic": "Historic 👑"
+    },
+    "noRivalries": "No rivalries yet. Rivalries appear when two players have faced each other 3+ times.",
+    "viewHeadToHead": "View Head-to-Head"
   },
   "events": {
     "title": "Events & PPV",

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -20,6 +20,7 @@ export { siteConfigApi } from './siteConfig.api';
 export { authApi } from './auth.api';
 export { profileApi } from './profile.api';
 export { statisticsApi } from './statistics.api';
+export { rivalriesApi } from './rivalries.api';
 export { imagesApi } from './images.api';
 export { challengesApi } from './challenges.api';
 export { promosApi } from './promos.api';

--- a/frontend/src/services/api/rivalries.api.ts
+++ b/frontend/src/services/api/rivalries.api.ts
@@ -1,0 +1,40 @@
+import { API_BASE_URL, fetchWithAuth } from './apiClient';
+
+export interface RivalryPlayer {
+  playerId: string;
+  name: string;
+  wrestlerName: string;
+  imageUrl?: string;
+}
+
+export interface Rivalry {
+  player1Id: string;
+  player2Id: string;
+  player1?: RivalryPlayer;
+  player2?: RivalryPlayer;
+  player1Wins: number;
+  player2Wins: number;
+  draws: number;
+  matchCount: number;
+  lastMatchDate: string;
+  championshipMatches: number;
+  recentMatchIds: string[];
+  intensityBadge: 'heatingUp' | 'intense' | 'historic';
+}
+
+export interface RivalriesResponse {
+  rivalries: Rivalry[];
+}
+
+export const rivalriesApi = {
+  getRivalries: async (seasonId?: string, signal?: AbortSignal): Promise<RivalriesResponse> => {
+    const params = new URLSearchParams();
+    if (seasonId) params.set('seasonId', seasonId);
+    const query = params.toString();
+    return fetchWithAuth(
+      `${API_BASE_URL}/rivalries${query ? `?${query}` : ''}`,
+      {},
+      signal
+    );
+  },
+};


### PR DESCRIPTION
Closes #166.

Implements **Rivalry Tracker**:
- **Backend**: New `GET /rivalries` endpoint; aggregates completed matches into pairings (min 3 matches), computes series record and intensity (Heating Up 🔥 / Intense 💥 / Historic 👑). Optional `seasonId` query. Reads Matches and Players only.
- **Frontend**: New Rivalries page at `/stats/rivalries` with rivalry cards (both players, images, series record, intensity badge, link to Head-to-Head). Season selector. Stats nav updated with Rivalries link.
- **i18n**: EN/DE keys for rivalries title, series text, intensity badges, empty state.