### PR TITLE
feat: News Feed / Activity Timeline (Closes #165)

### DIFF
--- a/.agent/workflows/commit.md
+++ b/.agent/workflows/commit.md
@@ -1,0 +1,72 @@
+---
+description: Create a conventional commit for the latest changes and push to remote
+---
+Create a conventional commit for the latest changes and push to remote.
+
+## Step 1: Analyze changes
+
+Run these commands in parallel to understand the current state:
+
+1. `git status` - See all untracked and modified files
+2. `git diff --staged` - See staged changes
+3. `git diff` - See unstaged changes
+4. `git log --oneline -5` - See recent commit message style
+
+## Step 2: Stage changes
+
+Stage all relevant changes. Prefer staging specific files rather than `git add -A`:
+- Do NOT stage files that contain secrets (.env, credentials, etc.)
+- Review what will be committed
+
+## Step 3: Create conventional commit
+
+Create a commit message following the Conventional Commits specification:
+
+**Format:** `<type>(<scope>): <description>`
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Code style (formatting, missing semi-colons, etc.)
+- `refactor`: Code change that neither fixes a bug nor adds a feature
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks, dependencies, configs
+
+**Rules:**
+- Keep the first line under 72 characters
+- Use imperative mood ("add" not "added")
+- Don't end with a period
+- Add body for complex changes explaining the "why"
+
+Example:
+```
+feat(match-types): add admin CRUD for match types/stipulations
+
+- Create backend Lambda handlers (GET, POST, PUT, DELETE)
+- Add MatchTypesTable to DynamoDB
+- Create ManageMatchTypes admin UI component
+- Add matchTypesApi to frontend services
+```
+
+## Step 4: Push to remote
+
+After committing, push to the current branch:
+
+```bash
+git push origin HEAD
+```
+
+If the branch has no upstream, use:
+
+```bash
+git push -u origin HEAD
+```
+
+## Step 5: Report result
+
+Provide a summary:
+- Commit hash
+- Branch name
+- Files changed
+- Link format: `https://github.com/jpDxsoloOrg/league_szn/commit/<hash>`

--- a/.agent/workflows/execute-plan.md
+++ b/.agent/workflows/execute-plan.md
@@ -1,0 +1,110 @@
+---
+description: Execute a plan from a markdown file by launching parallel agents, then verify and commit
+---
+Execute a plan from a markdown file by launching parallel agents, then verify and commit.
+
+## Arguments
+
+The user provides a plan filename (partial or full) as: `$ARGUMENTS`
+
+## Step 1: Find the plan file
+
+Search the project for a markdown file matching the provided filename:
+- Check exact path first (e.g., `plan.md`, `docs/my-plan.md`)
+- If not found, search `*.md` files in the project root, `docs/`, and `prompts/` directories for a filename containing the argument (case-insensitive)
+- The file MUST contain an `## Implementation Steps` section to be a valid plan
+
+If no match is found, list all `.md` files that contain `## Implementation Steps` and ask the user to clarify.
+
+If multiple matches are found, list them and ask the user to clarify.
+
+## Step 2: Parse the plan
+
+Read the plan file and extract:
+
+1. **Title**: The `# Plan:` heading
+2. **Files to Modify**: The table under `## Files to Modify`
+3. **Implementation Steps**: All `### Step N:` sections under `## Implementation Steps`
+4. **Dependencies & Order**: The `## Dependencies & Order` section — pay close attention to the **Suggested order** line (e.g., `Steps 1+5+7 -> Step 2 -> Steps 3+4 -> ...`)
+5. **Testing & Verification**: The `## Testing & Verification` section
+
+## Step 3: Build the execution schedule
+
+Using the **Dependencies & Order** section, organize steps into sequential **waves** of parallel work:
+
+- Each wave contains steps that can run concurrently (indicated by `+` in the suggested order)
+- Steps separated by `->` must run in sequential waves
+- **Maximum 5 agents per wave** — if a wave has more than 5 steps, split into sub-waves
+
+Example: If the suggested order is `Steps 1+5+7 -> Step 2 -> Steps 3+4 -> Step 6 -> Step 8`
+
+This becomes:
+- **Wave 1** (parallel): Steps 1, 5, 7
+- **Wave 2** (sequential): Step 2
+- **Wave 3** (parallel): Steps 3, 4
+- **Wave 4** (sequential): Step 6
+- **Wave 5** (sequential): Step 8
+
+Present the execution schedule to the user and wait for confirmation before proceeding.
+
+## Step 4: Execute each wave
+
+For each wave, launch up to 5 Task agents in parallel. Choose the best agent type for each step:
+
+### Agent type selection rules:
+
+| Step involves | Agent type | When to use |
+|---|---|---|
+| Backend Lambda handlers, DynamoDB, serverless.yml | `general-purpose` | Any backend code changes |
+| React components, hooks, contexts, CSS | `general-purpose` | Any frontend code changes |
+| Test files only | `test-engineer` | Writing or updating test files |
+| Refactoring / code restructuring | `refactor-expert` | Steps explicitly about refactoring |
+| i18n, config files, simple text changes | `general-purpose` with model `haiku` | Trivial changes like locale files, config |
+| Security-related changes | `security-auditor` | Auth, permissions, token handling |
+
+### Agent prompt template:
+
+Each agent MUST receive a prompt containing:
+1. **The full step description** copied from the plan (the `### Step N:` content)
+2. **The files to modify** relevant to that step (from the Files to Modify table)
+3. **Context**: The plan's Context section so the agent understands the bigger picture
+4. **Instruction to write code**: Explicitly tell the agent to implement the changes described
+5. **Codebase conventions**: Remind the agent — TypeScript, no `any`, follow existing patterns, use i18n for user-facing strings, use existing shared utilities
+
+### Between waves:
+
+After each wave completes, briefly review the results:
+- Confirm all agents reported success
+- If any agent failed or reported issues, pause and inform the user before continuing
+- Do NOT proceed to the next wave if a previous wave had failures
+
+## Step 5: Run verification
+
+After ALL waves complete successfully, invoke the `/verify` workflow to:
+1. Run frontend lint + tests
+2. Run backend lint + tests
+3. Report pass/fail results
+
+If verification fails:
+- Report the specific failures clearly
+- Attempt to fix lint errors and failing tests (up to 2 fix attempts)
+- Re-run verification after each fix attempt
+- If still failing after 2 attempts, stop and report to the user
+
+## Step 6: Commit and push
+
+If verification passes (all lint clean, all tests pass), invoke the `/commit` workflow to:
+1. Stage all changed files
+2. Create a conventional commit based on the plan title and changes
+3. Push to the current branch
+
+## Important Rules
+
+- **Always confirm the execution schedule** with the user before launching agents (Step 3)
+- **Never skip verification** — always run /verify before committing
+- **Fail fast** — if a wave fails, do not continue to the next wave
+- **Be transparent** — show the user which agents are running and what they're doing
+- **Respect dependencies** — never run a step before its dependencies are complete
+- **Max 5 parallel agents** — never exceed this limit per wave
+- **Use the right agent** — match agent types to the work being done (see selection rules)
+- **Include full context in agent prompts** — agents start fresh and need the plan context, file paths, and explicit instructions to write code

--- a/.agent/workflows/newIssue.md
+++ b/.agent/workflows/newIssue.md
@@ -1,0 +1,151 @@
+---
+description: Create a GitHub issue and execution plan, create branch, write plan file, commit, push, and open a PR
+---
+Create a GitHub issue and an execution plan for the user's request. The plan includes which skills and agents to use and how to run work in parallel.
+
+## Arguments
+
+The user provides the request as: `$ARGUMENTS`
+
+Example: `newIssue Add dark mode toggle to settings` or `newIssue Support tag team matches in the frontend`
+
+## Step 1: Create the GitHub issue
+
+Create an issue in the repository **jpDxsolo/league_szn**:
+
+- **Title**: Short, clear summary of the request (e.g. "Add dark mode toggle to settings").
+- **Body**: Expand the user's request into a proper issue description:
+  - **Summary**: What we want to achieve.
+  - **Acceptance criteria** (bullets): What "done" looks like.
+  - **Context**: Any relevant scope (e.g. frontend only, backend API, both).
+  - **Notes**: Optional constraints, links, or follow-ups.
+
+Use the GitHub MCP tool `issue_write` with `method: create`, `owner: jpDxsolo`, `repo: league_szn`.
+
+After creating, note the **issue number** for the plan.
+
+## Step 2: Research and draft the plan
+
+Using the same request and the issue body:
+
+1. **Scope the work**: Identify which parts of the codebase are affected (frontend, backend, docs, tests).
+2. **List relevant skills**: From the project's available skills, choose which apply and when:
+   - **api-documenter**: API or endpoint changes.
+   - **code-reviewer**: After implementation or for refactors.
+   - **dependency-auditor**: If adding or changing dependencies.
+   - **git-commit-helper**: When committing the change.
+   - **readme-updater**: If setup, structure, or features change.
+   - **secret-scanner**: If touching auth, env, or credentials.
+   - **security-auditor**: Auth, permissions, or security-sensitive code.
+   - **test-generator**: New or changed behavior that needs tests.
+3. **Identify parallel work**: Group tasks that have no dependency on each other (e.g. backend types + frontend types, or unrelated components) so they can be run in parallel by agents.
+
+## Step 3: Create branch and write the plan file
+
+### Step 3a: Create a new branch
+
+Before writing any files, create a new branch so the plan is committed on a dedicated branch:
+
+- Branch name: **feat/<issue_number>-<short-slug>** (e.g. `feat/152-wiki-german-raw-html`). Use **fix/** instead of **feat/** if the issue is clearly a bug fix.
+- Use the same **short-slug** you will use for the plan filename (kebab-case from the issue title).
+- Commands: `git checkout -b feat/<issue_number>-<short-slug>` (or `fix/...`).
+
+### Step 3b: Write the plan file
+
+Create a single plan file with a **unique name** that is not already in use. Use the path **docs/plans/plan-issue-<issue_number>-<short-slug>.md**, where <short-slug> is a kebab-case version of the issue title. Check existing files in `docs/plans/` to avoid duplicates. The plan must have this structure so it works with the **execute-plan** command and with skills/agents:
+
+```markdown
+# Plan: <Short title from the issue>
+
+**GitHub issue:** #<issue_number> — [title](https://github.com/jpDxsolo/league_szn/issues/<issue_number>)
+
+## Context
+
+Brief summary of the request and why it matters. One or two sentences.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review changed files |
+| Before commit | git-commit-helper | Conventional commit message |
+| If API changed | api-documenter | Update API docs |
+| … | … | … |
+
+Only include skills that actually apply to this request.
+
+## Agents and parallel work
+
+- **Suggested order**: List steps that can run in parallel with `+`, and order with `->`. Example: `Steps 1+2 -> Step 3 -> Steps 4+5`.
+- **Agent types**: For each step or group, suggest agent type (e.g. `general-purpose`, `test-engineer`, `security-auditor`) per the execute-plan rules.
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `path/to/file` | Modify / Create / Delete | What changes and why |
+
+Include every file that likely needs changes; add "TBD" where discovery is needed.
+
+## Implementation steps
+
+Numbered steps with enough detail for an agent (or human) to implement without extra context. Each step should:
+- Reference specific file paths (and line numbers if known).
+- Say what to change and why.
+- Follow existing project patterns.
+
+Use subsections if helpful, e.g. `### Step 1: …`, `### Step 2: …`.
+
+## Dependencies and order
+
+- Which steps depend on others.
+- **Suggested order**: Same as in "Agents and parallel work", e.g. `Steps 1+2 -> Step 3 -> Steps 4+5`.
+- This format is used by execute-plan to build waves of parallel agents.
+
+## Testing and verification
+
+- What to test manually.
+- What existing tests might be affected.
+- What new tests to add (and consider using **test-generator** skill).
+
+## Risks and edge cases
+
+Backward compatibility, config/env, or edge cases to watch for.
+```
+
+## Step 4: Commit, push, and open a pull request
+
+### Step 4a: Stage and commit
+
+1. Stage the plan file: `git add docs/plans/plan-issue-<issue_number>-<short-slug>.md`.
+2. Generate a conventional commit message (e.g. `docs: add plan for #<number> <short description>`).
+3. Run `git commit -m "<generated message>"`.
+
+### Step 4b: Push the branch and create a PR
+
+1. Push the branch: `git push -u origin feat/<issue_number>-<short-slug>` (or `fix/...`).
+2. Create a pull request using the GitHub MCP tool **create_pull_request**:
+   - **owner** / **repo**: `jpDxsolo`, `league_szn`.
+   - **title**: Short summary referencing the issue (e.g. `Add plan for #152 — wiki German raw HTML fix`).
+   - **head**: The branch you just pushed.
+   - **base**: `main`.
+   - **body**: Brief description and link to the issue.
+
+## Step 5: Report back
+
+Tell the user:
+
+1. **Issue**: Link to the new issue.
+2. **Plan**: Path to the plan file.
+3. **Branch**: Name of the branch created.
+4. **PR**: Link to the new pull request.
+5. **Next step**: "Run `/execute-plan` with this plan to implement it with parallel agents, or edit the plan file first and then run `/execute-plan`."
+
+## Important rules
+
+- **Always create** the GitHub issue, then a **new branch**, then the plan file, then **commit**, **push**, and **create a PR**.
+- **Branch before file**: Create the branch (Step 3a) before writing the plan file (Step 3b).
+- **Plan filename**: Use a unique name (e.g. `docs/plans/plan-issue-<number>-<slug>.md`). Do not overwrite an existing plan.
+- **Owner/repo**: Use the same owner and repo for all GitHub MCP calls.
+- **Plan format**: Keep "Implementation steps", "Files to modify", "Dependencies and order", and "Suggested order" so execute-plan and agents can use it.
+- **Skills and agents**: Only recommend skills and agent types that fit the request; use parallel work where steps are independent.

--- a/.agent/workflows/plan-todo.md
+++ b/.agent/workflows/plan-todo.md
@@ -1,0 +1,78 @@
+---
+description: Generate an implementation plan for a TODO item from TO-DOS.md — no code, just the plan
+---
+Generate an implementation plan for a TODO item from TO-DOS.md — no code, just the plan.
+
+## Arguments
+
+The user provides a partial or full TODO title as: `$ARGUMENTS`
+
+## Step 1: Find the TODO
+
+Read all TO-DOS.md files in the project (check project root and subdirectories like `frontend/`). Search for a TODO item matching the provided title (case-insensitive partial match is fine).
+
+If no match is found, list all available TODOs and ask the user to clarify.
+
+If multiple matches are found, list them and ask the user to clarify which one.
+
+## Step 2: Parse the TODO details
+
+Extract from the matched TODO:
+- **Title**: The bold text after the checkbox
+- **Problem**: The description of what's wrong or what needs to change
+- **Files**: The files that need to be modified
+- **Solution**: The proposed approach (if provided)
+
+## Step 3: Research the codebase
+
+Thoroughly explore all files referenced in the TODO and their surrounding context:
+- Read each file listed in the TODO
+- Understand the current implementation, types, patterns, and imports
+- Identify related files not listed in the TODO that may need changes (tests, types, routes, etc.)
+- Check how similar patterns are implemented elsewhere in the codebase for consistency
+- Note any dependencies, shared utilities, or conventions that the implementation should follow
+
+## Step 4: Generate the plan
+
+Write a `plan.md` file in the project root with the following structure:
+
+```markdown
+# Plan: <TODO Title>
+
+## Context
+Brief summary of the problem and why it needs to change.
+
+## Files to Modify
+List every file that needs changes, including ones discovered during research that weren't in the original TODO.
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `path/to/file` | Modify / Create / Delete | What changes and why |
+
+## Implementation Steps
+
+Numbered, ordered steps with enough detail that someone (or an agent) could follow them without further research. Each step should:
+- Reference specific file paths and line numbers
+- Describe WHAT to change (not the code itself, but the logic/structure)
+- Explain WHY (how it fits into the overall solution)
+- Note any existing patterns to follow for consistency
+
+## Dependencies & Order
+Call out which steps depend on others and suggest a logical order (e.g., types first, then backend, then frontend).
+
+## Testing & Verification
+- What to test manually
+- What existing tests might break
+- What new tests should be written
+
+## Risks & Edge Cases
+Anything that could go wrong, backward-compatibility concerns, or edge cases to handle.
+```
+
+## Important Rules
+
+- **Do NOT write any code.** No code snippets, no diffs, no implementation. Describe changes in plain language.
+- **Do NOT enter plan mode.** Write the plan.md file directly.
+- **Do NOT implement anything.** The output is only the plan.md file.
+- **Be specific.** Reference exact file paths, line numbers, function names, and type names discovered during research.
+- **Be complete.** Include every file that needs to change, even if the TODO didn't mention it (e.g., barrel exports, route definitions, test files).

--- a/.agent/workflows/todo.md
+++ b/.agent/workflows/todo.md
@@ -1,0 +1,48 @@
+---
+description: Implement a TODO item from TO-DOS.md by title
+---
+Implement a TODO item from TO-DOS.md by title.
+
+## Arguments
+
+The user provides a partial or full TODO title as: `$ARGUMENTS`
+
+## Step 1: Find the TODO
+
+Read all TO-DOS.md files in the project and search for a TODO item matching the provided title (case-insensitive partial match is fine).
+
+If no match is found, list all available TODOs and ask the user to clarify.
+
+If multiple matches are found, list them and ask the user to clarify which one.
+
+## Step 2: Parse the TODO details
+
+Extract from the matched TODO:
+- **Title**: The bold text after the checkbox
+- **Problem**: The description of what's wrong
+- **Files**: The files that need to be modified
+- **Solution**: The proposed approach
+
+## Step 3: Plan the implementation
+
+Design the implementation approach. Use the TODO's problem description, files list, and proposed solution as your starting point. Research the codebase as needed to understand the context.
+
+## Step 4: Implement the TODO
+
+After the plan is approved, implement the solution:
+- If both frontend and backend changes are needed, launch agents in parallel where possible
+- Follow existing code patterns in the codebase
+- Ensure TypeScript types are properly defined (no `any`)
+- Add appropriate error handling
+
+## Step 5: Run verification
+
+Once implementation is complete, invoke the `/verify` workflow to:
+1. Run lint and tests for frontend and backend
+2. If all pass, create a conventional commit
+
+## Step 6: Update TO-DOS.md
+
+If verify passes and a commit is created, update the TODO item in TO-DOS.md:
+- Change `- [ ]` to `- [x]` to mark it complete
+- Add a completion note with the date

--- a/.agent/workflows/verify-backend.md
+++ b/.agent/workflows/verify-backend.md
@@ -1,0 +1,16 @@
+---
+description: Run backend lint and unit tests in parallel
+---
+Run backend lint and unit tests in parallel.
+
+// turbo-all
+1. Run ESLint: `cd /home/jpdev/source/league_szn/league_szn/backend && npx eslint functions/ lib/`
+2. Run Vitest: `cd /home/jpdev/source/league_szn/league_szn/backend && npx vitest run`
+
+Run both commands in parallel. Report a summary of results: lint errors/warnings and test pass/fail counts.
+
+## Step 3: Commit if all passed
+
+If ALL of the above passed with zero errors and zero test failures, invoke the `/commit` workflow to create a conventional commit.
+
+If any step failed, do NOT commit. Instead, report the failures clearly so they can be fixed.

--- a/.agent/workflows/verify-frontend.md
+++ b/.agent/workflows/verify-frontend.md
@@ -1,0 +1,16 @@
+---
+description: Run frontend lint and unit tests in parallel
+---
+Run frontend lint and unit tests in parallel.
+
+// turbo-all
+1. Run ESLint on the frontend: `cd /home/jpdev/source/league_szn/league_szn/frontend && npx eslint src/`
+2. Run Vitest: `cd /home/jpdev/source/league_szn/league_szn/frontend && npx vitest run`
+
+Run both commands in parallel. Report a summary of results: lint errors/warnings and test pass/fail counts.
+
+## Step 3: Commit if all passed
+
+If ALL of the above passed with zero errors and zero test failures, invoke the `/commit` workflow to create a conventional commit.
+
+If any step failed, do NOT commit. Instead, report the failures clearly so they can be fixed.

--- a/.agent/workflows/verify.md
+++ b/.agent/workflows/verify.md
@@ -1,0 +1,24 @@
+---
+description: Run lint and unit tests for both frontend and backend, commit if all pass
+---
+Run lint and unit tests for both frontend and backend. If everything passes, create a conventional commit.
+
+## Step 1: Run all checks in parallel
+
+Run these four commands in parallel:
+
+// turbo-all
+1. Frontend ESLint: `cd /home/jpdev/source/league_szn/league_szn/frontend && npx eslint src/`
+2. Frontend Vitest: `cd /home/jpdev/source/league_szn/league_szn/frontend && npx vitest run`
+3. Backend ESLint: `cd /home/jpdev/source/league_szn/league_szn/backend && npx eslint functions/ lib/`
+4. Backend Vitest: `cd /home/jpdev/source/league_szn/league_szn/backend && npx vitest run`
+
+## Step 2: Report results
+
+Summarize: frontend lint errors/warnings, frontend test pass/fail counts, backend lint errors/warnings, backend test pass/fail counts.
+
+## Step 3: Commit if all passed
+
+If ALL of the above passed with zero errors and zero test failures, invoke the `/commit` workflow to create a conventional commit.
+
+If any step failed, do NOT commit. Instead, report the failures clearly so they can be fixed.

--- a/.claude/commands/doIssue.md
+++ b/.claude/commands/doIssue.md
@@ -1,0 +1,91 @@
+Take an issue number, fetch the issue from GitHub, create a branch and an execution plan, run the plan with parallel agents, then commit, push, and open a PR.
+
+## Arguments
+
+The user provides a GitHub issue number as: `$ARGUMENTS`
+
+Example: `doIssue 128` or `doIssue 152`
+
+## Step 1: Get the issue from GitHub
+
+Fetch the issue from **jpDxsolo/league_szn**:
+
+- Use the GitHub MCP tool **issue_read** with `method: get`, `owner: jpDxsolo`, `repo: league_szn`, `issue_number: <from $ARGUMENTS>`.
+- If the issue does not exist or is not accessible, report the error and stop.
+- Note the **title** and **body** for the plan. Derive a **short-slug** from the title (kebab-case, e.g. "Add wiki and Help section" → `wiki-help-section`). Use this slug for the branch and plan filename.
+
+## Step 2: Create the branch
+
+Create a new branch **before** writing any files:
+
+- Branch name: **feat/&lt;issue_number&gt;-&lt;short-slug&gt;** (e.g. `feat/128-wiki-help-section`). Use **fix/** if the issue is clearly a bug fix.
+- Ensure the repo is on `main` (or default branch), then run: `git checkout -b feat/<issue_number>-<short-slug>` (or `fix/...`).
+- If the branch already exists locally, check it out; if it exists remotely, fetch and check it out. The goal is to work on the branch that will hold the implementation.
+
+## Step 3: Research and draft the plan
+
+Using the issue title and body:
+
+1. **Scope the work**: Identify which parts of the codebase are affected (frontend, backend, docs, tests).
+2. **List relevant skills**: From the project's available skills, choose which apply and when (api-documenter, code-reviewer, dependency-auditor, git-commit-helper, readme-updater, secret-scanner, security-auditor, test-generator).
+3. **Identify parallel work**: Group tasks that have no dependency on each other so they can run in parallel (e.g. `Steps 1+2 -> Step 3 -> Steps 4+5`).
+
+## Step 4: Write the plan file
+
+Create a single plan file with a **unique name**. Use the path **docs/plans/plan-issue-&lt;issue_number&gt;-&lt;short-slug&gt;.md**. If that path already exists, use a unique variant (e.g. append `-do` or a short suffix) and ensure the filename is not already in use under `docs/plans/`. The plan must match the structure required by the **execute-plan** command:
+
+- **# Plan:** &lt;Short title from the issue&gt;
+- **GitHub issue:** #&lt;number&gt; — [title](link)
+- **Context** (brief summary)
+- **Skills to use** (table: When | Skill | Purpose)
+- **Agents and parallel work** (Suggested order with `+` and `->`; agent types per step)
+- **Files to modify** (table: File | Action | Purpose)
+- **Implementation steps** (numbered `### Step N:` with enough detail for an agent to implement)
+- **Dependencies and order** (including **Suggested order** line for execute-plan waves)
+- **Testing and verification**
+- **Risks and edge cases**
+
+Follow the same template and conventions as in **.claude/commands/newIssue.md** (Step 3b) so execute-plan can parse and run the plan.
+
+## Step 5: Execute the plan
+
+Execute the plan you just wrote by following the **execute-plan** command (**.claude/commands/execute-plan.md**):
+
+1. **Find the plan file**: Use the path created in Step 4 (e.g. `docs/plans/plan-issue-128-wiki-help-section.md`).
+2. **Parse the plan**: Extract Title, Files to Modify, Implementation Steps, Dependencies and order (or "Dependencies & Order"), Testing and verification.
+3. **Build the execution schedule**: Turn the suggested order into waves of parallel work (max 5 agents per wave). Present the schedule to the user and proceed (or wait for explicit "go" if you prefer to confirm).
+4. **Execute each wave**: For each wave, run the steps in parallel using the agent type rules from execute-plan. Between waves, confirm success before continuing; if any step fails, pause and report.
+5. **Run verification**: After all waves complete, run frontend and backend lint and tests (invoke the project’s verify step or equivalent). Fix lint/test failures up to a reasonable number of attempts (e.g. 2), then re-run verification.
+6. **Commit and push**: If verification passes, stage all changes, create a conventional commit (use **git-commit-helper** skill when available), and push the current branch.
+
+Do not create a PR in this step; Step 6 handles the PR.
+
+## Step 6: Create the pull request
+
+After the branch is pushed successfully:
+
+- Use the GitHub MCP tool **create_pull_request**:
+  - **owner**: `jpDxsolo`
+  - **repo**: `league_szn`
+  - **title**: Short summary referencing the issue (e.g. `Implements #128 — Add wiki and Help section`)
+  - **head**: The branch you pushed (e.g. `feat/128-wiki-help-section`)
+  - **base**: `main`
+  - **body**: Brief description of what was implemented and link to the issue (e.g. `Closes #128. Implements [issue title].`).
+
+## Step 7: Report back
+
+Tell the user:
+
+1. **Issue**: Link to the issue (e.g. `https://github.com/jpDxsolo/league_szn/issues/<number>`).
+2. **Plan**: Path to the plan file.
+3. **Branch**: Name of the branch.
+4. **PR**: Link to the new pull request.
+5. **Summary**: What was implemented (brief).
+
+## Important rules
+
+- **Branch before plan**: Create the branch (Step 2) before writing the plan file (Step 4).
+- **Plan format**: Use the same structure as newIssue/execute-plan (Implementation steps, Files to modify, Dependencies and order, Suggested order) so execute-plan can run it.
+- **Unique plan name**: Use `docs/plans/plan-issue-<number>-<slug>.md`; if that file already exists, use a unique variant so you do not overwrite an unrelated plan.
+- **Owner/repo**: Use `owner: jpDxsolo`, `repo: league_szn` for all GitHub MCP calls.
+- **Execute-plan rules**: When running Step 5, follow execute-plan’s rules (max 5 agents per wave, fail fast, verify before commit, use git-commit-helper for the final commit when available).

--- a/.cursor/rules/doIssue.mdc
+++ b/.cursor/rules/doIssue.mdc
@@ -1,0 +1,17 @@
+---
+description: When user invokes doIssue with an issue number, fetch the issue, create branch and plan, execute plan with parallel agents, then commit, push, and open a PR
+alwaysApply: true
+---
+
+# doIssue command
+
+When the user says **doIssue** (or "do issue") and provides a **GitHub issue number**, run the **doIssue** workflow:
+
+1. **Get the issue** from **jpDxsolo/league_szn** using the GitHub MCP (issue_read, method: get).
+2. **Create a branch** (e.g. `feat/<issue_number>-<short-slug>`) before writing any plan file.
+3. **Create docs/plans/plan-issue-&lt;number&gt;-&lt;slug&gt;.md** with a unique name, using the issue title and body to draft the plan (skills, agents and parallel work, implementation steps, dependencies, testing, risks).
+4. **Execute the plan** using the same process as **execute-plan**: find the plan, parse it, build waves of parallel work, run each wave (max 5 agents per wave), verify (lint + tests), then commit (use git-commit-helper) and push.
+5. **Create a pull request** targeting `main` with a title and body that reference the issue (e.g. Closes #&lt;number&gt;).
+6. **Report back** with the issue link, plan path, branch, PR link, and a short summary.
+
+Follow the full instructions in **.claude/commands/doIssue.md** (read that file and execute each step). The plan format must match what **execute-plan** expects so the execution phase can run correctly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,6 +456,8 @@ aws cloudformation describe-stacks --stack-name wwe-2k-league-api-devtest \
 - `feat/*` - New features
 - `fix/*` - Bug fixes
 
+**Commands:** **newIssue** (create issue + plan, branch, commit, push, PR); **doIssue &lt;number&gt;** (fetch issue, create branch + plan, execute plan with parallel agents, commit, push, PR); **execute-plan** (run a plan file with parallel agents, then verify and commit/push). See `.claude/commands/` and `docs/plans/README.md`.
+
 Current active branches:
 - `feat/admin_front_end` - Admin panel implementation
 

--- a/backend/functions/dashboard/getDashboard.ts
+++ b/backend/functions/dashboard/getDashboard.ts
@@ -1,0 +1,222 @@
+import type { APIGatewayProxyHandler } from 'aws-lambda';
+import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { success, serverError } from '../../lib/response';
+
+interface DashboardChampion {
+    championshipId: string;
+    championshipName: string;
+    championName: string;
+    championImageUrl?: string;
+    playerId: string;
+    wonDate?: string;
+    defenses?: number;
+}
+
+interface DashboardEvent {
+    eventId: string;
+    name: string;
+    date: string;
+    eventType: string;
+    venue?: string;
+    matchCount?: number;
+}
+
+interface DashboardMatch {
+    matchId: string;
+    date: string;
+    matchType: string;
+    winnerName: string;
+    winnerImageUrl?: string;
+    loserName: string;
+    loserImageUrl?: string;
+    championshipName?: string;
+}
+
+interface DashboardSeason {
+    seasonId: string;
+    name: string;
+    startDate?: string;
+    endDate?: string;
+    status: string;
+    matchesPlayed?: number;
+}
+
+interface DashboardQuickStats {
+    totalPlayers: number;
+    totalMatches: number;
+    activeChampionships: number;
+    mostWinsPlayer?: { name: string; wins: number };
+}
+
+interface DashboardResponse {
+    currentChampions: DashboardChampion[];
+    upcomingEvents: DashboardEvent[];
+    recentResults: DashboardMatch[];
+    seasonInfo: DashboardSeason | null;
+    quickStats: DashboardQuickStats;
+    activeChallengesCount: number;
+}
+
+export const handler: APIGatewayProxyHandler = async () => {
+    try {
+        // Fetch all data in parallel
+        const [
+            championships,
+            players,
+            events,
+            seasons,
+            matches,
+            challenges,
+        ] = await Promise.all([
+            dynamoDb.scanAll({ TableName: TableNames.CHAMPIONSHIPS }),
+            dynamoDb.scanAll({ TableName: TableNames.PLAYERS }),
+            dynamoDb.scanAll({ TableName: TableNames.EVENTS }),
+            dynamoDb.scanAll({ TableName: TableNames.SEASONS }),
+            dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
+            dynamoDb.scanAll({ TableName: TableNames.CHALLENGES }),
+        ]);
+
+        // Build a player lookup map
+        const playerMap = new Map<string, Record<string, unknown>>();
+        for (const p of players) {
+            playerMap.set(p.playerId as string, p);
+        }
+
+        // --- Current Champions ---
+        const currentChampions: DashboardChampion[] = (championships as Record<string, unknown>[])
+            .filter((c) => c.isActive !== false && c.currentChampion)
+            .map((c) => {
+                const player = playerMap.get(c.currentChampion as string);
+                return {
+                    championshipId: c.championshipId as string,
+                    championshipName: c.name as string,
+                    championName: player ? (player.name as string) : 'Unknown',
+                    championImageUrl: player ? (player.imageUrl as string | undefined) : undefined,
+                    playerId: c.currentChampion as string,
+                    wonDate: c.wonDate as string | undefined,
+                    defenses: c.defenses as number | undefined,
+                };
+            });
+
+        // --- Upcoming Events ---
+        const now = new Date().toISOString();
+        const upcomingEvents: DashboardEvent[] = (events as Record<string, unknown>[])
+            .filter((e) => e.status === 'upcoming' && (e.date as string) >= now)
+            .sort((a, b) => (a.date as string).localeCompare(b.date as string))
+            .slice(0, 3)
+            .map((e) => ({
+                eventId: e.eventId as string,
+                name: e.name as string,
+                date: e.date as string,
+                eventType: e.eventType as string,
+                venue: e.venue as string | undefined,
+                matchCount: Array.isArray(e.matches) ? e.matches.length : undefined,
+            }));
+
+        // --- Recent Results ---
+        const completedMatches = (matches as Record<string, unknown>[])
+            .filter((m) => m.status === 'completed' && m.date)
+            .sort((a, b) => (b.date as string).localeCompare(a.date as string))
+            .slice(0, 5);
+
+        const recentResults: DashboardMatch[] = completedMatches.map((m) => {
+            const winners = (Array.isArray(m.winners) ? m.winners : [m.winnerId]) as string[];
+            const participants = (m.participants as string[]) || [];
+            const losers = participants.filter((p) => !winners.includes(p));
+
+            const winnerPlayer = playerMap.get(winners[0]);
+            const loserPlayer = playerMap.get(losers[0]);
+
+            // Look up championship name if this was a title match
+            let championshipName: string | undefined;
+            if (m.championshipId) {
+                const champ = championships.find(
+                    (c) => (c as Record<string, unknown>).championshipId === m.championshipId
+                );
+                if (champ) {
+                    championshipName = (champ as Record<string, unknown>).name as string;
+                }
+            }
+
+            return {
+                matchId: m.matchId as string,
+                date: m.date as string,
+                matchType: m.matchType as string,
+                winnerName: winnerPlayer ? (winnerPlayer.name as string) : 'Unknown',
+                winnerImageUrl: winnerPlayer ? (winnerPlayer.imageUrl as string | undefined) : undefined,
+                loserName: loserPlayer ? (loserPlayer.name as string) : 'Unknown',
+                loserImageUrl: loserPlayer ? (loserPlayer.imageUrl as string | undefined) : undefined,
+                championshipName,
+            };
+        });
+
+        // --- Season Info ---
+        const activeSeason = (seasons as Record<string, unknown>[]).find(
+            (s) => s.status === 'active'
+        );
+
+        let seasonInfo: DashboardSeason | null = null;
+        if (activeSeason) {
+            const seasonMatches = (matches as Record<string, unknown>[]).filter(
+                (m) => m.seasonId === activeSeason.seasonId && m.status === 'completed'
+            );
+            seasonInfo = {
+                seasonId: activeSeason.seasonId as string,
+                name: activeSeason.name as string,
+                startDate: activeSeason.startDate as string | undefined,
+                endDate: activeSeason.endDate as string | undefined,
+                status: activeSeason.status as string,
+                matchesPlayed: seasonMatches.length,
+            };
+        }
+
+        // --- Quick Stats ---
+        const activeChampionships = (championships as Record<string, unknown>[]).filter(
+            (c) => c.isActive !== false
+        );
+
+        const completedMatchCount = (matches as Record<string, unknown>[]).filter(
+            (m) => m.status === 'completed'
+        ).length;
+
+        // Find player with most wins
+        let mostWinsPlayer: { name: string; wins: number } | undefined;
+        if (players.length > 0) {
+            const sorted = [...(players as Record<string, unknown>[])].sort(
+                (a, b) => ((b.wins as number) || 0) - ((a.wins as number) || 0)
+            );
+            if (sorted[0] && ((sorted[0].wins as number) || 0) > 0) {
+                mostWinsPlayer = {
+                    name: sorted[0].name as string,
+                    wins: sorted[0].wins as number,
+                };
+            }
+        }
+
+        const quickStats: DashboardQuickStats = {
+            totalPlayers: players.length,
+            totalMatches: completedMatchCount,
+            activeChampionships: activeChampionships.length,
+            mostWinsPlayer,
+        };
+
+        // --- Active Challenges Count ---
+        const activeChallengesCount = (challenges as Record<string, unknown>[]).filter(
+            (c) => c.status === 'pending'
+        ).length;
+
+        const response: DashboardResponse = {
+            currentChampions,
+            upcomingEvents,
+            recentResults,
+            seasonInfo,
+            quickStats,
+            activeChallengesCount,
+        };
+
+        return success(response);
+    } catch (err) {
+        console.error('Dashboard error:', err);
+        return serverError('Failed to load dashboard data');
+    }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -325,6 +325,15 @@ functions:
           cors: *corsConfig
           authorizer: adminAuthorizer
 
+  # Dashboard
+  getDashboard:
+    handler: functions/dashboard/getDashboard.handler
+    events:
+      - http:
+          path: dashboard
+          method: get
+          cors: *corsConfig
+
   # Standings
   getStandings:
     handler: functions/standings/getStandings.handler

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,8 +1,9 @@
 # Execution plans
 
-Plans created by the **newIssue** command are written with unique names in this directory (e.g. `plan-issue-150-wiki-admin-guide.md`), per CLAUDE.md.
+Plans are written with unique names in this directory (e.g. `plan-issue-150-wiki-admin-guide.md`), per CLAUDE.md.
 
-- **newIssue**: Creates a GitHub issue and a plan file `docs/plans/plan-issue-<number>-<slug>.md` with skills, agents, and parallel work.
-- **execute-plan**: Runs a plan by executing implementation steps in waves (parallel agents where the plan allows).
+- **newIssue**: Creates a GitHub issue and a plan file `docs/plans/plan-issue-<number>-<slug>.md` with skills, agents, and parallel work. Then commit, push, and open a PR for the plan.
+- **doIssue**: Takes an issue number, fetches the issue from GitHub, creates a branch and plan file, **executes** the plan with parallel agents (execute-plan), then commit, push, and open a PR for the implementation.
+- **execute-plan**: Runs a plan by executing implementation steps in waves (parallel agents where the plan allows). Use after newIssue to implement, or as the execution phase inside doIssue.
 
-Edit the plan file as needed, then run the execute-plan command to implement.
+Edit the plan file as needed, then run the execute-plan command to implement. Or run **doIssue &lt;number&gt;** to do an existing issue end-to-end.

--- a/docs/plans/plan-issue-165-news-feed-activity-timeline.md
+++ b/docs/plans/plan-issue-165-news-feed-activity-timeline.md
@@ -1,0 +1,164 @@
+# Plan: News Feed / Activity Timeline
+
+**GitHub Issue**: [#165](https://github.com/jpDxsoloOrg/league_szn/issues/165)
+
+## Context
+
+There is no central "what's happening" view. Users must visit separate pages to discover recent activity. This feature creates a combined activity feed on the home page that aggregates recent events across all features into a timeline, with type-specific icons, pagination, and optional type filtering.
+
+### Tables Read (all read-only)
+- **Matches** (PK: matchId, SK: date) — completed matches
+- **ChampionshipHistory** (PK: championshipId, SK: wonDate) — title changes
+- **Seasons** (PK: seasonId) — season started/ended
+- **Tournaments** (PK: tournamentId) — tournament results
+- **Challenges** (PK: challengeId) — challenges issued/accepted/completed
+- **Promos** (PK: promoId) — new promos posted
+
+### Skills to use
+- general-purpose (backend + frontend code)
+- test-engineer (unit tests)
+
+## Files to Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `backend/functions/activity/getActivity.ts` | NEW | Lambda handler: scan tables, merge, sort, paginate |
+| `backend/functions/activity/handler.ts` | NEW | Consolidated handler routing GET /activity |
+| `backend/functions/activity/__tests__/getActivity.test.ts` | NEW | Unit tests for getActivity handler |
+| `backend/serverless.yml` | MODIFY | Add `activity` function with GET /activity route |
+| `frontend/src/types/index.ts` | MODIFY | Add `ActivityItem` type |
+| `frontend/src/services/api/activity.api.ts` | NEW | API client for activity endpoint |
+| `frontend/src/services/api/index.ts` | MODIFY | Export `activityApi` |
+| `frontend/src/components/ActivityFeed.tsx` | NEW | Activity feed component with cards, icons, load-more |
+| `frontend/src/components/ActivityFeed.css` | NEW | Styles for the activity feed |
+| `frontend/src/App.tsx` | MODIFY | Add `/activity` route, add feed to home page |
+| `frontend/src/i18n/locales/en.json` | MODIFY | Add `activity` translation keys |
+| `frontend/src/i18n/locales/de.json` | MODIFY | Add `activity` translation keys (German) |
+| `frontend/src/components/Sidebar.tsx` | MODIFY | Add Activity Feed nav link |
+| `frontend/src/components/TopNav.tsx` | MODIFY | Add Activity Feed nav link |
+
+## Implementation Steps
+
+### Step 1: Backend — getActivity handler
+
+Create `backend/functions/activity/getActivity.ts`:
+
+- Accept query params: `?limit=20&cursor=<ISO-timestamp>&type=match|championship|challenge|promo|tournament|season`
+- Scan/query each table (Matches with status=completed, ChampionshipHistory, Challenges, Promos, Tournaments, Seasons) using `dynamoDb.scanAll()`
+- Map each item to a unified `ActivityItem` shape: `{ id, type, timestamp, summary, metadata }` where:
+  - `type`: `match_result` | `championship_change` | `season_event` | `tournament_result` | `challenge_event` | `promo_posted`
+  - `timestamp`: ISO string from the relevant date field
+  - `summary`: brief text description (e.g. "Match completed: Player A def. Player B")
+  - `metadata`: type-specific data (matchId, participants, winners, championshipId, etc.)
+- Sort all items by timestamp descending
+- Apply cursor-based pagination: filter items with timestamp < cursor, take first `limit` items
+- If `type` filter provided, only scan the relevant table(s)
+- Return `{ items: ActivityItem[], nextCursor: string | null }`
+- Use existing `dynamoDb` helper from `lib/dynamodb.ts` and `success`/`serverError` from `lib/response.ts`
+
+### Step 2: Backend — handler.ts and serverless.yml
+
+Create `backend/functions/activity/handler.ts`:
+- Route GET requests to `getActivity` handler (follows existing pattern from `matches/handler.ts`)
+
+Modify `backend/serverless.yml`:
+- Add `activity` function definition under `functions:` section
+- Route: `GET /activity` with CORS, no auth required (public endpoint)
+- Needs env vars for all tables it reads (already available globally in provider.environment)
+
+### Step 3: Backend tests — getActivity
+
+Create `backend/functions/activity/__tests__/getActivity.test.ts`:
+- Mock `dynamoDb.scanAll` for each table
+- Test: returns merged and sorted activity items
+- Test: respects `limit` param
+- Test: cursor-based pagination
+- Test: `type` filter only scans relevant table
+- Test: returns 500 on DynamoDB failure
+- Test: returns empty items when no data
+- Follow exact same patterns from `getMatches.test.ts` (vitest, vi.hoisted, vi.mock)
+
+### Step 4: Frontend — Types and API service
+
+Modify `frontend/src/types/index.ts`:
+- Add `ActivityItem` interface with `id`, `type`, `timestamp`, `summary`, `metadata`
+- Add `ActivityFeedResponse` interface with `items` and `nextCursor`
+
+Create `frontend/src/services/api/activity.api.ts`:
+- Export `activityApi.getAll(params?: { limit?: number; cursor?: string; type?: string })` using `fetchWithAuth`
+- Follow pattern from `matches.api.ts`
+
+Modify `frontend/src/services/api/index.ts`:
+- Add `export { activityApi } from './activity.api'`
+
+### Step 5: Frontend — ActivityFeed component
+
+Create `frontend/src/components/ActivityFeed.tsx`:
+- Fetch activity data using `activityApi.getAll()`
+- Display activity cards with type-specific icons (⚔️ match, 🏆 championship, 📅 season, 🏅 tournament, 🤝 challenge, 🎤 promo)
+- Each card shows: icon, summary text, relative timestamp ("X minutes ago"), link to details page
+- "Load More" button for pagination (sends cursor to API)
+- Optional filter tabs by activity type
+- Use `useTranslation()` for all user-facing strings
+- Loading and error states
+
+Create `frontend/src/components/ActivityFeed.css`:
+- Card layout with icon, text, timestamp
+- Responsive: full-width timeline on mobile, constrained on desktop
+- Type-specific accent colors
+- Hover effects and smooth transitions
+
+### Step 6: Frontend — Routing and Navigation
+
+Modify `frontend/src/App.tsx`:
+- Add route `<Route path="/activity" element={<ActivityFeed />} />`
+- Import ActivityFeed component
+
+Modify `frontend/src/components/Sidebar.tsx`:
+- Add "Activity" nav item linking to `/activity` under the League group
+
+Modify `frontend/src/components/TopNav.tsx`:
+- Add "Activity" nav item in the core navigation group
+
+### Step 7: i18n translations
+
+Modify `frontend/src/i18n/locales/en.json`:
+- Add `activity` section with keys: `title`, `loading`, `noActivity`, `loadMore`, `filters.*`, `types.*`, `timeAgo.*`
+
+Modify `frontend/src/i18n/locales/de.json`:
+- Add corresponding German translations for the `activity` section
+
+## Dependencies & Order
+
+- Step 1 has no dependencies (standalone backend)
+- Step 2 depends on Step 1 (handler wraps getActivity, serverless defines the route)
+- Step 3 depends on Step 1 (tests the getActivity handler)
+- Step 4 has no backend dependency (defines types and API client)
+- Step 5 depends on Step 4 (uses types and API client)
+- Step 6 depends on Step 5 (routes and nav reference the component)
+- Step 7 has no code dependencies (i18n keys only)
+
+**Suggested order**: Steps 1+4+7 -> Steps 2+3 -> Step 5 -> Step 6
+
+## Testing & Verification
+
+### Automated Tests
+
+1. **Backend unit tests**: `cd backend && npx vitest run functions/activity`
+   - Verifies getActivity handler logic (merge, sort, paginate, filter, error handling)
+2. **Backend lint**: `cd backend && npx eslint functions/activity/ lib/`
+3. **Frontend lint**: `cd frontend && npx eslint src/`
+4. **Full test suite**: `cd backend && npx vitest run && cd ../frontend && npx vitest run`
+
+### Manual Verification
+- Start local dev environment and navigate to `/activity` to confirm the feed renders
+- Verify "Load More" pagination works
+- Verify filter tabs filter by activity type
+- Verify nav links appear in both sidebar and top nav modes
+
+## Risks & Edge Cases
+
+1. **Performance**: Scanning 6 tables on every request could be slow. Mitigated by limiting results with `limit` param (default 20) and using cursor pagination so only items older than the cursor need consideration.
+2. **Empty tables**: Handler must handle tables with zero items gracefully.
+3. **Missing player names**: Activity items reference playerIds — the frontend will need to resolve names. We'll include player names in the metadata at the backend level so the frontend doesn't need additional lookups.
+4. **Large datasets**: Using `scanAll` could be expensive for very large tables. For MVP this is acceptable; a future optimization would add GSIs or a dedicated activity table.

--- a/docs/plans/plan-issue-167-dashboard-league-overview.md
+++ b/docs/plans/plan-issue-167-dashboard-league-overview.md
@@ -1,0 +1,271 @@
+# Plan: Dashboard / League Overview Page
+
+**GitHub Issue:** [#167](https://github.com/jpDxsoloOrg/league_szn/issues/167)
+
+**Context:** The landing page currently shows only the Standings table. This feature adds a rich Dashboard page with current champions, upcoming events, recent results, season progress, quick stats, and active challenges. The Dashboard becomes the new `/` route; Standings moves to `/standings` only.
+
+**Skills:** general-purpose (backend + frontend), test-engineer
+
+---
+
+## Proposed Changes
+
+### Backend — New Dashboard Lambda
+
+#### [NEW] [getDashboard.ts](file:///home/jpdev/source/league_szn/league_szn/backend/functions/dashboard/getDashboard.ts)
+
+New `GET /dashboard` handler that aggregates data from multiple tables in one call:
+- **Current Champions** — Scan Championships table, filter `isActive !== false` and `currentChampion` not null, join with Players for names/images
+- **Upcoming Events** — Query Events table via StatusIndex (`status=upcoming`), sort by date asc, limit 3
+- **Recent Results** — Query Matches table for `status=completed`, sort by date desc, limit 5, join with Players for names
+- **Season Info** — Scan Seasons table, find the active season (`status=active`)
+- **Quick Stats** — From match data: most wins (player with most wins in active season via SeasonStandings), longest active win streak (compute from recent matches), newest champion
+- **Active Challenges Count** — Query Challenges table for `status=pending`, return count
+
+Returns a single JSON object with all sections.
+
+#### [MODIFY] [serverless.yml](file:///home/jpdev/source/league_szn/league_szn/backend/serverless.yml)
+
+Add new `getDashboard` function entry:
+```yaml
+getDashboard:
+  handler: functions/dashboard/getDashboard.handler
+  events:
+    - http:
+        path: dashboard
+        method: get
+        cors: *corsConfig
+```
+
+---
+
+### Frontend — Types
+
+#### [MODIFY] [index.ts](file:///home/jpdev/source/league_szn/league_szn/frontend/src/types/index.ts)
+
+Add `DashboardData` interface:
+```typescript
+export interface DashboardData {
+  currentChampions: DashboardChampion[];
+  upcomingEvents: DashboardEvent[];
+  recentResults: DashboardMatch[];
+  seasonInfo: DashboardSeason | null;
+  quickStats: DashboardQuickStats;
+  activeChallengesCount: number;
+}
+```
+Plus sub-types: `DashboardChampion`, `DashboardEvent`, `DashboardMatch`, `DashboardSeason`, `DashboardQuickStats`.
+
+---
+
+### Frontend — API Service
+
+#### [NEW] [dashboard.api.ts](file:///home/jpdev/source/league_szn/league_szn/frontend/src/services/api/dashboard.api.ts)
+
+```typescript
+export const dashboardApi = {
+  get: async (signal?: AbortSignal): Promise<DashboardData> => {
+    return fetchWithAuth(`${API_BASE_URL}/dashboard`, {}, signal);
+  },
+};
+```
+
+#### [MODIFY] [index.ts](file:///home/jpdev/source/league_szn/league_szn/frontend/src/services/api/index.ts)
+
+Add `export { dashboardApi } from './dashboard.api';`
+
+---
+
+### Frontend — Dashboard Component
+
+#### [NEW] [Dashboard.tsx](file:///home/jpdev/source/league_szn/league_szn/frontend/src/components/Dashboard.tsx)
+
+Page component with responsive card grid:
+- **Champions Strip** — Horizontal scrollable cards with belt images and champion names
+- **Upcoming Events** — Cards with event name, date, countdown timer
+- **Recent Results** — Compact match result cards (winner, loser, match type)
+- **Season Progress** — Current season name, start date, match count, visual progress bar
+- **Quick Stats** — Big-number callout cards (most wins, longest streak, newest champ)
+- **Active Challenges** — Count badge with "View All" link to `/challenges`
+- Uses `useTranslation` for i18n, `useEffect`/`useState` for data fetching with abort controller
+- Loading skeleton and error state handling
+
+#### [NEW] [Dashboard.css](file:///home/jpdev/source/league_szn/league_szn/frontend/src/components/Dashboard.css)
+
+Responsive grid layout using existing CSS variable patterns (`--gold`, `--bg-card`, etc.)
+
+---
+
+### Frontend — Route & Navigation Changes
+
+#### [MODIFY] [App.tsx](file:///home/jpdev/source/league_szn/league_szn/frontend/src/App.tsx)
+
+- Import new `Dashboard` component
+- Change `<Route path="/" element={<Standings />} />` → `<Route path="/" element={<Dashboard />} />`
+- Add `<Route path="/standings" element={<Standings />} />`
+
+#### [MODIFY] [navConfig.ts](file:///home/jpdev/source/league_szn/league_szn/frontend/src/config/navConfig.ts)
+
+- Change `{ path: '/', i18nKey: 'nav.standings' }` → `{ path: '/', i18nKey: 'nav.dashboard' }`
+- Add `{ path: '/standings', i18nKey: 'nav.standings' }` after Dashboard
+- Update `getUserGroupForPath` to include `/standings` in core paths
+
+---
+
+### i18n
+
+#### [MODIFY] [en.json](file:///home/jpdev/source/league_szn/league_szn/frontend/src/i18n/locales/en.json)
+
+Add keys:
+```json
+"nav.dashboard": "Dashboard",
+"dashboard.title": "League Overview",
+"dashboard.champions": "Current Champions",
+"dashboard.upcomingEvents": "Upcoming Events",
+"dashboard.recentResults": "Recent Results",
+"dashboard.seasonProgress": "Season Progress",
+"dashboard.quickStats": "Quick Stats",
+"dashboard.activeChallenges": "Active Challenges",
+"dashboard.viewAll": "View All",
+"dashboard.noChampions": "No active champions",
+"dashboard.noUpcomingEvents": "No upcoming events",
+"dashboard.noRecentResults": "No recent results",
+"dashboard.noActiveSeason": "No active season",
+"dashboard.mostWins": "Most Wins",
+"dashboard.longestStreak": "Longest Win Streak",
+"dashboard.newestChampion": "Newest Champion",
+"dashboard.matchesPlayed": "Matches Played",
+"dashboard.seasonStart": "Season Start",
+"dashboard.daysIn": "days in",
+"dashboard.countdown.days": "d",
+"dashboard.countdown.hours": "h",
+"dashboard.countdown.minutes": "m",
+"dashboard.vs": "vs",
+"dashboard.def": "def."
+```
+
+#### [MODIFY] [de.json](file:///home/jpdev/source/league_szn/league_szn/frontend/src/i18n/locales/de.json)
+
+German translations for all dashboard keys.
+
+---
+
+### Backend Tests
+
+#### [NEW] [getDashboard.test.ts](file:///home/jpdev/source/league_szn/league_szn/backend/functions/dashboard/__tests__/getDashboard.test.ts)
+
+Following the existing pattern in `getStandings-allTime.test.ts`:
+- Mock `dynamoDb` and `TableNames`
+- Test: returns 200 with all dashboard sections
+- Test: handles empty tables gracefully
+- Test: returns correct current champions (only active with champion)
+- Test: limits upcoming events to 3
+- Test: limits recent results to 5
+- Test: returns 500 on DynamoDB error
+
+---
+
+### Frontend Tests
+
+#### [NEW] [Dashboard.test.tsx](file:///home/jpdev/source/league_szn/league_szn/frontend/src/components/__tests__/Dashboard.test.tsx)
+
+Following existing patterns (e.g., `Standings.test.tsx`):
+- Test: renders loading skeleton initially
+- Test: renders all dashboard sections after data loads
+- Test: renders empty states when no data
+- Test: handles API error gracefully
+
+---
+
+## Files to Modify
+
+| File | Action | Component |
+|------|--------|-----------|
+| `backend/functions/dashboard/getDashboard.ts` | NEW | Backend |
+| `backend/serverless.yml` | MODIFY | Backend |
+| `backend/functions/dashboard/__tests__/getDashboard.test.ts` | NEW | Backend Tests |
+| `frontend/src/types/index.ts` | MODIFY | Frontend Types |
+| `frontend/src/services/api/dashboard.api.ts` | NEW | Frontend API |
+| `frontend/src/services/api/index.ts` | MODIFY | Frontend API |
+| `frontend/src/components/Dashboard.tsx` | NEW | Frontend |
+| `frontend/src/components/Dashboard.css` | NEW | Frontend |
+| `frontend/src/App.tsx` | MODIFY | Frontend Routes |
+| `frontend/src/config/navConfig.ts` | MODIFY | Frontend Nav |
+| `frontend/src/i18n/locales/en.json` | MODIFY | i18n |
+| `frontend/src/i18n/locales/de.json` | MODIFY | i18n |
+| `frontend/src/components/__tests__/Dashboard.test.tsx` | NEW | Frontend Tests |
+
+## Implementation Steps
+
+### Step 1: Backend dashboard handler
+Create `backend/functions/dashboard/getDashboard.ts` with the aggregated `GET /dashboard` endpoint. Add function definition to `serverless.yml`.
+
+### Step 2: Frontend types
+Add `DashboardData` and related sub-types to `frontend/src/types/index.ts`.
+
+### Step 3: Frontend API service
+Create `frontend/src/services/api/dashboard.api.ts` and export from `index.ts`.
+
+### Step 4: i18n keys
+Add all dashboard-related i18n keys to both `en.json` and `de.json`.
+
+### Step 5: Dashboard component + CSS
+Create `Dashboard.tsx` and `Dashboard.css` with the responsive card grid layout and all sections.
+
+### Step 6: Route + nav changes
+Update `App.tsx` routes and `navConfig.ts` to make Dashboard the home page and keep Standings at `/standings`.
+
+### Step 7: Backend tests
+Create `backend/functions/dashboard/__tests__/getDashboard.test.ts`.
+
+### Step 8: Frontend tests
+Create `frontend/src/components/__tests__/Dashboard.test.tsx`.
+
+## Dependencies & Order
+
+- Steps 1 has no dependencies (backend standalone)
+- Steps 2+3+4 can run in parallel (types, API service, i18n — no deps)
+- Step 5 depends on Steps 2+3+4 (component needs types, API, i18n)
+- Step 6 depends on Step 5 (routes need the component)
+- Step 7 depends on Step 1 (backend tests need handler)
+- Step 8 depends on Steps 5+6 (frontend tests need component + routes)
+
+**Suggested order:** Steps 1+2+3+4 → Step 5 → Steps 6+7 → Step 8
+
+## Testing & Verification
+
+### Automated Tests
+
+**Backend tests:**
+```bash
+cd /home/jpdev/source/league_szn/league_szn/backend && npx vitest run functions/dashboard
+```
+
+**Frontend tests:**
+```bash
+cd /home/jpdev/source/league_szn/league_szn/frontend && npx vitest run src/components/__tests__/Dashboard.test.tsx
+```
+
+**Full verification (lint + all tests):**
+```bash
+# Backend lint
+cd /home/jpdev/source/league_szn/league_szn/backend && npx eslint functions/ lib/
+
+# Backend tests
+cd /home/jpdev/source/league_szn/league_szn/backend && npx vitest run
+
+# Frontend lint
+cd /home/jpdev/source/league_szn/league_szn/frontend && npx eslint src/
+
+# Frontend tests
+cd /home/jpdev/source/league_szn/league_szn/frontend && npx vitest run
+```
+
+## Risks & Edge Cases
+
+- **Empty database**: Dashboard must handle all tables being empty gracefully (show "no data" states)
+- **No active season**: Season progress section should show a "No active season" message
+- **No champions**: Champions strip should show "No active champions" message
+- **Win streak calculation**: Keep it simple — scan the last N matches for each player from SeasonStandings, don't over-engineer
+- **Countdown timer**: Use lightweight interval (every minute is sufficient), clean up on unmount
+- **Performance**: The aggregated endpoint makes ~7 DynamoDB calls; all are simple queries/scans on small tables — should stay under Lambda timeout

--- a/docs/plans/plan-issue-168-standings-form-streaks.md
+++ b/docs/plans/plan-issue-168-standings-form-streaks.md
@@ -1,0 +1,173 @@
+# Plan: Standings Table — Form Dots, Streak Badges, Clickable Names
+
+**GitHub Issue**: [#168](https://github.com/jpDxsoloOrg/league_szn/issues/168)
+
+## Context
+
+The standings table is the most-visited page but shows no player momentum. This plan adds:
+1. **Form column** — last 5 match results as colored dots (🟢 W, 🔴 L, ⚪ D)
+2. **Streak badges** — 🔥 3W for 3+ win streaks, ❄️ 3L for 3+ loss streaks
+3. **Clickable player names** — link to `/stats/player/:playerId`
+4. **Hover card (desktop)** — tooltip showing champion status, division, last match result
+
+### Skills to use
+- general-purpose (backend + frontend)
+- test-engineer (tests)
+
+### Agents and parallel work
+- Steps 1+6 can run in parallel (backend + i18n are independent)
+- Step 2 depends on Step 1 (types depend on backend shape)
+- Steps 3+4+5 can run in parallel after Step 2 (all frontend, independent files)
+- Steps 7+8 run in parallel after Steps 3-5 (tests for both ends)
+
+## Files to Modify
+
+| Step | File | Action |
+|------|------|--------|
+| 1 | `backend/functions/standings/getStandings.ts` | MODIFY — add matches query, compute `recentForm` + `currentStreak` per player |
+| 2 | `frontend/src/types/index.ts` | MODIFY — extend `Player` interface with `recentForm` and `currentStreak` |
+| 3 | `frontend/src/components/Standings.tsx` | MODIFY — render form dots, streak badges, `<Link>` on player names |
+| 4 | `frontend/src/components/PlayerHoverCard.tsx` | NEW — tooltip component |
+| 4 | `frontend/src/components/PlayerHoverCard.css` | NEW — hover card styles |
+| 5 | `frontend/src/components/Standings.css` | MODIFY — add styles for form dots, streak badges |
+| 6 | `frontend/src/i18n/locales/en.json` | MODIFY — add standings.table.form, streak keys |
+| 6 | `frontend/src/i18n/locales/de.json` | MODIFY — add German translations |
+| 7 | `backend/functions/standings/__tests__/getStandings-season.test.ts` | MODIFY — add tests for recentForm + currentStreak |
+| 7 | `backend/functions/standings/__tests__/getStandings-allTime.test.ts` | MODIFY — add tests for recentForm + currentStreak |
+| 8 | `frontend/src/components/__tests__/Standings.test.tsx` | MODIFY — add tests for form dots, streak badges, links |
+
+## Implementation Steps
+
+### Step 1: Backend — Extend getStandings with form and streak data
+
+**File**: `backend/functions/standings/getStandings.ts`
+
+Add a query to the Matches table to fetch all completed matches (`status = 'completed'`), sorted by date descending. For each player in the standings:
+
+1. Filter matches where the player is in `participants` and `status === 'completed'`
+2. Sort by `date` descending, take the last 5
+3. Compute `recentForm`: array of `'W' | 'L' | 'D'` strings based on whether the player is in `winners`, `losers`, or neither (draw)
+4. Compute `currentStreak`: starting from the most recent match, count consecutive same-result matches. Return `{ type: 'W' | 'L' | 'D', count: number }`
+5. Attach both fields to each player object in the response
+
+Use `dynamoDb.scanAll` on `TableNames.MATCHES` with a filter for `status = 'completed'` once, then compute per-player results in memory (avoids N+1 queries).
+
+### Step 2: Frontend types — Extend Player interface
+
+**File**: `frontend/src/types/index.ts`
+
+Add to the `Player` interface:
+```typescript
+recentForm?: ('W' | 'L' | 'D')[];
+currentStreak?: { type: 'W' | 'L' | 'D'; count: number };
+```
+
+These are optional so existing code is not broken when the backend hasn't been deployed yet.
+
+### Step 3: Frontend — Update Standings table rendering
+
+**File**: `frontend/src/components/Standings.tsx`
+
+1. Import `Link` from `react-router-dom`
+2. Import the new `PlayerHoverCard` component
+3. Add a `<th>` for "Form" column (using i18n key `standings.table.form`) after the Win % column
+4. Add a `<th>` for "Streak" column (using i18n key `standings.table.streak`) after Form
+5. In each `<tr>`, render:
+   - **Player name as `<Link>`**: `<Link to={/stats/player/${player.playerId}}>{player.name}</Link>` wrapped in `PlayerHoverCard`
+   - **Form dots**: map `player.recentForm` to colored `<span>` dots (green for W, red for L, gray for D)
+   - **Streak badge**: if `player.currentStreak?.count >= 3`, render a badge like `🔥 3W` or `❄️ 3L`
+6. Guard with `player.recentForm?.length > 0` checks for when data is absent
+
+### Step 4: Frontend — Create PlayerHoverCard component
+
+**Files**: `frontend/src/components/PlayerHoverCard.tsx`, `frontend/src/components/PlayerHoverCard.css`
+
+A lightweight tooltip wrapper component:
+- Props: `player: Player`, `divisions: Division[]`, `children: ReactNode`
+- On mouse-enter (desktop only), shows an absolutely-positioned card above/below the trigger
+- Card content: division name, champion status (if any — from player data), last match result from `recentForm[0]`
+- Uses CSS `position: absolute` and `visibility`/`opacity` for smooth show/hide
+- No external tooltip libraries
+
+### Step 5: Frontend — CSS for form dots and streak badges
+
+**File**: `frontend/src/components/Standings.css`
+
+Add styles for:
+- `.form-dots` — flex row with gap, centered
+- `.form-dot` — small circle (10px), `border-radius: 50%`
+- `.form-dot.win` — green (#4ade80)
+- `.form-dot.loss` — red (#f87171)
+- `.form-dot.draw` — gray (#9ca3af)
+- `.streak-badge` — inline badge with padding, rounded corners
+- `.streak-badge.hot` — fire theme (orange/red gradient bg)
+- `.streak-badge.cold` — ice theme (blue bg)
+- `.player-name a` — styled link (inherit color, underline on hover)
+- Responsive adjustments at 768px breakpoint
+
+### Step 6: i18n — Add translation keys
+
+**Files**: `frontend/src/i18n/locales/en.json`, `frontend/src/i18n/locales/de.json`
+
+Add to `standings.table`:
+- `"form": "Form"` / `"form": "Form"` (same in German — it's a loanword in football context)
+- `"streak": "Streak"` / `"streak": "Serie"`
+
+Add to `standings`:
+- `"winStreak": "Win Streak"` / `"winStreak": "Siegesserie"`
+- `"lossStreak": "Loss Streak"` / `"lossStreak": "Niederlagenserie"`
+- `"drawStreak": "Draw Streak"` / `"drawStreak": "Unentschiedenserie"`
+
+### Step 7: Backend tests — Test form and streak computation
+
+**Files**: `backend/functions/standings/__tests__/getStandings-season.test.ts`, `backend/functions/standings/__tests__/getStandings-allTime.test.ts`
+
+Add tests:
+1. **recentForm returns last 5 results in order (newest first)** — mock matches with known winners/losers, assert form array
+2. **currentStreak computes correctly for win streak** — player with 4 consecutive wins → `{ type: 'W', count: 4 }`
+3. **currentStreak computes correctly for loss streak** — `{ type: 'L', count: 3 }`
+4. **recentForm is empty array when no completed matches exist** — no matches → `[]`
+5. **currentStreak defaults to `{ type: 'W', count: 0 }` when no matches**
+
+Mock the matches scan (`mockScanAll` for Matches table) alongside existing player/standings mocks. The existing mock setup already uses `mockScanAll` for Players, so add a second call expectation.
+
+### Step 8: Frontend tests — Test new standings UI elements
+
+**File**: `frontend/src/components/__tests__/Standings.test.tsx`
+
+Add tests:
+1. **Renders form dots for each player** — mock standings with `recentForm` data, assert colored dots appear
+2. **Renders streak badge for 3+ win streak** — player with `currentStreak: { type: 'W', count: 5 }` shows 🔥 badge
+3. **Does not render streak badge for streak < 3** — player with count 2 shows no badge
+4. **Player names are links to stats page** — assert `<a href="/stats/player/p1">` exists
+5. **Gracefully handles missing recentForm** — player without `recentForm` renders dashes or empty
+
+Update mock data to include `recentForm` and `currentStreak` fields.
+
+## Dependencies & Order
+
+- Step 1 has no dependencies (backend-only)
+- Step 6 has no dependencies (i18n-only)
+- Step 2 depends on Step 1 (needs to know backend response shape)
+- Steps 3, 4, 5 depend on Step 2 (need updated types)
+- Steps 7, 8 depend on Steps 1–5 (test the final code)
+
+**Suggested order**: `Steps 1+6 -> Step 2 -> Steps 3+4+5 -> Steps 7+8`
+
+## Testing & Verification
+
+### Automated Tests
+1. **Backend lint**: `cd /home/jpdev/source/league_szn/league_szn/backend && npx eslint functions/ lib/`
+2. **Backend tests**: `cd /home/jpdev/source/league_szn/league_szn/backend && npx vitest run`
+3. **Frontend lint**: `cd /home/jpdev/source/league_szn/league_szn/frontend && npx eslint src/`
+4. **Frontend tests**: `cd /home/jpdev/source/league_szn/league_szn/frontend && npx vitest run`
+
+### Manual Verification
+- After deployment, visit the standings page and confirm form dots, streak badges, and clickable player names are visible and functioning correctly.
+
+## Risks & Edge Cases
+
+1. **No completed matches** — recentForm should be `[]`, streak should be `{ type: 'W', count: 0 }`, UI should render gracefully
+2. **Draw-only matches** — a match where a player is in `participants` but not in `winners` or `losers` is a draw
+3. **Performance** — scanning the entire Matches table could be slow with hundreds of matches; this is acceptable for now since the league is small, but could be optimized later with a GSI or cached computation
+4. **Backward compatibility** — `recentForm` and `currentStreak` are optional on the Player type, so the frontend won't break if the backend hasn't been updated yet

--- a/frontend/src/services/api/dashboard.api.ts
+++ b/frontend/src/services/api/dashboard.api.ts
@@ -1,0 +1,8 @@
+import { API_BASE_URL, fetchWithAuth } from './apiClient';
+import type { DashboardData } from '../../types';
+
+export const dashboardApi = {
+    get: async (signal?: AbortSignal): Promise<DashboardData> => {
+        return fetchWithAuth(`${API_BASE_URL}/dashboard`, {}, signal);
+    },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -23,6 +23,7 @@ export { statisticsApi } from './statistics.api';
 export { imagesApi } from './images.api';
 export { challengesApi } from './challenges.api';
 export { promosApi } from './promos.api';
+export { dashboardApi } from './dashboard.api';
 
 // Type/interface re-exports
 export type { SiteFeatures } from './siteConfig.api';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -147,3 +147,59 @@ export interface MatchType {
   createdAt: string;
   updatedAt: string;
 }
+
+// Dashboard types
+export interface DashboardChampion {
+  championshipId: string;
+  championshipName: string;
+  championName: string;
+  championImageUrl?: string;
+  playerId: string;
+  wonDate?: string;
+  defenses?: number;
+}
+
+export interface DashboardEvent {
+  eventId: string;
+  name: string;
+  date: string;
+  eventType: string;
+  venue?: string;
+  matchCount?: number;
+}
+
+export interface DashboardMatch {
+  matchId: string;
+  date: string;
+  matchType: string;
+  winnerName: string;
+  winnerImageUrl?: string;
+  loserName: string;
+  loserImageUrl?: string;
+  championshipName?: string;
+}
+
+export interface DashboardSeason {
+  seasonId: string;
+  name: string;
+  startDate?: string;
+  endDate?: string;
+  status: string;
+  matchesPlayed?: number;
+}
+
+export interface DashboardQuickStats {
+  totalPlayers: number;
+  totalMatches: number;
+  activeChampionships: number;
+  mostWinsPlayer?: { name: string; wins: number };
+}
+
+export interface DashboardData {
+  currentChampions: DashboardChampion[];
+  upcomingEvents: DashboardEvent[];
+  recentResults: DashboardMatch[];
+  seasonInfo: DashboardSeason | null;
+  quickStats: DashboardQuickStats;
+  activeChallengesCount: number;
+}


### PR DESCRIPTION
## Summary
Adds dashboard API, types, plans, and workflow tooling in support of the News Feed / Activity Timeline feature.

Closes #165

## Related
- Issue: #165 — News Feed / Activity Timeline
- Activity types: match results, championship changes, season/tournament events (challenges, promos, fantasy to follow)