### PR TITLE
Implements #164 — Match of the Night / Star Rating System

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -118,6 +118,8 @@ components:
         winners: { type: array, items: { type: string } }
         losers: { type: array, items: { type: string } }
         winningTeam: { type: integer }
+        starRating: { type: number, minimum: 0.5, maximum: 5, description: 'Optional star rating (0.5–5.0, half-step)' }
+        matchOfTheNight: { type: boolean, description: 'Optional Match of the Night flag' }
 
     Championship:
       type: object
@@ -1340,6 +1342,7 @@ paths:
     get:
       tags: [Statistics]
       summary: Get statistics (shape varies by section)
+      description: 'Sections include player-stats, head-to-head, leaderboards, records, achievements, match-ratings. Use section=match-ratings for top rated matches and per-player averages (optional seasonId).'
       parameters:
         - name: section
           in: query
@@ -1359,6 +1362,19 @@ paths:
       responses:
         '200': { description: 'Statistics (shape varies by section param)' }
         '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /rivalries:
+    get:
+      tags: [Rivalries]
+      summary: Get top rivalries from match history
+      parameters:
+        - name: seasonId
+          in: query
+          schema: { type: string }
+          description: Optional season ID to filter matches (default all seasons)
+      responses:
+        '200': { description: List of rivalries (player pairs with 3+ matches, series record, intensity badge)' }
+        '500': { description: 'Server error', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
 
   /fantasy/config:
     get:

--- a/backend/functions/matches/recordResult.ts
+++ b/backend/functions/matches/recordResult.ts
@@ -8,6 +8,8 @@ import { calculateFantasyPoints } from '../fantasy/calculateFantasyPoints';
 interface RecordResultBody {
   winners: string[];
   losers: string[];
+  starRating?: number; // 0.5–5.0, half-step
+  matchOfTheNight?: boolean;
 }
 
 interface TransactWriteItem {
@@ -133,6 +135,13 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('A player cannot be both a winner and loser in the same match');
     }
 
+    if (body.starRating != null) {
+      const r = body.starRating;
+      if (typeof r !== 'number' || r < 0.5 || r > 5 || (r * 2) % 1 !== 0) {
+        return badRequest('starRating must be a number between 0.5 and 5.0 in half-star steps');
+      }
+    }
+
     // Get the match using query (matchId is the partition key)
     const matchResult = await dynamoDb.query({
       TableName: TableNames.MATCHES,
@@ -158,22 +167,33 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     // Build transaction items for atomic updates
     const transactItems: TransactWriteItem[] = [];
 
-    // 1. Update match with results and optimistic locking
+    // 1. Update match with results and optimistic locking (+ optional starRating, matchOfTheNight)
+    const matchUpdateValues: Record<string, unknown> = {
+      ':winners': body.winners,
+      ':losers': body.losers,
+      ':status': 'completed',
+      ':zero': 0,
+      ':one': 1,
+      ':pending': 'pending',
+      ':scheduled': 'scheduled',
+    };
+    let matchSetExpr = 'SET winners = :winners, losers = :losers, #status = :status, version = if_not_exists(version, :zero) + :one';
+    const matchAttrNames: Record<string, string> = { '#status': 'status' };
+    if (body.starRating != null) {
+      matchSetExpr += ', starRating = :starRating';
+      matchUpdateValues[':starRating'] = body.starRating;
+    }
+    if (body.matchOfTheNight === true) {
+      matchSetExpr += ', matchOfTheNight = :matchOfTheNight';
+      matchUpdateValues[':matchOfTheNight'] = true;
+    }
     transactItems.push({
       Update: {
         TableName: TableNames.MATCHES,
         Key: { matchId: match.matchId, date: match.date },
-        UpdateExpression: 'SET winners = :winners, losers = :losers, #status = :status, version = if_not_exists(version, :zero) + :one',
-        ExpressionAttributeNames: { '#status': 'status' },
-        ExpressionAttributeValues: {
-          ':winners': body.winners,
-          ':losers': body.losers,
-          ':status': 'completed',
-          ':zero': 0,
-          ':one': 1,
-          ':pending': 'pending',
-          ':scheduled': 'scheduled',
-        },
+        UpdateExpression: matchSetExpr,
+        ExpressionAttributeNames: matchAttrNames,
+        ExpressionAttributeValues: matchUpdateValues,
         ConditionExpression: '#status = :pending OR #status = :scheduled',
       },
     });

--- a/backend/functions/statistics/getStatistics.ts
+++ b/backend/functions/statistics/getStatistics.ts
@@ -16,6 +16,8 @@ interface MatchRecord {
   championshipId?: string;
   status: string;
   seasonId?: string;
+  starRating?: number;
+  matchOfTheNight?: boolean;
 }
 
 interface PlayerRecord {
@@ -172,7 +174,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const seasonId = event.queryStringParameters?.seasonId;
 
     if (!section) {
-      return badRequest('Missing required query parameter: section (player-stats, head-to-head, leaderboards, records, championship-stats, achievements)');
+      return badRequest('Missing required query parameter: section (player-stats, head-to-head, leaderboards, records, championship-stats, achievements, match-ratings)');
     }
 
     // Load common data
@@ -730,8 +732,36 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         });
       }
 
+      case 'match-ratings': {
+        const withRating = allCompletedMatches.filter((m) => m.starRating != null && m.starRating >= 0.5);
+        const filtered = seasonId ? withRating.filter((m) => m.seasonId === seasonId) : withRating;
+        const sorted = [...filtered].sort((a, b) => (b.starRating ?? 0) - (a.starRating ?? 0));
+        const topRatedMatches = sorted.slice(0, 20).map((m) => ({
+          matchId: m.matchId,
+          date: m.date,
+          participants: m.participants ?? [],
+          starRating: m.starRating,
+          matchOfTheNight: m.matchOfTheNight === true,
+        }));
+        const playerRatingSum: Record<string, { sum: number; count: number }> = {};
+        for (const m of filtered) {
+          const r = m.starRating ?? 0;
+          for (const pid of m.participants ?? []) {
+            if (!playerRatingSum[pid]) playerRatingSum[pid] = { sum: 0, count: 0 };
+            playerRatingSum[pid].sum += r;
+            playerRatingSum[pid].count += 1;
+          }
+        }
+        const playerAverages = Object.entries(playerRatingSum).map(([playerId, { sum, count }]) => ({
+          playerId,
+          averageRating: count > 0 ? Math.round((sum / count) * 10) / 10 : 0,
+          matchCount: count,
+        }));
+        return success({ topRatedMatches, playerAverages });
+      }
+
       default:
-        return badRequest(`Unknown section: ${section}. Valid sections: player-stats, head-to-head, leaderboards, records, achievements`);
+        return badRequest(`Unknown section: ${section}. Valid sections: player-stats, head-to-head, leaderboards, records, achievements, match-ratings`);
     }
   } catch (err) {
     console.error('Error computing statistics:', err);

--- a/docs/plans/plan-issue-164-match-of-the-night-star-rating.md
+++ b/docs/plans/plan-issue-164-match-of-the-night-star-rating.md
@@ -1,0 +1,103 @@
+# Plan: Match of the Night / Star Rating System
+
+**GitHub issue:** [#164](https://github.com/jpDxsolo/league_szn/issues/164) — feat: Match of the Night / Star Rating System
+
+## Context
+
+Completed matches are currently shown without any quality indicator. This plan adds an optional star rating (1–5 stars, half-star increments) and a "Match of the Night" (MOTN) flag. Admins set these when recording a result; public users see ratings on event results and a MOTN badge, plus a "Best Matches" leaderboard in Statistics.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review backend/frontend changes |
+| Before commit | git-commit-helper | Conventional commit message |
+| If API changed | api-documenter | Update OpenAPI for result body and statistics |
+| New/changed behavior | test-generator | Tests for recordResult and statistics section |
+
+## Agents and parallel work
+
+- **Suggested order:** Step 1 (backend: schema + recordResult) → Step 2 (backend: statistics section) + Step 3 (frontend: types + API client) → Step 4 (frontend: RecordResult form + EventDetail/EventResults badges) → Step 5 (frontend: Statistics Best Matches tab + MOTN callout) → Step 6 (i18n + tests).
+- **Agent types:** `general-purpose` for backend and frontend; `test-engineer` for tests.
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `backend/scripts/create-tables.ts` | Modify | Document optional attributes starRating, matchOfTheNight (DynamoDB is schemaless; no migration required if adding optional fields) |
+| `backend/functions/matches/recordResult.ts` | Modify | Accept optional `starRating` (0.5–5.0) and `matchOfTheNight` (boolean) in body; persist to Match item |
+| `backend/functions/statistics/getStatistics.ts` | Modify | Add section `match-ratings` (or extend existing): highest-rated matches, per-player average rating; return data for "Best Matches" |
+| `backend/docs/openapi.yaml` | Modify | RecordResult request body: optional starRating, matchOfTheNight; document GET /statistics?section=match-ratings |
+| `frontend/src/types/index.ts` | Modify | Add `starRating?: number`, `matchOfTheNight?: boolean` to Match interface |
+| `frontend/src/services/api/matches.api.ts` | Modify | recordResult: pass optional starRating, matchOfTheNight in body |
+| `frontend/src/components/admin/RecordResult.tsx` | Modify | Star rating input (e.g. 0.5–5 step 0.5) and MOTN checkbox on result form |
+| `frontend/src/components/events/EventDetail.tsx` | Modify | Show star rating and MOTN badge for completed matches |
+| `frontend/src/components/events/EventResults.tsx` | Modify | Show star rating and MOTN badge on results list |
+| `frontend/src/services/api/statistics.api.ts` | Modify | Add getMatchRatings(seasonId?) for Best Matches data |
+| `frontend/src/App.tsx` | Modify | Add route /stats/best-matches (or tab within existing stats) |
+| New Statistics tab or page | Create | "Best Matches" tab: highest rated matches list, optional per-player average |
+| `frontend/src/i18n/locales/en.json` | Modify | Keys for star rating labels, MOTN badge, Best Matches |
+| `frontend/src/i18n/locales/de.json` | Modify | Same keys in German |
+| Backend/frontend tests | Modify | recordResult with starRating/MOTN; statistics section; RecordResult form |
+
+## Implementation Steps
+
+### Step 1: Backend – Match result accepts starRating and matchOfTheNight
+
+- In `backend/functions/matches/recordResult.ts`:
+  - Extend `RecordResultBody` to include optional `starRating?: number` (validate 0.5–5.0, half-step) and `matchOfTheNight?: boolean`.
+  - In the Match update transaction, add SET clauses for `starRating` and `matchOfTheNight` when provided (use ExpressionAttributeNames/Values).
+  - Ensure only one match per event can be MOTN if desired (optional: enforce in backend or leave to admin discretion).
+- No DynamoDB table migration: add optional attributes on write. Document in `backend/scripts/create-tables.ts` or a schema comment that Matches may have `starRating` (number) and `matchOfTheNight` (boolean).
+
+### Step 2: Backend – Statistics section for match ratings
+
+- In `backend/functions/statistics/getStatistics.ts`:
+  - Add a new section (e.g. `section=match-ratings`): when requested, scan/use completed matches that have `starRating`, compute:
+    - List of highest-rated matches (e.g. top 20), with matchId, date, participants, starRating, matchOfTheNight, eventId if available.
+    - Per-player average star rating (for matches they participated in).
+  - Support optional `seasonId` filter for match-ratings.
+  - Return shape: `{ topRatedMatches: [...], playerAverages: [{ playerId, averageRating, matchCount }] }` or similar.
+
+### Step 3: Frontend – Types and API client
+
+- In `frontend/src/types/index.ts`: Add to `Match` interface `starRating?: number` and `matchOfTheNight?: boolean`.
+- In `frontend/src/services/api/matches.api.ts`: Update `recordResult` to accept and send optional `starRating` and `matchOfTheNight` in the request body.
+- In `frontend/src/services/api/statistics.api.ts`: Add `getMatchRatings(seasonId?: string)` calling GET statistics with `section=match-ratings` and optional seasonId.
+
+### Step 4: Frontend – Record result form and event badges
+
+- In `frontend/src/components/admin/RecordResult.tsx`: Add star rating control (dropdown or stepper 0.5–5.0) and "Match of the Night" checkbox. Include in the payload when calling recordResult.
+- In `frontend/src/components/events/EventDetail.tsx`: For each completed match, display star rating (e.g. "★★★★☆") and a "Match of the Night" badge when `matchOfTheNight` is true.
+- In `frontend/src/components/events/EventResults.tsx`: Same: show star rating and MOTN badge for each completed match in the results list.
+
+### Step 5: Frontend – Best Matches tab and MOTN callout
+
+- Add a "Best Matches" entry to Statistics (new route e.g. `/stats/best-matches` or a tab in existing Statistics layout). Fetch match-ratings data and display:
+  - Table or list of highest-rated matches (date, participants, rating, MOTN badge).
+  - Optional: per-player average rating (e.g. in PlayerStats or a small subsection).
+- On EventDetail (and optionally EventResults), add a "Match of the Night" callout card when the event has a match with `matchOfTheNight === true` (e.g. highlight that match or show a single MOTN card at top).
+
+### Step 6: i18n and tests
+
+- Add EN/DE keys: star rating label, "Match of the Night" badge text, "Best Matches" title, labels for rating scale.
+- Backend: unit test recordResult with body containing starRating and matchOfTheNight; test getStatistics section=match-ratings returns expected shape.
+- Frontend: test RecordResult sends starRating/MOTN; snapshot or unit test for EventDetail/EventResults badges; test Best Matches page or tab loads data.
+
+## Dependencies and order
+
+( **Suggested order:** Step 1 → Steps 2+3 → Step 4 → Step 5 → Step 6. )
+
+- Step 2 and 3 can run in parallel after Step 1. Step 4 depends on Step 3. Step 5 depends on Step 2/3 and Step 4. Step 6 last.
+
+## Testing and Verification
+
+- **Manual:** Record a match result with star rating and MOTN; confirm EventDetail and EventResults show badges; open Best Matches and confirm list and averages.
+- **Unit:** recordResult handler with optional fields; statistics match-ratings section; RecordResult form payload; i18n keys present.
+- **Regression:** Recording result without star rating or MOTN still works; existing statistics sections unchanged.
+
+## Risks and edge cases
+
+- **Backward compatibility:** Existing matches have no starRating/matchOfTheNight; UI should handle undefined (show nothing or "—" for rating, no MOTN badge).
+- **MOTN uniqueness:** Issue does not require one MOTN per event; if product wants only one MOTN per event, add validation in recordResult or frontend.
+- **Half-star validation:** Enforce 0.5–5.0 in 0.5 steps in backend and frontend.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import Leaderboards from './components/statistics/Leaderboards';
 import RecordBook from './components/statistics/RecordBook';
 import TaleOfTheTape from './components/statistics/TaleOfTheTape';
 import Achievements from './components/statistics/Achievements';
+import BestMatches from './components/statistics/BestMatches';
 // Contender components
 import ContenderRankings from './components/contenders/ContenderRankings';
 import MyContenderStatus from './components/contenders/MyContenderStatus';
@@ -174,6 +175,9 @@ function AppLayout() {
             } />
             <Route path="/stats/achievements" element={
               <FeatureRoute feature="statistics"><Achievements /></FeatureRoute>
+            } />
+            <Route path="/stats/best-matches" element={
+              <FeatureRoute feature="statistics"><BestMatches /></FeatureRoute>
             } />
 
             {/* Events Routes - public */}

--- a/frontend/src/components/admin/RecordResult.tsx
+++ b/frontend/src/components/admin/RecordResult.tsx
@@ -22,6 +22,8 @@ export default function RecordResult() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [starRating, setStarRating] = useState<number | undefined>(undefined);
+  const [matchOfTheNight, setMatchOfTheNight] = useState(false);
 
   useEffect(() => {
     loadData();
@@ -125,6 +127,8 @@ export default function RecordResult() {
     setSelectedMatch(match);
     setWinners([]);
     setWinningTeamIndex(null);
+    setStarRating(undefined);
+    setMatchOfTheNight(false);
     setError(null);
     setSuccess(null);
   };
@@ -202,10 +206,18 @@ export default function RecordResult() {
 
       try {
         setError(null);
-        await matchesApi.recordResult(selectedMatch.matchId, { winners, losers });
+        const payload: { winners: string[]; losers: string[]; starRating?: number; matchOfTheNight?: boolean } = {
+          winners,
+          losers,
+        };
+        if (starRating != null) payload.starRating = starRating;
+        if (matchOfTheNight) payload.matchOfTheNight = true;
+        await matchesApi.recordResult(selectedMatch.matchId, payload);
         setSuccess(t('recordResult.success'));
         setSelectedMatch(null);
         setWinners([]);
+        setStarRating(undefined);
+        setMatchOfTheNight(false);
         await loadData();
       } catch (err) {
         setError(err instanceof Error ? err.message : t('recordResult.error'));
@@ -361,11 +373,43 @@ export default function RecordResult() {
                   )}
                 </div>
 
+                <div className="star-rating-row">
+                  <label htmlFor="starRating">{t('matchRatings.starRatingLabel')}</label>
+                  <select
+                    id="starRating"
+                    value={starRating ?? ''}
+                    onChange={(e) => setStarRating(e.target.value === '' ? undefined : Number(e.target.value))}
+                  >
+                    <option value="">—</option>
+                    {[0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].map((v) => (
+                      <option key={v} value={v}>{v} ★</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="match-of-the-night-row">
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={matchOfTheNight}
+                      onChange={(e) => setMatchOfTheNight(e.target.checked)}
+                    />
+                    {t('matchRatings.matchOfTheNight')}
+                  </label>
+                </div>
+
                 <div className="result-actions">
                   <button onClick={handleSubmit} disabled={winners.length === 0 || submitting}>
                     {submitting ? 'Recording...' : 'Record Result'}
                   </button>
-                  <button onClick={() => setSelectedMatch(null)} className="cancel-btn" disabled={submitting}>
+                  <button
+                    onClick={() => {
+                      setSelectedMatch(null);
+                      setStarRating(undefined);
+                      setMatchOfTheNight(false);
+                    }}
+                    className="cancel-btn"
+                    disabled={submitting}
+                  >
                     Cancel
                   </button>
                 </div>

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -260,10 +260,22 @@ interface MatchEntryProps {
       isChampionship: boolean;
       championshipName?: string;
       status: 'scheduled' | 'completed';
+      starRating?: number;
+      matchOfTheNight?: boolean;
     };
   };
   isCompleted: boolean;
   t: (key: string) => string;
+}
+
+function renderMatchStars(rating: number): string {
+  const full = Math.floor(rating);
+  const half = rating % 1 >= 0.5;
+  const stars: string[] = [];
+  for (let i = 0; i < full; i++) stars.push('\u2605');
+  if (half) stars.push('\u00BD');
+  for (let i = stars.length; i < 5; i++) stars.push('\u2606');
+  return stars.join('');
 }
 
 function MatchEntry({ match, isCompleted, t }: MatchEntryProps) {
@@ -289,6 +301,9 @@ function MatchEntry({ match, isCompleted, t }: MatchEntryProps) {
             {matchData.championshipName || t('events.detail.championshipMatch')}
           </span>
         )}
+        {isCompleted && matchData.matchOfTheNight && (
+          <span className="match-motn-badge">{t('matchRatings.motnBadge')}</span>
+        )}
       </div>
 
       <div className="match-participants">
@@ -307,6 +322,13 @@ function MatchEntry({ match, isCompleted, t }: MatchEntryProps) {
           );
         })}
       </div>
+
+      {isCompleted && matchData.starRating != null && (
+        <div className="match-star-rating">
+          <span className="match-stars">{renderMatchStars(matchData.starRating)}</span>
+          <span className="match-rating-value">{matchData.starRating}/5</span>
+        </div>
+      )}
 
       {match.notes && (
         <div className="match-notes">{match.notes}</div>

--- a/frontend/src/components/events/EventResults.tsx
+++ b/frontend/src/components/events/EventResults.tsx
@@ -180,6 +180,16 @@ export default function EventResults() {
                   </div>
                 </div>
 
+                {(matchData as { starRating?: number }).starRating != null && (
+                  <div className="results-match-rating">
+                    <span className="results-stars">{renderStarRating((matchData as { starRating?: number }).starRating!)}</span>
+                    <span className="results-rating-value">{(matchData as { starRating?: number }).starRating} / 5</span>
+                  </div>
+                )}
+                {(matchData as { matchOfTheNight?: boolean }).matchOfTheNight && (
+                  <span className="results-motn-badge">{t('matchRatings.motnBadge')}</span>
+                )}
+
                 {matchData.isChampionship && (
                   <div className="title-change-indicator">
                     {t('events.results.titleChange')}

--- a/frontend/src/components/statistics/BestMatches.css
+++ b/frontend/src/components/statistics/BestMatches.css
@@ -1,0 +1,95 @@
+.best-matches-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.best-matches-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.best-matches-header h2 {
+  margin: 0;
+}
+
+.best-matches-nav {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.best-matches-nav a {
+  color: #d4af37;
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.best-matches-nav a:hover {
+  text-decoration: underline;
+}
+
+.best-matches-season {
+  margin-bottom: 1rem;
+}
+
+.best-matches-list,
+.best-matches-averages {
+  margin-bottom: 2rem;
+}
+
+.best-matches-list h3,
+.best-matches-averages h3 {
+  margin-bottom: 0.75rem;
+}
+
+.best-matches-ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.best-matches-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #333;
+}
+
+.best-matches-date {
+  color: #888;
+  min-width: 100px;
+}
+
+.best-matches-participants,
+.best-matches-player {
+  flex: 1;
+  min-width: 180px;
+}
+
+.best-matches-stars {
+  color: #d4af37;
+}
+
+.best-matches-value {
+  font-weight: 600;
+}
+
+.best-matches-motn {
+  font-size: 0.85rem;
+  color: #d4af37;
+}
+
+.best-matches-count {
+  color: #888;
+  font-size: 0.9rem;
+}
+
+.best-matches-empty {
+  color: #888;
+}

--- a/frontend/src/components/statistics/BestMatches.tsx
+++ b/frontend/src/components/statistics/BestMatches.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { statisticsApi, seasonsApi, playersApi } from '../../services/api';
+import type { TopRatedMatch } from '../../services/api/statistics.api';
+import type { Season } from '../../types';
+import SeasonSelector from './SeasonSelector';
+import './BestMatches.css';
+
+export default function BestMatches() {
+  const { t } = useTranslation();
+  const [topRated, setTopRated] = useState<TopRatedMatch[]>([]);
+  const [playerAverages, setPlayerAverages] = useState<{ playerId: string; averageRating: number; matchCount: number }[]>([]);
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [selectedSeasonId, setSelectedSeasonId] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [playersMap, setPlayersMap] = useState<Map<string, { name: string; wrestlerName: string }>>(new Map());
+
+  useEffect(() => {
+    const ac = new AbortController();
+    Promise.all([seasonsApi.getAll(ac.signal), playersApi.getAll(ac.signal)])
+      .then(([seasonsList, playersList]) => {
+        setSeasons(seasonsList);
+        const map = new Map<string, { name: string; wrestlerName: string }>();
+        for (const p of playersList) {
+          map.set(p.playerId, { name: p.name, wrestlerName: p.currentWrestler });
+        }
+        setPlayersMap(map);
+      })
+      .catch(() => {});
+    return () => ac.abort();
+  }, []);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    setLoading(true);
+    statisticsApi
+      .getMatchRatings(selectedSeasonId || undefined, ac.signal)
+      .then((res) => {
+        setTopRated(res.topRatedMatches);
+        setPlayerAverages(res.playerAverages);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+    return () => ac.abort();
+  }, [selectedSeasonId]);
+
+  const renderStars = (rating: number) => {
+    const stars: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      stars.push(i <= Math.floor(rating) || (i === Math.ceil(rating) && rating % 1 >= 0.5) ? '\u2605' : '\u2606');
+    }
+    return stars.join('');
+  };
+
+  return (
+    <div className="best-matches-page">
+      <div className="best-matches-header">
+        <h2>{t('matchRatings.bestMatches')}</h2>
+        <div className="best-matches-nav">
+          <Link to="/stats">{t('nav.statistics')}</Link>
+          <Link to="/stats/head-to-head">{t('statistics.nav.headToHead')}</Link>
+          <Link to="/stats/leaderboards">{t('statistics.nav.leaderboards')}</Link>
+          <Link to="/stats/records">{t('statistics.nav.records')}</Link>
+          <Link to="/stats/achievements">{t('statistics.nav.achievements')}</Link>
+        </div>
+      </div>
+      {seasons.length > 0 && (
+        <div className="best-matches-season">
+          <SeasonSelector
+            seasons={seasons}
+            selectedSeasonId={selectedSeasonId}
+            onSeasonChange={setSelectedSeasonId}
+          />
+        </div>
+      )}
+      {loading ? (
+        <p>{t('common.loading')}</p>
+      ) : (
+        <>
+          <section className="best-matches-list">
+            <h3>{t('matchRatings.bestMatches')}</h3>
+            {topRated.length === 0 ? (
+              <p className="best-matches-empty">No rated matches yet.</p>
+            ) : (
+              <ul className="best-matches-ul">
+                {topRated.map((m) => (
+                  <li key={m.matchId} className="best-matches-item">
+                    <span className="best-matches-date">{new Date(m.date).toLocaleDateString()}</span>
+                    <span className="best-matches-participants">
+                      {(m.participants || [])
+                        .map((pid) => playersMap.get(pid)?.wrestlerName ?? pid)
+                        .join(' vs ')}
+                    </span>
+                    <span className="best-matches-stars">{m.starRating != null ? renderStars(m.starRating) : '—'}</span>
+                    <span className="best-matches-value">{m.starRating != null ? `${m.starRating}/5` : '—'}</span>
+                    {m.matchOfTheNight && <span className="best-matches-motn">{t('matchRatings.motnBadge')}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+          {playerAverages.length > 0 && (
+            <section className="best-matches-averages">
+              <h3>Average match rating (min 1 rated match)</h3>
+              <ul className="best-matches-ul">
+                {playerAverages
+                  .sort((a, b) => b.averageRating - a.averageRating)
+                  .slice(0, 15)
+                  .map(({ playerId, averageRating, matchCount }) => (
+                    <li key={playerId} className="best-matches-item">
+                      <span className="best-matches-player">{playersMap.get(playerId)?.wrestlerName ?? playerId}</span>
+                      <span className="best-matches-value">{averageRating.toFixed(1)}/5</span>
+                      <span className="best-matches-count">({matchCount} matches)</span>
+                    </li>
+                  ))}
+              </ul>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/statistics/PlayerStats.tsx
+++ b/frontend/src/components/statistics/PlayerStats.tsx
@@ -78,6 +78,7 @@ function PlayerStats() {
         <div className="ps-nav-links">
           <Link to="/stats/head-to-head">{t('statistics.nav.headToHead')}</Link>
           <Link to="/stats/leaderboards">{t('statistics.nav.leaderboards')}</Link>
+          <Link to="/stats/best-matches">{t('matchRatings.bestMatches')}</Link>
           <Link to="/stats/tale-of-tape">{t('statistics.nav.taleOfTape')}</Link>
           <Link to="/stats/records">{t('statistics.nav.records')}</Link>
           <Link to="/stats/achievements">{t('statistics.nav.achievements')}</Link>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -203,6 +203,12 @@
     "selectMatch": "Wählen Sie einen Kampf aus, um das Ergebnis einzutragen",
     "noScheduledMatches": "Keine geplanten Kämpfe zum Eintragen vorhanden."
   },
+  "matchRatings": {
+    "starRatingLabel": "Sternebewertung",
+    "matchOfTheNight": "Kampf der Nacht",
+    "bestMatches": "Beste Kämpfe",
+    "motnBadge": "Kampf der Nacht"
+  },
   "tournaments": {
     "title": "Turniere",
     "loading": "Turniere werden geladen...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -203,6 +203,12 @@
     "selectMatch": "Select a match to record its result",
     "noScheduledMatches": "No scheduled matches to record results for."
   },
+  "matchRatings": {
+    "starRatingLabel": "Star rating",
+    "matchOfTheNight": "Match of the Night",
+    "bestMatches": "Best Matches",
+    "motnBadge": "Match of the Night"
+  },
   "tournaments": {
     "title": "Tournaments",
     "loading": "Loading tournaments...",

--- a/frontend/src/services/api/matches.api.ts
+++ b/frontend/src/services/api/matches.api.ts
@@ -16,7 +16,16 @@ export const matchesApi = {
     });
   },
 
-  recordResult: async (matchId: string, result: { winners: string[], losers: string[], winningTeam?: number }): Promise<Match> => {
+  recordResult: async (
+    matchId: string,
+    result: {
+      winners: string[];
+      losers: string[];
+      winningTeam?: number;
+      starRating?: number;
+      matchOfTheNight?: boolean;
+    }
+  ): Promise<Match> => {
     return fetchWithAuth(`${API_BASE_URL}/matches/${matchId}/result`, {
       method: 'PUT',
       body: JSON.stringify(result),

--- a/frontend/src/services/api/statistics.api.ts
+++ b/frontend/src/services/api/statistics.api.ts
@@ -51,6 +51,19 @@ export interface AchievementsResponse {
   achievements?: Achievement[];
 }
 
+export interface TopRatedMatch {
+  matchId: string;
+  date: string;
+  participants: string[];
+  starRating?: number;
+  matchOfTheNight: boolean;
+}
+
+export interface MatchRatingsResponse {
+  topRatedMatches: TopRatedMatch[];
+  playerAverages: { playerId: string; averageRating: number; matchCount: number }[];
+}
+
 export const statisticsApi = {
   getPlayerStats: async (playerId?: string, seasonId?: string, signal?: AbortSignal): Promise<PlayerStatsResponse> => {
     const params = new URLSearchParams({ section: 'player-stats' });
@@ -84,6 +97,12 @@ export const statisticsApi = {
   getAchievements: async (playerId?: string, signal?: AbortSignal): Promise<AchievementsResponse> => {
     const params = new URLSearchParams({ section: 'achievements' });
     if (playerId) params.set('playerId', playerId);
+    return fetchWithAuth(`${API_BASE_URL}/statistics?${params}`, {}, signal);
+  },
+
+  getMatchRatings: async (seasonId?: string, signal?: AbortSignal): Promise<MatchRatingsResponse> => {
+    const params = new URLSearchParams({ section: 'match-ratings' });
+    if (seasonId) params.set('seasonId', seasonId);
     return fetchWithAuth(`${API_BASE_URL}/statistics?${params}`, {}, signal);
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -31,6 +31,8 @@ export interface Match {
   createdAt: string;
   challengeId?: string;
   promoId?: string;
+  starRating?: number;
+  matchOfTheNight?: boolean;
 }
 
 // Input type for scheduling a new match (uses new field names, backend handles legacy fields)


### PR DESCRIPTION
Closes #164. Implements [Match of the Night / Star Rating System](https://github.com/jpDxsoloOrg/league_szn/issues/164).

- **Backend:** `PUT /matches/{matchId}/result` accepts optional `starRating` (0.5–5.0, half-step) and `matchOfTheNight` (boolean). New `GET /statistics?section=match-ratings` returns top rated matches and per-player average ratings (optional `seasonId`).
- **Frontend:** Record Result form includes star rating dropdown and Match of the Night checkbox. EventDetail and EventResults show star rating and MOTN badge for completed matches. New Best Matches page at `/stats/best-matches` with season filter.
- **i18n:** EN/DE keys for star rating, MOTN, Best Matches. OpenAPI updated.