### PR TITLE
Implements #166 — Rivalry Tracker

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1360,6 +1360,19 @@ paths:
         '200': { description: 'Statistics (shape varies by section param)' }
         '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
 
+  /rivalries:
+    get:
+      tags: [Rivalries]
+      summary: Get top rivalries from match history
+      parameters:
+        - name: seasonId
+          in: query
+          schema: { type: string }
+          description: Optional season ID to filter matches (default all seasons)
+      responses:
+        '200': { description: List of rivalries (player pairs with 3+ matches, series record, intensity badge)' }
+        '500': { description: 'Server error', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
   /fantasy/config:
     get:
       tags: [Fantasy]

--- a/backend/functions/rivalries/getRivalries.ts
+++ b/backend/functions/rivalries/getRivalries.ts
@@ -1,0 +1,182 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, serverError } from '../../lib/response';
+
+interface MatchRecord {
+  matchId: string;
+  date: string;
+  participants: string[];
+  winners?: string[];
+  losers?: string[];
+  status: string;
+  seasonId?: string;
+  championshipId?: string;
+  isChampionship?: boolean;
+}
+
+interface PlayerRecord {
+  playerId: string;
+  name: string;
+  currentWrestler: string;
+  imageUrl?: string;
+}
+
+type IntensityKey = 'heating-up' | 'intense' | 'historic';
+
+const MIN_MATCHES_HEATING_UP = 3;
+const MIN_MATCHES_INTENSE = 5;
+const MIN_MATCHES_HISTORIC = 10;
+const TOP_N = 20;
+const RECENT_MATCHES_LIMIT = 5;
+
+function normalizePair(id1: string, id2: string): [string, string] {
+  return id1 < id2 ? [id1, id2] : [id2, id1];
+}
+
+function getIntensity(matchCount: number): IntensityKey {
+  if (matchCount >= MIN_MATCHES_HISTORIC) return 'historic';
+  if (matchCount >= MIN_MATCHES_INTENSE) return 'intense';
+  if (matchCount >= MIN_MATCHES_HEATING_UP) return 'heating-up';
+  return 'heating-up'; // fallback for 1-2 (we filter by MIN_MATCHES_HEATING_UP)
+}
+
+function intensityScore(
+  matchCount: number,
+  hasChampionship: boolean,
+  recentMatchDaysAgo: number | null
+): number {
+  let score = matchCount * 10;
+  if (hasChampionship) score += 20;
+  if (recentMatchDaysAgo !== null && recentMatchDaysAgo < 90) score += 15;
+  if (recentMatchDaysAgo !== null && recentMatchDaysAgo < 30) score += 10;
+  return score;
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const seasonId = event.queryStringParameters?.seasonId ?? undefined;
+
+    const [matchesResult, playersResult] = await Promise.all([
+      dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
+      dynamoDb.scanAll({ TableName: TableNames.PLAYERS }),
+    ]);
+
+    const allMatches = matchesResult as unknown as MatchRecord[];
+    const completed = allMatches.filter((m) => m.status === 'completed');
+    const matches = seasonId
+      ? completed.filter((m) => m.seasonId === seasonId)
+      : completed;
+
+    const players = playersResult as unknown as PlayerRecord[];
+    const playerMap = new Map(players.map((p) => [p.playerId, p]));
+
+    // Build pair key -> { winsA, winsB, matches[], hasChampionship }
+    type PairKey = string;
+    const pairKey = (a: string, b: string) => `${a}|${b}`;
+
+    interface PairAgg {
+      idA: string;
+      idB: string;
+      winsA: number;
+      winsB: number;
+      matches: { matchId: string; date: string; championshipId?: string }[];
+      hasChampionship: boolean;
+    }
+    const aggregates = new Map<PairKey, PairAgg>();
+
+    for (const m of matches) {
+      const w = m.winners ?? [];
+      const l = m.losers ?? [];
+      let idA: string;
+      let idB: string;
+      let winnerFirst: boolean;
+      if (w.length === 1 && l.length === 1) {
+        idA = w[0] as string;
+        idB = l[0] as string;
+        winnerFirst = true;
+      } else if (m.participants?.length === 2) {
+        idA = m.participants[0] as string;
+        idB = m.participants[1] as string;
+        winnerFirst = w.includes(idA);
+      } else {
+        continue;
+      }
+      const [pA, pB] = normalizePair(idA, idB);
+      const key = pairKey(pA, pB);
+      let agg = aggregates.get(key);
+      if (!agg) {
+        agg = { idA: pA, idB: pB, winsA: 0, winsB: 0, matches: [], hasChampionship: false };
+        aggregates.set(key, agg);
+      }
+      if (m.isChampionship || m.championshipId) agg.hasChampionship = true;
+      agg.matches.push({
+        matchId: m.matchId,
+        date: m.date,
+        championshipId: m.championshipId,
+      });
+      const aWon = w.includes(pA);
+      const bWon = w.includes(pB);
+      if (aWon) agg.winsA += 1;
+      else if (bWon) agg.winsB += 1;
+    }
+
+    const now = Date.now();
+    const rivalries = Array.from(aggregates.entries())
+      .filter(([, agg]) => agg.matches.length >= MIN_MATCHES_HEATING_UP)
+      .map(([, agg]) => {
+        const sortedMatches = [...agg.matches].sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+        );
+        const recentMatchDaysAgo =
+          sortedMatches.length > 0
+            ? Math.floor((now - new Date(sortedMatches[0].date).getTime()) / (24 * 60 * 60 * 1000))
+            : null;
+        const score = intensityScore(
+          agg.matches.length,
+          agg.hasChampionship,
+          recentMatchDaysAgo
+        );
+        return {
+          ...agg,
+          recentMatches: sortedMatches.slice(0, RECENT_MATCHES_LIMIT),
+          intensity: getIntensity(agg.matches.length),
+          intensityScore: score,
+        };
+      })
+      .sort((a, b) => b.intensityScore - a.intensityScore)
+      .slice(0, TOP_N)
+      .map((r) => {
+        const playerA = playerMap.get(r.idA);
+        const playerB = playerMap.get(r.idB);
+        return {
+          playerIds: [r.idA, r.idB] as [string, string],
+          playerA: playerA
+            ? {
+                playerId: r.idA,
+                name: playerA.name,
+                wrestlerName: playerA.currentWrestler,
+                imageUrl: playerA.imageUrl,
+              }
+            : { playerId: r.idA, name: '', wrestlerName: '', imageUrl: undefined },
+          playerB: playerB
+            ? {
+                playerId: r.idB,
+                name: playerB.name,
+                wrestlerName: playerB.currentWrestler,
+                imageUrl: playerB.imageUrl,
+              }
+            : { playerId: r.idB, name: '', wrestlerName: '', imageUrl: undefined },
+          winsA: r.winsA,
+          winsB: r.winsB,
+          recentMatches: r.recentMatches,
+          intensity: r.intensity,
+          championshipAtStake: r.hasChampionship,
+        };
+      });
+
+    return success({ rivalries });
+  } catch (err) {
+    console.error('Error computing rivalries:', err);
+    return serverError('Failed to compute rivalries');
+  }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -510,6 +510,15 @@ functions:
           method: get
           cors: *corsConfig
 
