### PR TITLE
feat(ux): 404, scroll-to-top, clickable standings/calendar, sidebar collapse, favicon, dynamic title, print (#156, #160, #161, #162)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,9 +15,9 @@
       frame-ancestors 'none';
       upgrade-insecure-requests;
     ">
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WWE 2K League</title>
+    <title>League SZN</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="4" fill="#0f0f0f"/>
+  <text x="16" y="22" font-family="system-ui, sans-serif" font-size="18" font-weight="bold" fill="#d4af37" text-anchor="middle">L</text>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,7 +14,17 @@ main {
   padding: 2rem;
   padding-top: calc(56px + 2rem);
   max-width: 1200px;
-  margin-left: 300px;
+  margin-left: 260px;
+  transition: margin-left 0.2s ease;
+}
+
+/* When sidebar is collapsed (64px) */
+.App.layout-sidebar .sidebar.collapsed ~ .top-bar {
+  left: 64px;
+}
+
+.App.layout-sidebar .sidebar.collapsed ~ main {
+  margin-left: 64px;
 }
 
 h2 {
@@ -94,7 +104,7 @@ tr:hover {
   }
 }
 
-/* Print: hide app chrome so wiki and other content print cleanly */
+/* Print: hide app chrome and ensure readable contrast */
 @media print {
   .sidebar,
   .hamburger-btn,
@@ -106,8 +116,11 @@ tr:hover {
     display: none !important;
   }
 
-  .App {
-    background: #fff;
+  .App,
+  main,
+  body {
+    background: #fff !important;
+    color: #000 !important;
   }
 
   main {
@@ -116,5 +129,25 @@ tr:hover {
     padding: 0.5in;
     padding-top: 0.5in;
     max-width: none;
+  }
+
+  h1, h2, h3, h4, th {
+    color: #000 !important;
+  }
+
+  td, p, span, a {
+    color: #000 !important;
+  }
+
+  table {
+    border-color: #333 !important;
+  }
+
+  th, td {
+    border-bottom-color: #333 !important;
+  }
+
+  a {
+    text-decoration: underline;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { SiteConfigProvider } from './contexts/SiteConfigContext';
 import { NavLayoutProvider } from './contexts/NavLayoutContext';
 import { useNavLayout } from './contexts/navLayoutContext';
 import ErrorBoundary from './components/ErrorBoundary';
+import ScrollToTop from './components/ScrollToTop';
+import NotFound from './components/NotFound';
 import Sidebar from './components/Sidebar';
 import TopBar from './components/TopBar';
 import TopNav from './components/TopNav';
@@ -62,6 +64,7 @@ function App() {
   return (
     <ErrorBoundary>
       <Router>
+        <ScrollToTop />
         <AuthProvider>
           <SiteConfigProvider>
             <NavLayoutProvider>
@@ -240,6 +243,9 @@ function AppLayout() {
                 </ProtectedRoute>
               </FeatureRoute>
             } />
+
+            {/* Catch-all 404 */}
+            <Route path="*" element={<NotFound />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/components/BackLink.css
+++ b/frontend/src/components/BackLink.css
@@ -1,0 +1,12 @@
+.back-link {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: #bbb;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.2s;
+}
+
+.back-link:hover {
+  color: #d4af37;
+}

--- a/frontend/src/components/BackLink.tsx
+++ b/frontend/src/components/BackLink.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import './BackLink.css';
+
+type BackLinkProps = {
+  to: string;
+  label?: string;
+};
+
+export default function BackLink({ to, label }: BackLinkProps) {
+  const { t } = useTranslation();
+  return (
+    <Link to={to} className="back-link" aria-label={label ?? t('common.back')}>
+      ← {label ?? t('common.back')}
+    </Link>
+  );
+}

--- a/frontend/src/components/Championships.tsx
+++ b/frontend/src/components/Championships.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { championshipsApi, divisionsApi, playersApi } from '../services/api';
 import { formatDate } from '../utils/dateUtils';
 import { logger } from '../utils/logger';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { type Division, type Championship, type ChampionshipReign, type Player } from '../types';
 import './Championships.css';
 
 export default function Championships() {
   const { t } = useTranslation();
+  useDocumentTitle(t('nav.championships'));
   const [championships, setChampionships] = useState<Championship[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
   const [divisions, setDivisions] = useState<Division[]>([]);

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { dashboardApi } from '../services/api';
 import type { DashboardData, DashboardEvent, DashboardMatch } from '../types';
 import './Dashboard.css';
@@ -117,6 +118,7 @@ function RecentResultsGrouped({
 
 export default function Dashboard() {
   const { t } = useTranslation();
+  useDocumentTitle(t('nav.dashboard'));
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/NotFound.css
+++ b/frontend/src/components/NotFound.css
@@ -1,0 +1,42 @@
+.not-found-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+.not-found-code {
+  font-size: 4rem;
+  color: #d4af37;
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.not-found-page h2 {
+  margin-bottom: 0.75rem;
+}
+
+.not-found-page p {
+  color: #bbb;
+  max-width: 400px;
+  margin-bottom: 1.5rem;
+}
+
+.not-found-home-link {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: #d4af37;
+  color: #000;
+  font-weight: bold;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background-color 0.3s;
+}
+
+.not-found-home-link:hover {
+  background-color: #b8941f;
+  color: #000;
+}

--- a/frontend/src/components/NotFound.tsx
+++ b/frontend/src/components/NotFound.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import './NotFound.css';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+  useDocumentTitle(t('notFound.title'));
+  return (
+    <div className="not-found-page">
+      <h1 className="not-found-code">404</h1>
+      <h2>{t('notFound.title')}</h2>
+      <p>{t('notFound.message')}</p>
+      <Link to="/" className="not-found-home-link">
+        {t('common.backToHome')}
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Scrolls the window to top when the route pathname changes.
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -2,7 +2,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 300px;
+  width: 260px;
   height: 100vh;
   background-color: #111;
   border-right: 2px solid #d4af37;
@@ -10,6 +10,51 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  transition: width 0.2s ease;
+}
+
+.sidebar.collapsed {
+  width: 64px;
+  overflow: hidden;
+}
+
+.sidebar.collapsed .sidebar-header > *:not(.sidebar-collapse-toggle),
+.sidebar.collapsed .sidebar-nav,
+.sidebar.collapsed .auth-section {
+  display: none !important;
+}
+
+.sidebar.collapsed .sidebar-header {
+  justify-content: center;
+  padding: 0.5rem;
+}
+
+.sidebar.collapsed .sidebar-header .sidebar-collapse-toggle {
+  margin: 0;
+}
+
+.sidebar-collapse-toggle {
+  background: none;
+  border: none;
+  color: #d4af37;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.sidebar-collapse-toggle:hover {
+  color: #fff;
+  background-color: #252525;
+  border-radius: 4px;
+}
+
+.collapse-label {
+  font-size: 0.75rem;
+  font-weight: normal;
 }
 
 .sidebar-header {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -43,6 +43,13 @@ export default function Sidebar() {
   const [adminExpanded, setAdminExpanded] = useState(true);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({ core: true });
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem('sidebar-collapsed') === 'true';
+    } catch {
+      return false;
+    }
+  });
 
   const toggleGroup = useCallback((groupKey: string) => {
     setExpandedGroups(prev => ({ ...prev, [groupKey]: !prev[groupKey] }));
@@ -77,6 +84,16 @@ export default function Sidebar() {
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
   }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('sidebar-collapsed', String(collapsed));
+    } catch {
+      // ignore
+    }
+  }, [collapsed]);
+
+  const toggleCollapsed = useCallback(() => setCollapsed((prev) => !prev), []);
 
   // Prevent body scroll when sidebar is open on mobile
   useEffect(() => {
@@ -117,8 +134,17 @@ export default function Sidebar() {
       <div className="sidebar-overlay" onClick={() => setMobileOpen(false)} />
     )}
 
-    <aside className={`sidebar ${mobileOpen ? 'mobile-open' : ''}`}>
+    <aside className={`sidebar ${mobileOpen ? 'mobile-open' : ''} ${collapsed ? 'collapsed' : ''}`}>
       <div className="sidebar-header">
+        <button
+          type="button"
+          className="sidebar-collapse-toggle"
+          onClick={toggleCollapsed}
+          aria-label={collapsed ? t('nav.switchToSidebar') : 'Collapse sidebar'}
+          title={collapsed ? t('nav.switchToSidebar') : 'Collapse sidebar'}
+        >
+          <span className="collapse-label">{collapsed ? '\u203A' : '\u2039'}</span>
+        </button>
         <h2>{t('header.title')}</h2>
         <LanguageSwitcher />
       </div>

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -1,3 +1,7 @@
+.standings-row-clickable {
+  cursor: pointer;
+}
+
 .standings-container {
   width: 100%;
 }

--- a/frontend/src/components/Standings.tsx
+++ b/frontend/src/components/Standings.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { standingsApi, seasonsApi, divisionsApi } from '../services/api';
 import { logger } from '../utils/logger';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import type { Standings as StandingsType, Season, Division, Player } from '../types';
 import PlayerHoverCard from './PlayerHoverCard';
 import './Standings.css';
 
 export default function Standings() {
   const { t } = useTranslation();
+  useDocumentTitle(t('standings.title'));
+  const navigate = useNavigate();
   const [standings, setStandings] = useState<StandingsType | null>(null);
   const [divisions, setDivisions] = useState<Division[]>([]);
   const [selectedDivision, setSelectedDivision] = useState<string>('all');
@@ -218,7 +221,20 @@ export default function Standings() {
           </thead>
           <tbody>
             {playersWithStats.map((player, index) => (
-              <tr key={player.playerId}>
+              <tr
+                key={player.playerId}
+                className="standings-row-clickable"
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/stats/player/${player.playerId}`)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    navigate(`/stats/player/${player.playerId}`);
+                  }
+                }}
+                aria-label={t('standings.table.player')}
+              >
                 <td className="rank">{index + 1}</td>
                 <td className="wrestler-image-cell">
                   {player.imageUrl ? (
@@ -233,7 +249,11 @@ export default function Standings() {
                 </td>
                 <td className="player-name">
                   <PlayerHoverCard player={player} divisions={divisions}>
-                    <Link to={`/stats/player/${player.playerId}`} className="player-name-link">
+                    <Link
+                      to={`/stats/player/${player.playerId}`}
+                      className="player-name-link"
+                      onClick={(e) => e.stopPropagation()}
+                    >
                       {player.name}
                     </Link>
                   </PlayerHoverCard>

--- a/frontend/src/components/TopBar.css
+++ b/frontend/src/components/TopBar.css
@@ -1,7 +1,8 @@
 .top-bar {
   position: fixed;
   top: 0;
-  left: 300px;
+  left: 260px;
+  transition: left 0.2s ease;
   right: 0;
   height: 56px;
   background-color: #1a1a1a;

--- a/frontend/src/components/events/EventsCalendar.css
+++ b/frontend/src/components/events/EventsCalendar.css
@@ -144,11 +144,13 @@
 }
 
 .calendar-event-dot {
+  display: inline-block;
   width: 10px;
   height: 10px;
   border-radius: 50%;
   cursor: pointer;
   transition: transform 0.15s;
+  text-decoration: none;
 }
 
 .calendar-event-dot:hover {

--- a/frontend/src/components/events/EventsCalendar.tsx
+++ b/frontend/src/components/events/EventsCalendar.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { EventType, EventCalendarEntry } from '../../types/event';
 import { eventsApi } from '../../services/api';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import EventCard from './EventCard';
 import './EventsCalendar.css';
 
@@ -16,6 +18,7 @@ type FilterTab = 'all' | EventType;
 
 export default function EventsCalendar() {
   const { t } = useTranslation();
+  useDocumentTitle(t('events.title'));
   const now = new Date();
   const [currentMonth, setCurrentMonth] = useState(now.getMonth());
   const [currentYear, setCurrentYear] = useState(now.getFullYear());
@@ -240,11 +243,13 @@ export default function EventsCalendar() {
                   {eventsByDay[day] && (
                     <div className="calendar-day-events">
                       {eventsByDay[day].map((evt) => (
-                        <div
+                        <Link
                           key={evt.eventId}
+                          to={`/events/${evt.eventId}`}
                           className="calendar-event-dot"
                           style={{ backgroundColor: eventTypeColors[evt.eventType] }}
                           title={evt.name}
+                          aria-label={evt.name}
                         />
                       ))}
                     </div>

--- a/frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+const BASE_TITLE = 'League SZN';
+
+/**
+ * Sets the document title for the current page.
+ * @param pageTitle - The page-specific title (e.g. "Standings"). Resulting title: "{pageTitle} | League SZN"
+ * @param options - If { fullTitle: true }, use pageTitle as the entire title with no suffix.
+ */
+export function useDocumentTitle(
+  pageTitle: string,
+  options?: { fullTitle?: boolean }
+): void {
+  useEffect(() => {
+    const previous = document.title;
+    document.title = options?.fullTitle
+      ? pageTitle
+      : pageTitle
+        ? `${pageTitle} | ${BASE_TITLE}`
+        : BASE_TITLE;
+    return () => {
+      document.title = previous;
+    };
+  }, [pageTitle, options?.fullTitle]);
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -30,7 +30,13 @@
     "submitting": "Wird eingereicht...",
     "loading": "Wird geladen...",
     "print": "Drucken",
-    "accessDenied": "Zugriff verweigert"
+    "accessDenied": "Zugriff verweigert",
+    "back": "Zurück",
+    "backToHome": "Zurück zur Startseite"
+  },
+  "notFound": {
+    "title": "Seite nicht gefunden",
+    "message": "Die angeforderte Seite existiert nicht oder wurde verschoben."
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -30,7 +30,13 @@
     "submitting": "Submitting...",
     "loading": "Loading...",
     "print": "Print",
-    "accessDenied": "Access Denied"
+    "accessDenied": "Access Denied",
+    "back": "Back",
+    "backToHome": "Back to Home"
+  },
+  "notFound": {
+    "title": "Page Not Found",
+    "message": "The page you're looking for doesn't exist or has been moved."
   },
   "nav": {
     "dashboard": "Dashboard",


### PR DESCRIPTION
## Summary

Implements four enhancement issues in parallel on a single branch:

### #156 — UX: 404 page, breadcrumbs, scroll-to-top
- **NotFound** page with friendly message and "Back to Home" link
- **ScrollToTop** component: scrolls to top on route change
- **BackLink** component for detail pages (reusable)
- Catch-all route `path="*"` in `App.tsx` so invalid URLs show 404

### #160 — UX: Standings rows and calendar event dots interactive
- **Standings**: Table rows are clickable (navigate to `/stats/player/:playerId`); player name link uses `stopPropagation` so both work
- **EventsCalendar**: Event dots in the calendar grid are now `<Link to={/events/:eventId}>` so clicking opens event detail

### #161 — UX: Sidebar width and collapsible mode
- Sidebar width reduced from 300px to **260px** (TopBar and main margin updated)
- **Collapsible**: Toggle in header collapses sidebar to **64px** (icon-only width); state persisted in `localStorage`
- When collapsed, only the expand/collapse chevron is shown

### #162 — Polish: Favicon, dynamic title, print styles
- **useDocumentTitle** hook: pages set document title (e.g. "Standings | League SZN")
- **Favicon**: `public/favicon.svg` (gold "L" on dark background); `index.html` title set to "League SZN"
- **Print**: Improved print styles so text is black on white and tables/borders are readable

---

Closes #156, #160, #161, #162.