### PR TITLE
Implements #157 — UX: Fix modal and dropdown interaction patterns

### DIFF
--- a/docs/plans/plan-issue-157-modal-dropdown-interaction.md
+++ b/docs/plans/plan-issue-157-modal-dropdown-interaction.md
@@ -1,0 +1,68 @@
+# Plan: UX — Fix modal and dropdown interaction patterns
+
+**GitHub issue:** #157 — [UX: Fix modal and dropdown interaction patterns](https://github.com/jpDxsolo/league_szn/issues/157)
+
+## Context
+
+Championship History and Tournament detail modals lack backdrop click-to-close and Escape key handling. TopNav desktop dropdowns use a fragile 150ms `setTimeout` on blur, causing unreliable close behavior and keyboard issues. This plan adds standard modal UX (backdrop click, Escape) and replaces the dropdown blur hack with a proper click-outside listener.
+
+## Skills to use
+
+| When | Skill | Purpose |
+|------|--------|---------|
+| After implementation | code-reviewer | Review changed components |
+| Before commit | git-commit-helper | Conventional commit message |
+
+## Agents and parallel work
+
+- **Suggested order**: Steps 1+2+3 (all three components can be updated in parallel).
+- **Agent types**: general-purpose for all steps (React/frontend).
+
+## Files to modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/components/Championships.tsx` | Modify | Add backdrop click + Escape for history modal; optional focus trap |
+| `frontend/src/components/Tournaments.tsx` | Modify | Add backdrop click + Escape for tournament detail modal |
+| `frontend/src/components/TopNav.tsx` | Modify | Replace onBlur setTimeout with click-outside (useRef + useEffect) |
+
+## Implementation steps
+
+### Step 1: Championships.tsx — modal backdrop and Escape
+
+- **Backdrop close**: The history modal is a div with class `history-modal` wrapping `history-content`. Add an `onClick` on the outer `history-modal` div that calls `setSelectedChampionship(null)` when the modal is open. On the inner `history-content` div, add `onClick={(e) => e.stopPropagation()}` so clicks inside the content do not close the modal.
+- **Escape key**: Add a `useEffect` that subscribes to `keydown` on `document` when `selectedChampionship` is non-null. If `e.key === 'Escape'`, call `setSelectedChampionship(null)`. Clean up the listener in the effect return. Dependencies: `[selectedChampionship]`.
+- **Optional (nice-to-have)**: Add `role="dialog"` and `aria-modal="true"` if not already present (they are). Consider focusing the close button or the modal container when the modal opens and restoring focus on close; if time permits, add a simple focus trap (focus stays inside the modal until closed).
+- Do not change loading/error/data logic; only change how the modal is dismissed.
+
+### Step 2: Tournaments.tsx — modal backdrop and Escape
+
+- **Backdrop close**: The tournament detail modal uses `tournament-modal` (outer) and `tournament-content` (inner). Add `onClick` on the outer div to call `setSelectedTournament(null)`. On the inner `tournament-content` div, add `onClick={(e) => e.stopPropagation()}` so clicks inside do not close the modal.
+- **Escape key**: Add a `useEffect` that subscribes to `keydown` when `selectedTournament` is non-null. If `e.key === 'Escape'`, call `setSelectedTournament(null)`. Clean up in the effect return. Dependencies: `[selectedTournament]`.
+- Ensure the modal has `role="dialog"` and `aria-modal="true"` and `aria-labelledby` pointing to the modal title for accessibility (add if missing).
+- Do not change tournament data or render logic; only modal dismissal behavior.
+
+### Step 3: TopNav.tsx — replace blur setTimeout with click-outside
+
+- **Remove** the `onBlur={() => setTimeout(closeDropdown, 150)}` from both dropdown buttons (user nav groups and admin button). Do not rely on blur + timeout to close the dropdown.
+- **Add** a click-outside (and optionally focus-outside) listener: In a `useEffect`, when `openGroup` is non-null, add a `mousedown` listener on `document`. In the handler, if the event target is not contained in `navRef.current` (and not inside the flyout), call `closeDropdown()`. Use `navRef` which already exists; ensure the flyout content is inside the element guarded by `navRef` so clicks on flyout links do not close prematurely. Attach the listener only when `openGroup !== null` and clean up on unmount or when `openGroup` becomes null. Dependencies: `[openGroup, closeDropdown]`.
+- **Keyboard**: Escape already closes the dropdown (existing `handleEscape` in `useEffect`). Ensure that when using the new click-outside approach, keyboard navigation (Tab, Enter) still works for links inside the flyout; the click-outside should not fire when focus moves to a link (only actual outside clicks). If needed, use `mousedown` (not `click`) so that focus changes from button to link do not trigger a spurious close.
+- Test that opening a group and clicking a link still navigates and closes the dropdown; opening and clicking outside closes the dropdown without flashing.
+
+## Dependencies and order
+
+- Steps 1, 2, and 3 are independent (different files, no shared state).
+- **Suggested order**: Steps 1+2+3.
+
+## Testing and verification
+
+- **Manual**: Open Championships, click "View history" on a title; click the backdrop → modal closes; press Escape → modal closes; click inside content → modal stays open.
+- **Manual**: Open Tournaments, click "View details" on a tournament; same backdrop and Escape behavior; click inside content → modal stays open.
+- **Manual**: TopNav desktop: open a nav group dropdown; click outside (e.g. on page content) → dropdown closes; click a link inside → navigates and dropdown closes; no flash or failure to close. Use Tab and Enter to navigate dropdown items and confirm no regression.
+- Run frontend lint and existing tests; no new test files required unless the team prefers unit tests for modal/dropdown behavior.
+
+## Risks and edge cases
+
+- **TopNav**: If the flyout is rendered in a portal or outside `navRef`, the click-outside check must include the flyout container so clicks on menu items are not treated as outside. Current structure has flyout inside `topnav-dropdown-wrap` which is inside `navRef`; verify and adjust the containment check if needed.
+- **Escape**: If multiple modals could be stacked in the future, consider closing only the topmost; for this issue, only one modal is open at a time.
+- **Focus**: Restoring focus to the trigger button after closing the modal improves accessibility; add if straightforward in the same change set.