+  # Rivalries (detect and return top rivalries from match history)
+  getRivalries:
+    handler: functions/rivalries/getRivalries.handler
+    events:
+      - http:
+          path: rivalries
+          method: get
+          cors: *corsConfig
+
   # Fantasy (Phase 3 consolidated: all 12 fantasy handlers)
   fantasy:
     handler: functions/fantasy/handler.handler

--- a/docs/plans/plan-issue-166-rivalry-tracker.md
+++ b/docs/plans/plan-issue-166-rivalry-tracker.md
@@ -1,0 +1,93 @@
+# Plan: Rivalry Tracker
+
+**GitHub issue:** [#166](https://github.com/jpDxsolo/league_szn/issues/166) — feat: Rivalry Tracker
+
+## Context
+
+The app has no way to surface active rivalries. This plan adds automatic detection of rivalries from match history (repeated pairings in the current season), a new GET /rivalries endpoint, and a Rivalries page with cards showing both players, series record, recent matches, championship at stake, and intensity badges (Heating Up / Intense / Historic).
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review backend logic and frontend components |
+| Before commit | git-commit-helper | Conventional commit message |
+| If API changed | api-documenter | Update OpenAPI for GET /rivalries |
+| New behavior | test-generator | Tests for rivalries handler and Rivalries page |
+
+## Agents and parallel work
+
+- **Suggested order:** Step 1 (backend: rivalries Lambda + scoring) → Step 2 (API client + types) + Step 3 (Rivalries page + cards) → Step 4 (i18n + nav + optional Rivalry of the Week) → Step 5 (tests + docs).
+- **Agent types:** `general-purpose` for backend and frontend; `test-engineer` for tests.
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `backend/functions/rivalries/` (new) | Create | Lambda handler: GET /rivalries, analyze Matches for pairings, score intensity, return sorted list |
+| `backend/serverless.yml` | Modify | Add rivalries function and HTTP GET /rivalries route |
+| `backend/docs/openapi.yaml` | Modify | Document GET /rivalries response schema |
+| `frontend/src/services/api/rivalries.api.ts` | Create | getRivalries(seasonId?) |
+| `frontend/src/types/index.ts` | Modify | Add Rivalry, RivalryMatch types (or in api types) |
+| `frontend/src/components/rivalries/Rivalries.tsx` | Create | Page with rivalry cards; optional featured "Rivalry of the Week" |
+| `frontend/src/components/rivalries/RivalryCard.tsx` | Create | Card: both players (images), series record, recent matches, intensity badge |
+| `frontend/src/App.tsx` | Modify | Add route /rivalries (feature-gate if needed) |
+| `frontend/src/components/Sidebar.tsx` (or nav) | Modify | Add Rivalries link |
+| `frontend/src/i18n/locales/en.json` | Modify | Rivalries title, intensity badges, series record format |
+| `frontend/src/i18n/locales/de.json` | Modify | Same keys in German |
+| Backend/frontend tests | Modify | Rivalries handler; Rivalries page load |
+
+## Implementation Steps
+
+### Step 1: Backend – GET /rivalries endpoint and scoring
+
+- Create `backend/functions/rivalries/` (e.g. `getRivalries.ts` or `handler.ts`):
+  - Scan or query Matches (completed only); optionally filter by `seasonId` (query param).
+  - For each completed match, derive pair(s) of opponents: for singles use (winners[0], losers[0]) or participants; for tag, use team aggregates or skip (configurable). Normalize pair to sorted [playerIdA, playerIdB] so A < B for consistency.
+  - Aggregate by pair: match count, list of recent matches (matchId, date, championshipId, etc.), wins per player.
+  - Score "rivalry intensity" from: match count (e.g. 3+ = Heating Up, 5+ = Intense, 10+ = Historic), recency (recent matches boost), championship involvement (title matches boost), optional: active challenges between the two (read Challenges table).
+  - Sort by intensity score descending; return top N (e.g. 20) rivalries. Each item: playerIds [idA, idB], series record { winsA, winsB }, recentMatches[], intensity badge key, optional championshipId at stake.
+  - Read Players (for names, images), Championships (for at-stake), Challenges (optional) — all read-only.
+- In `backend/serverless.yml`: Add rivalries function, attach to API Gateway GET /rivalries (public or feature-gated as per project).
+
+### Step 2: Frontend – API client and types
+
+- Define types: `Rivalry { playerIds: [string, string], playerA: { playerId, name, imageUrl? }, playerB: {...}, winsA: number, winsB: number, recentMatches: RivalryMatch[], intensity: 'heating-up' | 'intense' | 'historic', championshipId?: string }`, `RivalryMatch { matchId, date, championshipId? }`.
+- Create `frontend/src/services/api/rivalries.api.ts`: `getRivalries(seasonId?: string)` calling GET /rivalries with optional seasonId.
+
+### Step 3: Frontend – Rivalries page and RivalryCard
+
+- Create `frontend/src/components/rivalries/Rivalries.tsx`: Fetch rivalries; render list of RivalryCards. Optional: pick first or highest-rated as "Rivalry of the Week" and show as featured card at top.
+- Create `frontend/src/components/rivalries/RivalryCard.tsx`: Display both players (avatar/name), series record (e.g. "AJ Styles leads 3-2"), recent matches (expandable or inline), intensity badge (Heating Up 🔥 / Intense 💥 / Historic 👑), optional championship at stake. Clicking card can expand to full match history or link to head-to-head.
+- Add route in `App.tsx`: e.g. `/rivalries` → Rivalries page (inside FeatureRoute for "statistics" or equivalent if desired).
+- Add "Rivalries" to sidebar/nav (e.g. near Statistics).
+
+### Step 4: i18n and optional Rivalry of the Week
+
+- Add EN/DE keys: "Rivalries", "Heating Up", "Intense", "Historic", series record format ("{name} leads {winsA}-{winsB}", "Tied {winsA}-{winsB}"), "Recent matches", "Rivalry of the Week".
+- If implementing Rivalry of the Week: use first item or highest intensity as featured; style differently (larger card or callout).
+
+### Step 5: Tests and docs
+
+- Backend: unit test rivalries handler — mock DynamoDB scan/query, assert pair aggregation, intensity scoring, and response shape.
+- Frontend: test Rivalries page loads and displays cards; test RivalryCard with mock data.
+- OpenAPI: document GET /rivalries query params (seasonId), response schema.
+
+## Dependencies and order
+
+( **Suggested order:** Step 1 → Steps 2+3 (parallel) → Step 4 → Step 5. )
+
+- **Suggested order:** Step 1 → Steps 2+3 (parallel) → Step 4 → Step 5.
+- Step 2 and 3 can run in parallel after Step 1. Step 4 and 5 after 2+3.
+
+## Testing and Verification
+
+- **Manual:** Open /rivalries; confirm cards show for pairs with 3+ matches; verify series record and intensity badges; expand or link to match history.
+- **Unit:** Rivalries handler aggregation and scoring; API client; Rivalries/RivalryCard render.
+- **Regression:** Statistics and matches pages unchanged.
+
+## Risks and edge cases
+
+- **Tag / multi-way matches:** Define how to derive "pair" for tag or triple-threat (e.g. treat as multiple pairs or skip; document in plan).
+- **Empty state:** When no rivalries meet threshold, show empty state message (i18n).
+- **Performance:** Scanning all matches is acceptable for small/medium leagues; if needed, add caching or limit to current season by default.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import Leaderboards from './components/statistics/Leaderboards';
 import RecordBook from './components/statistics/RecordBook';
 import TaleOfTheTape from './components/statistics/TaleOfTheTape';
 import Achievements from './components/statistics/Achievements';
+import Rivalries from './components/rivalries/Rivalries';
 // Contender components
 import ContenderRankings from './components/contenders/ContenderRankings';
 import MyContenderStatus from './components/contenders/MyContenderStatus';
@@ -174,6 +175,9 @@ function AppLayout() {
             } />
             <Route path="/stats/achievements" element={
               <FeatureRoute feature="statistics"><Achievements /></FeatureRoute>
+            } />
+            <Route path="/rivalries" element={
+              <FeatureRoute feature="statistics"><Rivalries /></FeatureRoute>
             } />
 
             {/* Events Routes - public */}

--- a/frontend/src/components/rivalries/Rivalries.css
+++ b/frontend/src/components/rivalries/Rivalries.css
@@ -1,0 +1,59 @@
+.rivalries-page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.rivalries-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.rivalries-page__header h2 {
+  margin: 0;
+}
+
+.rivalries-page__nav {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.rivalries-page__nav a {
+  color: #d4af37;
+  text-decoration: none;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid #333;
+  border-radius: 4px;
+  transition: background-color 0.3s;
+}
+
+.rivalries-page__nav a:hover {
+  background-color: #333;
+}
+
+.rivalries-page__season {
+  margin-bottom: 1.5rem;
+}
+
+.rivalries-page__empty {
+  color: #888;
+}
+
+.rivalries-page__error {
+  color: #e57373;
+}
+
+.rivalries-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.rivalries-page__grid .rivalry-card--featured {
+  grid-column: 1 / -1;
+}

--- a/frontend/src/components/rivalries/Rivalries.tsx
+++ b/frontend/src/components/rivalries/Rivalries.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { rivalriesApi, seasonsApi } from '../../services/api';
+import type { Rivalry } from '../../services/api/rivalries.api';
+import type { Season } from '../../types';
+import SeasonSelector from '../statistics/SeasonSelector';
+import RivalryCard from './RivalryCard';
+import './Rivalries.css';
+
+export default function Rivalries() {
+  const { t } = useTranslation();
+  const [rivalries, setRivalries] = useState<Rivalry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [selectedSeasonId, setSelectedSeasonId] = useState('');
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const fetchSeasons = async () => {
+      try {
+        const list = await seasonsApi.getAll(abortController.signal);
+        setSeasons(list);
+      } catch {
+        // ignore
+      }
+    };
+    fetchSeasons();
+    return () => abortController.abort();
+  }, []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    setLoading(true);
+    setError(null);
+    rivalriesApi
+      .getRivalries(selectedSeasonId || undefined, abortController.signal)
+      .then((res) => {
+        setRivalries(res.rivalries);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          setError(err.message);
+        }
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+    return () => abortController.abort();
+  }, [selectedSeasonId]);
+
+  const featured = rivalries.length > 0 ? rivalries[0] : null;
+  const rest = rivalries.length > 1 ? rivalries.slice(1) : [];
+
+  if (loading && rivalries.length === 0) {
+    return (
+      <div className="rivalries-page">
+        <h2>{t('rivalries.title')}</h2>
+        <p>{t('rivalries.loading')}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rivalries-page">
+        <h2>{t('rivalries.title')}</h2>
+        <p className="rivalries-page__error">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rivalries-page">
+      <div className="rivalries-page__header">
+        <h2>{t('rivalries.title')}</h2>
+        <div className="rivalries-page__nav">
+          <Link to="/stats">{t('nav.statistics')}</Link>
+          <Link to="/stats/head-to-head">{t('statistics.nav.headToHead')}</Link>
+          <Link to="/stats/leaderboards">{t('statistics.nav.leaderboards')}</Link>
+        </div>
+      </div>
+      {seasons.length > 0 && (
+        <div className="rivalries-page__season">
+          <SeasonSelector
+            seasons={seasons}
+            selectedSeasonId={selectedSeasonId}
+            onSeasonChange={setSelectedSeasonId}
+          />
+        </div>
+      )}
+      {rivalries.length === 0 ? (
+        <p className="rivalries-page__empty">{t('rivalries.noRivalries')}</p>
+      ) : (
+        <div className="rivalries-page__grid">
+          {featured && <RivalryCard rivalry={featured} featured />}
+          {rest.map((r) => (
+            <RivalryCard key={`${r.playerIds[0]}-${r.playerIds[1]}`} rivalry={r} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/rivalries/RivalryCard.css
+++ b/frontend/src/components/rivalries/RivalryCard.css
@@ -1,0 +1,134 @@
+.rivalry-card {
+  background: #2d2d2d;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  position: relative;
+}
+
+.rivalry-card--featured {
+  border-color: #d4af37;
+  box-shadow: 0 0 0 1px #d4af37;
+}
+
+.rivalry-card__badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  font-size: 0.75rem;
+  color: #d4af37;
+  font-weight: 600;
+}
+
+.rivalry-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.rivalry-card__players {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.rivalry-card__player {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.rivalry-card__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.rivalry-card__avatar--placeholder {
+  background: #444;
+}
+
+.rivalry-card__name {
+  font-weight: 600;
+  color: #eee;
+}
+
+.rivalry-card__vs {
+  color: #888;
+  font-size: 0.9rem;
+}
+
+.rivalry-card__intensity {
+  font-size: 0.85rem;
+  color: #d4af37;
+}
+
+.rivalry-card__series {
+  margin: 0 0 0.5rem;
+  color: #bbb;
+  font-size: 0.95rem;
+}
+
+.rivalry-card__championship {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: #d4af37;
+}
+
+.rivalry-card__recent {
+  margin-top: 0.75rem;
+}
+
+.rivalry-card__toggle {
+  background: none;
+  border: none;
+  color: #8ab4f8;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.rivalry-card__toggle:hover {
+  color: #a8c7fa;
+}
+
+.rivalry-card__matches {
+  margin: 0.5rem 0 0 1rem;
+  padding: 0;
+  list-style: none;
+}
+
+.rivalry-card__matches li {
+  margin-bottom: 0.25rem;
+}
+
+.rivalry-card__matches a {
+  color: #8ab4f8;
+  text-decoration: none;
+}
+
+.rivalry-card__matches a:hover {
+  text-decoration: underline;
+}
+
+.rivalry-card__footer {
+  margin-top: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #444;
+}
+
+.rivalry-card__link {
+  color: #d4af37;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.rivalry-card__link:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/components/rivalries/RivalryCard.tsx
+++ b/frontend/src/components/rivalries/RivalryCard.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import type { Rivalry } from '../../services/api/rivalries.api';
+import './RivalryCard.css';
+
+const INTENSITY_EMOJI: Record<string, string> = {
+  'heating-up': '🔥',
+  intense: '💥',
+  historic: '👑',
+};
+
+interface RivalryCardProps {
+  rivalry: Rivalry;
+  featured?: boolean;
+}
+
+export default function RivalryCard({ rivalry, featured }: RivalryCardProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const { playerA, playerB, winsA, winsB, recentMatches, intensity, championshipAtStake } = rivalry;
+  const total = winsA + winsB;
+  const emoji = INTENSITY_EMOJI[intensity] ?? '🔥';
+  const intensityKey = `rivalries.intensity.${intensity}` as const;
+
+  const seriesText =
+    winsA === winsB
+      ? t('rivalries.seriesTied', { wins: winsA })
+      : winsA > winsB
+        ? t('rivalries.seriesLeads', {
+            name: playerA.wrestlerName || playerA.name,
+            wins: winsA,
+            losses: winsB,
+          })
+        : t('rivalries.seriesLeads', {
+            name: playerB.wrestlerName || playerB.name,
+            wins: winsB,
+            losses: winsA,
+          });
+
+  return (
+    <article className={`rivalry-card ${featured ? 'rivalry-card--featured' : ''}`}>
+      {featured && (
+        <div className="rivalry-card__badge">{t('rivalries.rivalryOfTheWeek')}</div>
+      )}
+      <div className="rivalry-card__header">
+        <div className="rivalry-card__players">
+          <div className="rivalry-card__player">
+            {playerA.imageUrl ? (
+              <img src={playerA.imageUrl} alt="" className="rivalry-card__avatar" />
+            ) : (
+              <div className="rivalry-card__avatar rivalry-card__avatar--placeholder" />
+            )}
+            <span className="rivalry-card__name">{playerA.wrestlerName || playerA.name}</span>
+          </div>
+          <span className="rivalry-card__vs">{t('common.vs')}</span>
+          <div className="rivalry-card__player">
+            {playerB.imageUrl ? (
+              <img src={playerB.imageUrl} alt="" className="rivalry-card__avatar" />
+            ) : (
+              <div className="rivalry-card__avatar rivalry-card__avatar--placeholder" />
+            )}
+            <span className="rivalry-card__name">{playerB.wrestlerName || playerB.name}</span>
+          </div>
+        </div>
+        <div className="rivalry-card__intensity" title={t(intensityKey)}>
+          {emoji} {t(intensityKey)}
+        </div>
+      </div>
+      <p className="rivalry-card__series">{seriesText}</p>
+      {championshipAtStake && (
+        <p className="rivalry-card__championship">{t('rivalries.championshipAtStake')}</p>
+      )}
+      <div className="rivalry-card__recent">
+        <button
+          type="button"
+          className="rivalry-card__toggle"
+          onClick={() => setExpanded((e) => !e)}
+          aria-expanded={expanded}
+        >
+          {t('rivalries.recentMatches')} ({recentMatches.length})
+        </button>
+        {expanded && (
+          <ul className="rivalry-card__matches">
+            {recentMatches.map((m) => (
+              <li key={m.matchId}>
+                <span>
+                  {new Date(m.date).toLocaleDateString()}
+                  {m.championshipId ? ' 🏆' : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="rivalry-card__footer">
+        <Link to="/stats/head-to-head" className="rivalry-card__link">
+          {t('statistics.nav.headToHead')} →
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/config/navConfig.ts
+++ b/frontend/src/config/navConfig.ts
@@ -36,6 +36,7 @@ export const USER_NAV_GROUPS: NavGroup[] = [
       { path: '/tournaments', i18nKey: 'nav.tournaments' },
       { path: '/contenders', i18nKey: 'nav.contenders', feature: 'contenders' },
       { path: '/stats', i18nKey: 'nav.statistics', feature: 'statistics' },
+      { path: '/rivalries', i18nKey: 'nav.rivalries', feature: 'statistics' },
     ],
   },
   {
@@ -118,9 +119,9 @@ export const ADMIN_NAV_GROUPS: NavGroup[] = [
 
 /** Path → group key for user nav (for auto-expand) */
 export function getUserGroupForPath(pathname: string): string | null {
-  const core = ['/', '/championships', '/events', '/tournaments', '/contenders', '/stats'];
+  const core = ['/', '/championships', '/events', '/tournaments', '/contenders', '/stats', '/rivalries'];
   const wrestler = ['/profile', '/challenges', '/promos'];
-  if (core.some((p) => pathname === p) || pathname.startsWith('/events/') || pathname.startsWith('/stats/') || pathname.startsWith('/contenders/')) return 'core';
+  if (core.some((p) => pathname === p) || pathname.startsWith('/events/') || pathname.startsWith('/stats/') || pathname.startsWith('/contenders/') || pathname.startsWith('/rivalries')) return 'core';
   if (wrestler.some((p) => pathname === p || pathname.startsWith(p + '/'))) return 'wrestler';
   return null;
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -41,6 +41,7 @@
     "challenges": "Herausforderungen",
     "promos": "Promos",
     "statistics": "Statistiken",
+    "rivalries": "Rivalitäten",
     "help": "Hilfe",
     "wiki": "Wiki",
     "admin": "Admin",
@@ -228,6 +229,21 @@
       "d": "U",
       "points": "Punkte"
     }
+  },
+  "rivalries": {
+    "title": "Rivalitäten",
+    "loading": "Rivalitäten werden geladen...",
+    "noRivalries": "Noch keine Rivalitäten. Sie erscheinen, wenn zwei Spieler 3+ Kämpfe in der Saison haben.",
+    "intensity": {
+      "heatingUp": "Heiß läuft",
+      "intense": "Intensiv",
+      "historic": "Historisch"
+    },
+    "seriesLeads": "{{name}} führt {{wins}}-{{losses}}",
+    "seriesTied": "Unentschieden {{wins}}-{{wins}}",
+    "recentMatches": "Letzte Kämpfe",
+    "rivalryOfTheWeek": "Rivalität der Woche",
+    "championshipAtStake": "Meisterschaft im Spiel"
   },
   "admin": {
     "panel": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -41,6 +41,7 @@
     "challenges": "Challenges",
     "promos": "Promos",
     "statistics": "Stats",
+    "rivalries": "Rivalries",
     "help": "Help",
     "wiki": "Wiki",
     "admin": "Admin",
@@ -228,6 +229,21 @@
       "d": "D",
       "points": "Points"
     }
+  },
+  "rivalries": {
+    "title": "Rivalries",
+    "loading": "Loading rivalries...",
+    "noRivalries": "No rivalries yet. Rivalries appear when two players have 3+ matches in the season.",
+    "intensity": {
+      "heatingUp": "Heating Up",
+      "intense": "Intense",
+      "historic": "Historic"
+    },
+    "seriesLeads": "{{name}} leads {{wins}}-{{losses}}",
+    "seriesTied": "Tied {{wins}}-{{wins}}",
+    "recentMatches": "Recent matches",
+    "rivalryOfTheWeek": "Rivalry of the Week",
+    "championshipAtStake": "Championship at stake"
   },
   "admin": {
     "panel": {

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -20,6 +20,7 @@ export { siteConfigApi } from './siteConfig.api';
 export { authApi } from './auth.api';
 export { profileApi } from './profile.api';
 export { statisticsApi } from './statistics.api';
+export { rivalriesApi } from './rivalries.api';
 export { imagesApi } from './images.api';
 export { challengesApi } from './challenges.api';
 export { promosApi } from './promos.api';

--- a/frontend/src/services/api/rivalries.api.ts
+++ b/frontend/src/services/api/rivalries.api.ts
@@ -1,0 +1,42 @@
+import { API_BASE_URL, fetchWithAuth } from './apiClient';
+
+export interface RivalryPlayer {
+  playerId: string;
+  name: string;
+  wrestlerName: string;
+  imageUrl?: string;
+}
+
+export interface RivalryMatch {
+  matchId: string;
+  date: string;
+  championshipId?: string;
+}
+
+export interface Rivalry {
+  playerIds: [string, string];
+  playerA: RivalryPlayer;
+  playerB: RivalryPlayer;
+  winsA: number;
+  winsB: number;
+  recentMatches: RivalryMatch[];
+  intensity: 'heating-up' | 'intense' | 'historic';
+  championshipAtStake?: boolean;
+}
+
+export interface RivalriesResponse {
+  rivalries: Rivalry[];
+}
+
+export const rivalriesApi = {
+  getRivalries: async (seasonId?: string, signal?: AbortSignal): Promise<RivalriesResponse> => {
+    const params = new URLSearchParams();
+    if (seasonId) params.set('seasonId', seasonId);
+    const query = params.toString();
+    return fetchWithAuth(
+      `${API_BASE_URL}/rivalries${query ? `?${query}` : ''}`,
+      {},
+      signal
+    );
+  },
+};


### PR DESCRIPTION
Closes #166. Implements [Rivalry Tracker](https://github.com/jpDxsoloOrg/league_szn/issues/166).

- **Backend:** New `GET /rivalries` endpoint; analyzes completed matches for repeated pairings, series records, intensity (Heating Up / Intense / Historic); optional `seasonId` filter.
- **Frontend:** Rivalries page with rivalry cards (both players, series record, recent matches, intensity badge, optional Rivalry of the Week); nav and i18n (EN/DE).
- **Docs:** Plan in `docs/plans/plan-issue-166-rivalry-tracker.md`, OpenAPI updated.