### PR TITLE
feat(frontend): Batch UX enhancements — 404, scroll-to-top, clickable standings/calendar, polish, sidebar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,9 +15,9 @@
       frame-ancestors 'none';
       upgrade-insecure-requests;
     ">
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WWE 2K League</title>
+    <title>League SZN</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="4" fill="#0f0f0f"/>
+  <text x="16" y="22" font-family="system-ui, sans-serif" font-size="18" font-weight="bold" fill="#d4af37" text-anchor="middle">L</text>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,7 +14,25 @@ main {
   padding: 2rem;
   padding-top: calc(56px + 2rem);
   max-width: 1200px;
-  margin-left: 300px;
+  margin-left: 250px;
+  animation: pageFadeIn 0.2s ease-out;
+}
+
+.App.sidebar-collapsed main {
+  margin-left: 60px;
+}
+
+.App.sidebar-collapsed .top-bar {
+  left: 60px;
+}
+
+@keyframes pageFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 h2 {
@@ -94,7 +112,7 @@ tr:hover {
   }
 }
 
-/* Print: hide app chrome so wiki and other content print cleanly */
+/* Print: hide app chrome and ensure readable content */
 @media print {
   .sidebar,
   .hamburger-btn,
@@ -106,8 +124,10 @@ tr:hover {
     display: none !important;
   }
 
+  body,
   .App {
-    background: #fff;
+    background: #fff !important;
+    color: #000 !important;
   }
 
   main {
@@ -116,5 +136,28 @@ tr:hover {
     padding: 0.5in;
     padding-top: 0.5in;
     max-width: none;
+    color: #000 !important;
+    background: #fff !important;
+  }
+
+  main h1,
+  main h2,
+  main h3 {
+    color: #000 !important;
+  }
+
+  main table,
+  main th,
+  main td {
+    border-color: #333 !important;
+    color: #000 !important;
+  }
+
+  main th {
+    background: #eee !important;
+  }
+
+  main a {
+    color: #000 !important;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,12 +56,15 @@ import WrestlerProfile from './components/profile/WrestlerProfile';
 // Route guard
 import ProtectedRoute from './components/ProtectedRoute';
 import FeatureRoute from './components/FeatureRoute';
+import ScrollToTop from './components/ScrollToTop';
+import NotFound from './components/NotFound';
 import './App.css';
 
 function App() {
   return (
     <ErrorBoundary>
       <Router>
+        <ScrollToTop />
         <AuthProvider>
           <SiteConfigProvider>
             <NavLayoutProvider>
@@ -75,9 +78,9 @@ function App() {
 }
 
 function AppLayout() {
-  const { mode } = useNavLayout();
+  const { mode, sidebarCollapsed } = useNavLayout();
   return (
-    <div className={`App layout-${mode}`}>
+    <div className={`App layout-${mode}${mode === 'sidebar' && sidebarCollapsed ? ' sidebar-collapsed' : ''}`}>
       {mode === 'sidebar' ? (
         <>
           <Sidebar />
@@ -240,6 +243,9 @@ function AppLayout() {
                 </ProtectedRoute>
               </FeatureRoute>
             } />
+
+            {/* Catch-all 404 */}
+            <Route path="*" element={<NotFound />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/components/BackLink.css
+++ b/frontend/src/components/BackLink.css
@@ -1,0 +1,12 @@
+.back-link {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: #999;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s;
+}
+
+.back-link:hover {
+  color: #d4af37;
+}

--- a/frontend/src/components/BackLink.tsx
+++ b/frontend/src/components/BackLink.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import './BackLink.css';
+
+type BackLinkProps = {
+  to: string;
+  label?: string;
+};
+
+export default function BackLink({ to, label }: BackLinkProps) {
+  const { t } = useTranslation();
+  const text = label ?? t('common.back', '← Back');
+  return (
+    <Link to={to} className="back-link">
+      {text}
+    </Link>
+  );
+}

--- a/frontend/src/components/Championships.tsx
+++ b/frontend/src/components/Championships.tsx
@@ -4,10 +4,12 @@ import { championshipsApi, divisionsApi, playersApi } from '../services/api';
 import { formatDate } from '../utils/dateUtils';
 import { logger } from '../utils/logger';
 import { type Division, type Championship, type ChampionshipReign, type Player } from '../types';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import './Championships.css';
 
 export default function Championships() {
   const { t } = useTranslation();
+  useDocumentTitle(t('championships.title'));
   const [championships, setChampionships] = useState<Championship[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
   const [divisions, setDivisions] = useState<Division[]>([]);

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { dashboardApi } from '../services/api';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type { DashboardData, DashboardEvent, DashboardMatch } from '../types';
 import './Dashboard.css';
 
@@ -117,6 +118,7 @@ function RecentResultsGrouped({
 
 export default function Dashboard() {
   const { t } = useTranslation();
+  useDocumentTitle(t('nav.dashboard'));
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/NotFound.css
+++ b/frontend/src/components/NotFound.css
@@ -1,0 +1,43 @@
+.not-found {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  text-align: center;
+  padding: 2rem;
+}
+
+.not-found-code {
+  font-size: 4rem;
+  color: #d4af37;
+  margin: 0 0 0.5rem;
+  font-weight: bold;
+}
+
+.not-found-message {
+  font-size: 1.25rem;
+  color: #fff;
+  margin: 0 0 0.5rem;
+}
+
+.not-found-hint {
+  color: #999;
+  margin: 0 0 1.5rem;
+  max-width: 400px;
+}
+
+.not-found-link {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: #d4af37;
+  color: #000;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.not-found-link:hover {
+  background-color: #b8941f;
+}

--- a/frontend/src/components/NotFound.tsx
+++ b/frontend/src/components/NotFound.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import './NotFound.css';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+  useEffect(() => {
+    document.title = `404 | League SZN`;
+    return () => { document.title = 'League SZN'; };
+  }, []);
+  return (
+    <div className="not-found">
+      <h1 className="not-found-code">404</h1>
+      <p className="not-found-message">{t('common.pageNotFound', 'Page not found')}</p>
+      <p className="not-found-hint">{t('common.pageNotFoundHint', 'The page you’re looking for doesn’t exist or has been moved.')}</p>
+      <Link to="/" className="not-found-link">{t('common.backToHome', 'Back to Home')}</Link>
+    </div>
+  );
+}

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -2,7 +2,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 300px;
+  width: 250px;
   height: 100vh;
   background-color: #111;
   border-right: 2px solid #d4af37;
@@ -10,6 +10,53 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  transition: width 0.2s ease;
+}
+
+.sidebar.collapsed {
+  width: 60px;
+  overflow: hidden;
+}
+
+.sidebar.collapsed .sidebar-nav {
+  display: none !important;
+}
+
+.sidebar.collapsed .sidebar-header h2,
+.sidebar.collapsed .sidebar-header > *:not(.sidebar-collapse-toggle) {
+  display: none !important;
+}
+
+.sidebar.collapsed .sidebar-header {
+  justify-content: center;
+  padding: 0.5rem;
+}
+
+.sidebar-collapse-toggle {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0 !important;
+  margin-right: 0.5rem;
+  background: none !important;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #d4af37;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.sidebar-collapse-toggle:hover {
+  color: #fff;
+  border-color: #d4af37;
+}
+
+.sidebar.collapsed .sidebar-collapse-toggle {
+  margin-right: 0;
 }
 
 .sidebar-header {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { useSiteConfig } from '../contexts/SiteConfigContext';
+import { useNavLayout } from '../contexts/navLayoutContext';
 import LanguageSwitcher from './LanguageSwitcher';
 import {
   USER_NAV_GROUPS,
@@ -40,6 +41,7 @@ export default function Sidebar() {
   const location = useLocation();
   const { isAuthenticated, isAdminOrModerator, isSuperAdmin, isWrestler, isFantasy, signOut } = useAuth();
   const { features } = useSiteConfig();
+  const { sidebarCollapsed, setSidebarCollapsed } = useNavLayout();
   const [adminExpanded, setAdminExpanded] = useState(true);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({ core: true });
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -117,8 +119,17 @@ export default function Sidebar() {
       <div className="sidebar-overlay" onClick={() => setMobileOpen(false)} />
     )}
 
-    <aside className={`sidebar ${mobileOpen ? 'mobile-open' : ''}`}>
+    <aside className={`sidebar ${mobileOpen ? 'mobile-open' : ''} ${sidebarCollapsed ? 'collapsed' : ''}`}>
       <div className="sidebar-header">
+        <button
+          type="button"
+          className="sidebar-collapse-toggle"
+          onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+          aria-label={sidebarCollapsed ? t('nav.expandSidebar', 'Expand sidebar') : t('nav.collapseSidebar', 'Collapse sidebar')}
+          title={sidebarCollapsed ? t('nav.expandSidebar', 'Expand sidebar') : t('nav.collapseSidebar', 'Collapse sidebar')}
+        >
+          {sidebarCollapsed ? '\u25B6' : '\u25C0'}
+        </button>
         <h2>{t('header.title')}</h2>
         <LanguageSwitcher />
       </div>

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -154,6 +154,10 @@
   color: #d4af37;
 }
 
+.standings-table .standings-row-clickable {
+  cursor: pointer;
+}
+
 .form-cell,
 .streak-cell {
   text-align: center;

--- a/frontend/src/components/Standings.tsx
+++ b/frontend/src/components/Standings.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { standingsApi, seasonsApi, divisionsApi } from '../services/api';
 import { logger } from '../utils/logger';
 import type { Standings as StandingsType, Season, Division, Player } from '../types';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import PlayerHoverCard from './PlayerHoverCard';
 import './Standings.css';
 
 export default function Standings() {
   const { t } = useTranslation();
+  useDocumentTitle(t('standings.pageTitle'));
+  const navigate = useNavigate();
   const [standings, setStandings] = useState<StandingsType | null>(null);
   const [divisions, setDivisions] = useState<Division[]>([]);
   const [selectedDivision, setSelectedDivision] = useState<string>('all');
@@ -218,7 +221,19 @@ export default function Standings() {
           </thead>
           <tbody>
             {playersWithStats.map((player, index) => (
-              <tr key={player.playerId}>
+              <tr
+                key={player.playerId}
+                className="standings-row-clickable"
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/stats/player/${player.playerId}`)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    navigate(`/stats/player/${player.playerId}`);
+                  }
+                }}
+              >
                 <td className="rank">{index + 1}</td>
                 <td className="wrestler-image-cell">
                   {player.imageUrl ? (
@@ -231,7 +246,7 @@ export default function Standings() {
                     <div className="no-image-placeholder">-</div>
                   )}
                 </td>
-                <td className="player-name">
+                <td className="player-name" onClick={(e) => e.stopPropagation()}>
                   <PlayerHoverCard player={player} divisions={divisions}>
                     <Link to={`/stats/player/${player.playerId}`} className="player-name-link">
                       {player.name}

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -1,9 +1,10 @@
 .top-bar {
   position: fixed;
   top: 0;
-  left: 300px;
+  left: 250px;
   right: 0;
   height: 56px;
+  transition: left 0.2s ease;
   background-color: #1a1a1a;
   border-bottom: 1px solid rgba(212, 175, 55, 0.2);
   display: flex;

--- a/frontend/src/components/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/__tests__/Sidebar.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../../contexts/SiteConfigContext', () => ({
 }));
 
 vi.mock('../../contexts/navLayoutContext', () => ({
-  useNavLayout: () => ({ mode: 'sidebar', setMode: vi.fn(), toggleMode: vi.fn() }),
+  useNavLayout: () => ({ mode: 'sidebar', setMode: vi.fn(), toggleMode: vi.fn(), sidebarCollapsed: false, setSidebarCollapsed: vi.fn() }),
 }));
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/__tests__/TopBar.test.tsx
@@ -7,7 +7,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('../../contexts/navLayoutContext', () => ({
-  useNavLayout: () => ({ mode: 'sidebar', setMode: vi.fn(), toggleMode: vi.fn() }),
+  useNavLayout: () => ({ mode: 'sidebar', setMode: vi.fn(), toggleMode: vi.fn(), sidebarCollapsed: false, setSidebarCollapsed: vi.fn() }),
 }));
 
 vi.mock('../TopBar.css', () => ({}));

--- a/frontend/src/components/events/EventsCalendar.css
+++ b/frontend/src/components/events/EventsCalendar.css
@@ -144,11 +144,13 @@
 }
 
 .calendar-event-dot {
+  display: inline-block;
   width: 10px;
   height: 10px;
   border-radius: 50%;
   cursor: pointer;
   transition: transform 0.15s;
+  text-decoration: none;
 }
 
 .calendar-event-dot:hover {

--- a/frontend/src/components/events/EventsCalendar.tsx
+++ b/frontend/src/components/events/EventsCalendar.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import type { EventType, EventCalendarEntry } from '../../types/event';
 import { eventsApi } from '../../services/api';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import EventCard from './EventCard';
 import './EventsCalendar.css';
 
@@ -16,6 +18,7 @@ type FilterTab = 'all' | EventType;
 
 export default function EventsCalendar() {
   const { t } = useTranslation();
+  useDocumentTitle(t('events.title'));
   const now = new Date();
   const [currentMonth, setCurrentMonth] = useState(now.getMonth());
   const [currentYear, setCurrentYear] = useState(now.getFullYear());
@@ -240,11 +243,13 @@ export default function EventsCalendar() {
                   {eventsByDay[day] && (
                     <div className="calendar-day-events">
                       {eventsByDay[day].map((evt) => (
-                        <div
+                        <Link
                           key={evt.eventId}
+                          to={`/events/${evt.eventId}`}
                           className="calendar-event-dot"
                           style={{ backgroundColor: eventTypeColors[evt.eventType] }}
                           title={evt.name}
+                          aria-label={evt.name}
                         />
                       ))}
                     </div>

--- a/frontend/src/components/statistics/PlayerStats.tsx
+++ b/frontend/src/components/statistics/PlayerStats.tsx
@@ -6,6 +6,7 @@ import type { StatsPlayer } from '../../services/api';
 import { usePlayerStats } from '../../hooks/usePlayerStats';
 import PlayerStatsContent from './PlayerStatsContent';
 import SeasonSelector from './SeasonSelector';
+import BackLink from '../BackLink';
 import './PlayerStats.css';
 
 function PlayerStats() {
@@ -73,6 +74,9 @@ function PlayerStats() {
 
   return (
     <div className="player-stats">
+      {routePlayerId && (
+        <BackLink to="/stats" label={t('statistics.nav.backToStats', '← Back to Statistics')} />
+      )}
       <div className="ps-header">
         <h2>{t('statistics.playerStats.title')}</h2>
         <div className="ps-nav-links">

--- a/frontend/src/contexts/NavLayoutContext.tsx
+++ b/frontend/src/contexts/NavLayoutContext.tsx
@@ -2,8 +2,20 @@ import { useState, useEffect, useCallback, ReactNode } from 'react';
 import { NAV_LAYOUT_STORAGE_KEY, type NavLayoutMode } from './navLayoutTypes';
 import { NavLayoutContext, readStoredMode } from './navLayoutContext';
 
+const SIDEBAR_COLLAPSED_KEY = 'league_szn_sidebar_collapsed';
+
+function readSidebarCollapsed(): boolean {
+  try {
+    const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
+    return stored === 'true';
+  } catch {
+    return false;
+  }
+}
+
 export function NavLayoutProvider({ children }: { children: ReactNode }) {
   const [mode, setModeState] = useState<NavLayoutMode>(() => readStoredMode());
+  const [sidebarCollapsed, setSidebarCollapsedState] = useState(readSidebarCollapsed);
 
   useEffect(() => {
     try {
@@ -13,6 +25,14 @@ export function NavLayoutProvider({ children }: { children: ReactNode }) {
     }
   }, [mode]);
 
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(sidebarCollapsed));
+    } catch {
+      // ignore
+    }
+  }, [sidebarCollapsed]);
+
   const setMode = useCallback((next: NavLayoutMode) => {
     setModeState(next);
   }, []);
@@ -21,8 +41,12 @@ export function NavLayoutProvider({ children }: { children: ReactNode }) {
     setModeState((prev) => (prev === 'sidebar' ? 'topnav' : 'sidebar'));
   }, []);
 
+  const setSidebarCollapsed = useCallback((value: boolean) => {
+    setSidebarCollapsedState(value);
+  }, []);
+
   return (
-    <NavLayoutContext.Provider value={{ mode, setMode, toggleMode }}>
+    <NavLayoutContext.Provider value={{ mode, setMode, toggleMode, sidebarCollapsed, setSidebarCollapsed }}>
       {children}
     </NavLayoutContext.Provider>
   );

--- a/frontend/src/contexts/navLayoutContext.ts
+++ b/frontend/src/contexts/navLayoutContext.ts
@@ -5,6 +5,8 @@ export interface NavLayoutContextType {
   mode: NavLayoutMode;
   setMode: (mode: NavLayoutMode) => void;
   toggleMode: () => void;
+  sidebarCollapsed: boolean;
+  setSidebarCollapsed: (value: boolean) => void;
 }
 
 export const NavLayoutContext = createContext<NavLayoutContextType | undefined>(undefined);

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+const BASE_TITLE = 'League SZN';
+
+/**
+ * Sets document.title to "title | League SZN" when provided,
+ * or restores BASE_TITLE when title is empty.
+ */
+export function useDocumentTitle(title: string | undefined): void {
+  useEffect(() => {
+    document.title = title ? `${title} | ${BASE_TITLE}` : BASE_TITLE;
+    return () => {
+      document.title = BASE_TITLE;
+    };
+  }, [title]);
+}


### PR DESCRIPTION
## Summary

Implements four enhancement issues in one branch (parallel-friendly changes):

### Closes #156 — 404 page, breadcrumbs, scroll-to-top
- **NotFound** component with friendly message and "Back to Home" link; catch-all route `path="*"`.
- **ScrollToTop** component that scrolls to top on every route change.
- **BackLink** component; added "Back to Statistics" on Player Stats when viewing a specific player. (Event, Challenge, and Promo detail pages already had back links.)

### Closes #160 — Clickable standings rows and calendar event dots
- **Standings**: Table rows are clickable (navigate to `/stats/player/:playerId`); player name cell uses `stopPropagation` so the link still works. Keyboard support (Enter/Space).
- **EventsCalendar**: Event dots in the calendar grid are now `<Link to={/events/:eventId}>` with `aria-label` for accessibility.

### Closes #162 — Polish: page transitions, print styles, favicon, dynamic titles
- **useDocumentTitle** hook; used on Dashboard, Standings, Championships, Events, and NotFound.
- **index.html**: Title set to "League SZN", favicon to `/favicon.svg` (custom "L" SVG).
- **App.css**: Subtle `pageFadeIn` animation on `main`; print media query updated so body/main and tables use black text on white background for readable printing.

### Closes #161 — Sidebar width and collapsible mode
- Sidebar width reduced from 300px to **250px**; main content and TopBar margins updated.
- **Collapsible sidebar**: Toggle in header collapses to 60px (icon rail); state persisted in `localStorage`. When collapsed, nav and header title are hidden; expand button (▶) shown. Main and TopBar `margin-left`/`left` switch to 60px when collapsed.
- NavLayoutContext extended with `sidebarCollapsed` and `setSidebarCollapsed`.

## Testing

- Frontend lint: ✅
- Frontend tests: ✅ (406 tests)
- Sidebar and TopBar test mocks updated for new `useNavLayout()` fields.