--- a/frontend/src/components/Championships.tsx
+++ b/frontend/src/components/Championships.tsx
@@ -100,6 +100,15 @@ export default function Championships() {
     }
   }, []);
 
+  useEffect(() => {
+    if (!selectedChampionship) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSelectedChampionship(null);
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [selectedChampionship]);
+
   const filteredChampionships = useMemo((): Championship[] => {
     if (selectedDivision === 'all') {
       return championships;
@@ -203,8 +212,9 @@ export default function Championships() {
           role="dialog"
           aria-modal="true"
           aria-labelledby="history-modal-title"
+          onClick={() => setSelectedChampionship(null)}
         >
-          <div className="history-content">
+          <div className="history-content" onClick={(e) => e.stopPropagation()}>
             <div className="history-header">
               <h3 id="history-modal-title">
                 {championships.find(c => c.championshipId === selectedChampionship)?.name} {t('championships.history')}

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -93,6 +93,17 @@ export default function TopNav() {
 
   const closeDropdown = useCallback(() => setOpenGroup(null), []);
 
+  useEffect(() => {
+    if (openGroup === null) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) {
+        closeDropdown();
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [openGroup, closeDropdown]);
+
   const isActive = (path: string) => location.pathname === path;
   const isActivePrefix = (path: string) => location.pathname === path || location.pathname.startsWith(path + '/');
 
@@ -271,7 +282,6 @@ export default function TopNav() {
                   type="button"
                   className="topnav-menu-btn"
                   onClick={() => setOpenGroup(isOpen ? null : group.key)}
-                  onBlur={() => setTimeout(closeDropdown, 150)}
                   aria-expanded={isOpen}
                   aria-haspopup="true"
                 >
@@ -331,7 +341,6 @@ export default function TopNav() {
                 type="button"
                 className="topnav-menu-btn"
                 onClick={() => setOpenGroup(openGroup === 'admin' ? null : 'admin')}
-                onBlur={() => setTimeout(closeDropdown, 150)}
                 aria-expanded={openGroup === 'admin'}
                 aria-haspopup="true"
               >

--- a/frontend/src/components/Tournaments.tsx
+++ b/frontend/src/components/Tournaments.tsx
@@ -62,6 +62,15 @@ export default function Tournaments() {
     return () => abortController.abort();
   }, []);
 
+  useEffect(() => {
+    if (!selectedTournament) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSelectedTournament(null);
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [selectedTournament]);
+
   const getPlayerName = (playerId: string) => {
     const player = players.find(p => p.playerId === playerId);
     return player ? player.name : t('common.unknown');
@@ -213,13 +222,20 @@ export default function Tournaments() {
       </div>
 
       {selectedTournament && (
-        <div className="tournament-modal">
-          <div className="tournament-content">
+        <div
+          className="tournament-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="tournament-modal-title"
+          onClick={() => setSelectedTournament(null)}
+        >
+          <div className="tournament-content" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
-              <h3>{selectedTournament.name}</h3>
+              <h3 id="tournament-modal-title">{selectedTournament.name}</h3>
               <button
                 onClick={() => setSelectedTournament(null)}
                 className="close-btn"
+                aria-label={t('common.closeModal') || 'Close modal'}
               >
                 ×
               </button>


### PR DESCRIPTION
Closes #157.

Implements [UX: Fix modal and dropdown interaction patterns](https://github.com/jpDxsoloOrg/league_szn/issues/157).

**Changes:**
- **Championships.tsx**: History modal now closes on backdrop click and Escape key; inner content uses `stopPropagation` so clicks inside do not close.
- **Tournaments.tsx**: Tournament detail modal gets the same backdrop click and Escape behavior; added `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and close button `aria-label`.
- **TopNav.tsx**: Replaced `onBlur` + 150ms `setTimeout` on dropdown buttons with a document `mousedown` click-outside listener using `navRef`, so dropdowns close reliably when clicking outside without flashing.