### PR TITLE
feat: Advanced Match Search & Filtering (#205)

### DIFF
--- a/backend/functions/matches/__tests__/getMatches.test.ts
+++ b/backend/functions/matches/__tests__/getMatches.test.ts
@@ -43,7 +43,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: { authorizer: {} } as any,
+    requestContext: { authorizer: {} } as unknown as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -98,13 +98,13 @@ describe('getMatches', () => {
     expect(mockScan).toHaveBeenCalledWith(
       expect.objectContaining({
         FilterExpression: '#status = :status',
-        ExpressionAttributeNames: { '#status': 'status' },
-        ExpressionAttributeValues: { ':status': 'scheduled' },
+        ExpressionAttributeNames: expect.objectContaining({ '#status': 'status' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':status': 'scheduled' }),
       }),
     );
   });
 
-  it('does not add filter when no status parameter provided', async () => {
+  it('does not add filter when no query parameters provided', async () => {
     mockScan.mockResolvedValue({ Items: [] });
 
     await getMatches(makeEvent(), ctx, cb);
@@ -113,6 +113,174 @@ describe('getMatches', () => {
     expect(callArgs.FilterExpression).toBeUndefined();
     expect(callArgs.ExpressionAttributeNames).toBeUndefined();
     expect(callArgs.ExpressionAttributeValues).toBeUndefined();
+  });
+
+  it('filters by playerId using contains on participants', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { playerId: 'p1' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: 'contains(#participants, :playerId)',
+        ExpressionAttributeNames: expect.objectContaining({ '#participants': 'participants' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':playerId': 'p1' }),
+      }),
+    );
+  });
+
+  it('filters by matchType', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { matchType: 'Singles' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: '#matchFormat = :matchFormat',
+        ExpressionAttributeNames: expect.objectContaining({ '#matchFormat': 'matchFormat' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':matchFormat': 'Singles' }),
+      }),
+    );
+  });
+
+  it('filters by stipulationId', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { stipulationId: 'stip1' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: '#stipulationId = :stipulationId',
+        ExpressionAttributeNames: expect.objectContaining({ '#stipulationId': 'stipulationId' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':stipulationId': 'stip1' }),
+      }),
+    );
+  });
+
+  it('filters by championshipId', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { championshipId: 'champ1' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: '#championshipId = :championshipId',
+        ExpressionAttributeNames: expect.objectContaining({ '#championshipId': 'championshipId' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':championshipId': 'champ1' }),
+      }),
+    );
+  });
+
+  it('filters by seasonId', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { seasonId: 's1' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: '#seasonId = :seasonId',
+        ExpressionAttributeNames: expect.objectContaining({ '#seasonId': 'seasonId' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':seasonId': 's1' }),
+      }),
+    );
+  });
+
+  it('filters by dateFrom', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { dateFrom: '2024-01-01' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: '#date >= :dateFrom',
+        ExpressionAttributeNames: expect.objectContaining({ '#date': 'date' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':dateFrom': '2024-01-01' }),
+      }),
+    );
+  });
+
+  it('filters by dateTo', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: { dateTo: '2024-12-31' },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    expect(mockScan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: '#date <= :dateTo',
+        ExpressionAttributeNames: expect.objectContaining({ '#date': 'date' }),
+        ExpressionAttributeValues: expect.objectContaining({ ':dateTo': '2024-12-31' }),
+      }),
+    );
+  });
+
+  it('combines multiple filters with AND logic', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: {
+        status: 'completed',
+        playerId: 'p1',
+        matchType: 'Singles',
+        seasonId: 's1',
+      },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    const callArgs = mockScan.mock.calls[0][0];
+    const filterExpr = callArgs.FilterExpression as string;
+    expect(filterExpr).toContain('#status = :status');
+    expect(filterExpr).toContain('contains(#participants, :playerId)');
+    expect(filterExpr).toContain('#matchFormat = :matchFormat');
+    expect(filterExpr).toContain('#seasonId = :seasonId');
+    expect(filterExpr.split(' AND ')).toHaveLength(4);
+  });
+
+  it('combines dateFrom and dateTo into a single expression', async () => {
+    mockScan.mockResolvedValue({ Items: [] });
+
+    const event = makeEvent({
+      queryStringParameters: {
+        dateFrom: '2024-01-01',
+        dateTo: '2024-12-31',
+      },
+    });
+
+    await getMatches(event, ctx, cb);
+
+    const callArgs = mockScan.mock.calls[0][0];
+    const filterExpr = callArgs.FilterExpression as string;
+    expect(filterExpr).toContain('#date >= :dateFrom');
+    expect(filterExpr).toContain('#date <= :dateTo');
+    expect(filterExpr.split(' AND ')).toHaveLength(2);
   });
 
   it('returns 500 when scan throws', async () => {

--- a/backend/functions/matches/getMatches.ts
+++ b/backend/functions/matches/getMatches.ts
@@ -4,20 +4,74 @@ import { success, serverError } from '../../lib/response';
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
-    const status = event.queryStringParameters?.status;
+    const params = event.queryStringParameters ?? {};
+
+    const filters: string[] = [];
+    const attrNames: Record<string, string> = {};
+    const attrValues: Record<string, unknown> = {};
+
+    if (params.status) {
+      filters.push('#status = :status');
+      attrNames['#status'] = 'status';
+      attrValues[':status'] = params.status;
+    }
+
+    if (params.playerId) {
+      filters.push('contains(#participants, :playerId)');
+      attrNames['#participants'] = 'participants';
+      attrValues[':playerId'] = params.playerId;
+    }
+
+    if (params.matchType) {
+      filters.push('#matchFormat = :matchFormat');
+      attrNames['#matchFormat'] = 'matchFormat';
+      attrValues[':matchFormat'] = params.matchType;
+    }
+
+    if (params.stipulationId) {
+      filters.push('#stipulationId = :stipulationId');
+      attrNames['#stipulationId'] = 'stipulationId';
+      attrValues[':stipulationId'] = params.stipulationId;
+    }
+
+    if (params.championshipId) {
+      filters.push('#championshipId = :championshipId');
+      attrNames['#championshipId'] = 'championshipId';
+      attrValues[':championshipId'] = params.championshipId;
+    }
+
+    if (params.seasonId) {
+      filters.push('#seasonId = :seasonId');
+      attrNames['#seasonId'] = 'seasonId';
+      attrValues[':seasonId'] = params.seasonId;
+    }
+
+    if (params.dateFrom) {
+      filters.push('#date >= :dateFrom');
+      attrNames['#date'] = 'date';
+      attrValues[':dateFrom'] = params.dateFrom;
+    }
+
+    if (params.dateTo) {
+      if (!attrNames['#date']) {
+        attrNames['#date'] = 'date';
+      }
+      filters.push('#date <= :dateTo');
+      attrValues[':dateTo'] = params.dateTo;
+    }
 
     const result = await dynamoDb.scan({
       TableName: TableNames.MATCHES,
-      ...(status && {
-        FilterExpression: '#status = :status',
-        ExpressionAttributeNames: { '#status': 'status' },
-        ExpressionAttributeValues: { ':status': status },
+      ...(filters.length > 0 && {
+        FilterExpression: filters.join(' AND '),
+        ExpressionAttributeNames: attrNames,
+        ExpressionAttributeValues: attrValues,
       }),
     });
 
     // Sort by date descending (most recent first)
     const matches = (result.Items || []).sort((a, b) => {
-      return new Date(b.date).getTime() - new Date(a.date).getTime();
+      return new Date(b.date as string).getTime() - new Date(a.date as string).getTime();
     });
 
     return success(matches);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Standings from './components/Standings';
 import ActivityFeed from './components/ActivityFeed';
 import Championships from './components/Championships';
 import Tournaments from './components/Tournaments';
+import MatchSearch from './components/MatchSearch';
 import { WikiLayout } from './components/Wiki';
 import WikiIndex from './components/WikiIndex';
 import WikiArticle from './components/WikiArticle';
@@ -100,7 +101,7 @@ function AppLayout() {
             <Route path="/standings" element={<Standings />} />
             <Route path="/activity" element={<ActivityFeed />} />
             <Route path="/championships" element={<Championships />} />
-            <Route path="/matches" element={<Navigate to="/events" replace />} />
+            <Route path="/matches" element={<MatchSearch />} />
             <Route path="/tournaments" element={<Tournaments />} />
             <Route path="/guide" element={<Navigate to="/guide/wiki" replace />} />
             <Route path="/guide/wiki" element={<WikiLayout />}>

--- a/frontend/src/components/MatchSearch.css
+++ b/frontend/src/components/MatchSearch.css
@@ -1,0 +1,222 @@
+.match-search-container {
+  width: 100%;
+}
+
+.match-search-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.match-search-header h2 {
+  margin: 0;
+}
+
+/* Filter Panel */
+.match-search-filters {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-row:last-child {
+  margin-bottom: 0;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 160px;
+}
+
+.filter-field label {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.filter-field select,
+.filter-field input[type="date"] {
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.filter-field select:focus,
+.filter-field input[type="date"]:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.filter-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.clear-filters-btn {
+  padding: 0.375rem 0.75rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.clear-filters-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.results-count {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+/* Match Cards */
+.match-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.match-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+.match-card:hover {
+  border-color: var(--color-primary);
+}
+
+.match-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.match-date {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.match-status-badge {
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.match-status-badge.completed {
+  background-color: rgba(76, 175, 80, 0.15);
+  color: #4caf50;
+}
+
+.match-status-badge.scheduled {
+  background-color: rgba(255, 193, 7, 0.15);
+  color: #ffc107;
+}
+
+.match-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.match-participants {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.match-vs {
+  color: var(--color-text-secondary);
+  font-weight: 400;
+  font-size: 0.85rem;
+}
+
+.match-winner {
+  color: #4caf50;
+  font-weight: 600;
+}
+
+.match-loser {
+  color: var(--color-text-secondary);
+}
+
+.match-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.match-tag {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  background-color: var(--color-background);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+
+.match-tag.championship-tag {
+  background-color: rgba(255, 215, 0, 0.1);
+  color: #ffd700;
+  border-color: rgba(255, 215, 0, 0.3);
+}
+
+.match-tag.season-tag {
+  background-color: rgba(100, 149, 237, 0.1);
+  color: #6495ed;
+  border-color: rgba(100, 149, 237, 0.3);
+}
+
+.match-tag.star-tag {
+  background-color: rgba(255, 193, 7, 0.1);
+  color: #ffc107;
+  border-color: rgba(255, 193, 7, 0.3);
+}
+
+.match-tag.motn-tag {
+  background-color: rgba(255, 87, 34, 0.1);
+  color: #ff5722;
+  border-color: rgba(255, 87, 34, 0.3);
+}
+
+@media (max-width: 768px) {
+  .filter-row {
+    flex-direction: column;
+  }
+
+  .filter-field {
+    min-width: unset;
+  }
+}

--- a/frontend/src/components/MatchSearch.tsx
+++ b/frontend/src/components/MatchSearch.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { matchesApi, playersApi, seasonsApi, championshipsApi, stipulationsApi, matchTypesApi } from '../services/api';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import type { Match, MatchFilters, Player, Season, Championship, Stipulation, MatchType } from '../types';
+import Skeleton from './ui/Skeleton';
+import EmptyState from './ui/EmptyState';
+import './MatchSearch.css';
+
+const FILTER_KEYS: (keyof MatchFilters)[] = [
+  'status', 'playerId', 'matchType', 'stipulationId', 'championshipId', 'seasonId', 'dateFrom', 'dateTo',
+];
+
+function filtersFromParams(params: URLSearchParams): MatchFilters {
+  const filters: MatchFilters = {};
+  for (const key of FILTER_KEYS) {
+    const value = params.get(key);
+    if (value) {
+      (filters as Record<string, string>)[key] = value;
+    }
+  }
+  return filters;
+}
+
+function filtersToParams(filters: MatchFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) params.set(key, value);
+  }
+  return params;
+}
+
+function hasActiveFilters(filters: MatchFilters): boolean {
+  return Object.values(filters).some((v) => !!v);
+}
+
+export default function MatchSearch() {
+  const { t } = useTranslation();
+  useDocumentTitle(t('matchSearch.title'));
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [championships, setChampionships] = useState<Championship[]>([]);
+  const [stipulations, setStipulations] = useState<Stipulation[]>([]);
+  const [matchTypes, setMatchTypes] = useState<MatchType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const filters = useMemo(() => filtersFromParams(searchParams), [searchParams]);
+
+  const updateFilter = useCallback((key: keyof MatchFilters, value: string) => {
+    const next = { ...filtersFromParams(searchParams) };
+    if (value) {
+      (next as Record<string, string>)[key] = value;
+    } else {
+      delete (next as Record<string, string>)[key];
+    }
+    setSearchParams(filtersToParams(next), { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const clearFilters = useCallback(() => {
+    setSearchParams(new URLSearchParams(), { replace: true });
+  }, [setSearchParams]);
+
+  // Load reference data on mount
+  useEffect(() => {
+    const controller = new AbortController();
+    const load = async () => {
+      try {
+        const [playersData, seasonsData, championshipsData, stipulationsData, matchTypesData] = await Promise.all([
+          playersApi.getAll(controller.signal),
+          seasonsApi.getAll(controller.signal),
+          championshipsApi.getAll(controller.signal),
+          stipulationsApi.getAll(controller.signal),
+          matchTypesApi.getAll(controller.signal),
+        ]);
+        if (!controller.signal.aborted) {
+          setPlayers(playersData);
+          setSeasons(seasonsData);
+          setChampionships(championshipsData);
+          setStipulations(stipulationsData);
+          setMatchTypes(matchTypesData);
+        }
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          console.error('Failed to load reference data', err);
+        }
+      }
+    };
+    load();
+    return () => controller.abort();
+  }, []);
+
+  // Load matches whenever filters change
+  useEffect(() => {
+    const controller = new AbortController();
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await matchesApi.getAll(
+          hasActiveFilters(filters) ? filters : undefined,
+          controller.signal,
+        );
+        if (!controller.signal.aborted) {
+          setMatches(data);
+        }
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          setError(err instanceof Error ? err.message : 'Failed to load matches');
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => controller.abort();
+  }, [filters]);
+
+  const playerMap = useMemo(() => {
+    const map = new Map<string, Player>();
+    for (const p of players) map.set(p.playerId, p);
+    return map;
+  }, [players]);
+
+  const championshipMap = useMemo(() => {
+    const map = new Map<string, Championship>();
+    for (const c of championships) map.set(c.championshipId, c);
+    return map;
+  }, [championships]);
+
+  const stipulationMap = useMemo(() => {
+    const map = new Map<string, Stipulation>();
+    for (const s of stipulations) map.set(s.stipulationId, s);
+    return map;
+  }, [stipulations]);
+
+  const seasonMap = useMemo(() => {
+    const map = new Map<string, Season>();
+    for (const s of seasons) map.set(s.seasonId, s);
+    return map;
+  }, [seasons]);
+
+  const getPlayerName = useCallback((id: string) => playerMap.get(id)?.name ?? id, [playerMap]);
+
+  return (
+    <div className="match-search-container">
+      <div className="match-search-header">
+        <h2>{t('matchSearch.title')}</h2>
+      </div>
+
+      {/* Filter Panel */}
+      <div className="match-search-filters" role="search" aria-label={t('matchSearch.filtersLabel')}>
+        <div className="filter-row">
+          {/* Player */}
+          <div className="filter-field">
+            <label htmlFor="filter-player">{t('matchSearch.filters.player')}</label>
+            <select
+              id="filter-player"
+              value={filters.playerId ?? ''}
+              onChange={(e) => updateFilter('playerId', e.target.value)}
+            >
+              <option value="">{t('common.all')}</option>
+              {players.map((p) => (
+                <option key={p.playerId} value={p.playerId}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Match Type */}
+          <div className="filter-field">
+            <label htmlFor="filter-matchType">{t('matchSearch.filters.matchType')}</label>
+            <select
+              id="filter-matchType"
+              value={filters.matchType ?? ''}
+              onChange={(e) => updateFilter('matchType', e.target.value)}
+            >
+              <option value="">{t('common.all')}</option>
+              {matchTypes.map((mt) => (
+                <option key={mt.matchTypeId} value={mt.name}>{mt.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Stipulation */}
+          <div className="filter-field">
+            <label htmlFor="filter-stipulation">{t('matchSearch.filters.stipulation')}</label>
+            <select
+              id="filter-stipulation"
+              value={filters.stipulationId ?? ''}
+              onChange={(e) => updateFilter('stipulationId', e.target.value)}
+            >
+              <option value="">{t('common.all')}</option>
+              {stipulations.map((s) => (
+                <option key={s.stipulationId} value={s.stipulationId}>{s.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Status */}
+          <div className="filter-field">
+            <label htmlFor="filter-status">{t('matchSearch.filters.status')}</label>
+            <select
+              id="filter-status"
+              value={filters.status ?? ''}
+              onChange={(e) => updateFilter('status', e.target.value)}
+            >
+              <option value="">{t('common.all')}</option>
+              <option value="scheduled">{t('common.scheduled')}</option>
+              <option value="completed">{t('common.completed')}</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="filter-row">
+          {/* Championship */}
+          <div className="filter-field">
+            <label htmlFor="filter-championship">{t('matchSearch.filters.championship')}</label>
+            <select
+              id="filter-championship"
+              value={filters.championshipId ?? ''}
+              onChange={(e) => updateFilter('championshipId', e.target.value)}
+            >
+              <option value="">{t('common.all')}</option>
+              {championships.map((c) => (
+                <option key={c.championshipId} value={c.championshipId}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Season */}
+          <div className="filter-field">
+            <label htmlFor="filter-season">{t('matchSearch.filters.season')}</label>
+            <select
+              id="filter-season"
+              value={filters.seasonId ?? ''}
+              onChange={(e) => updateFilter('seasonId', e.target.value)}
+            >
+              <option value="">{t('common.all')}</option>
+              {seasons.map((s) => (
+                <option key={s.seasonId} value={s.seasonId}>{s.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Date From */}
+          <div className="filter-field">
+            <label htmlFor="filter-dateFrom">{t('matchSearch.filters.dateFrom')}</label>
+            <input
+              id="filter-dateFrom"
+              type="date"
+              value={filters.dateFrom ?? ''}
+              onChange={(e) => updateFilter('dateFrom', e.target.value)}
+            />
+          </div>
+
+          {/* Date To */}
+          <div className="filter-field">
+            <label htmlFor="filter-dateTo">{t('matchSearch.filters.dateTo')}</label>
+            <input
+              id="filter-dateTo"
+              type="date"
+              value={filters.dateTo ?? ''}
+              onChange={(e) => updateFilter('dateTo', e.target.value)}
+            />
+          </div>
+        </div>
+
+        {hasActiveFilters(filters) && (
+          <div className="filter-actions">
+            <button type="button" className="clear-filters-btn" onClick={clearFilters}>
+              {t('matchSearch.filters.clearAll')}
+            </button>
+            <span className="results-count">
+              {t('matchSearch.resultsCount', { count: matches.length })}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Results */}
+      {loading ? (
+        <Skeleton variant="block" count={5} />
+      ) : error ? (
+        <EmptyState
+          title={t('common.error')}
+          description={error}
+          actionLabel={t('common.retry')}
+          onAction={() => setSearchParams(searchParams, { replace: true })}
+        />
+      ) : matches.length === 0 ? (
+        <EmptyState
+          title={t('matchSearch.noResults')}
+          description={
+            hasActiveFilters(filters)
+              ? t('matchSearch.noResultsFiltered')
+              : t('matchSearch.noMatches')
+          }
+          actionLabel={hasActiveFilters(filters) ? t('matchSearch.filters.clearAll') : undefined}
+          onAction={hasActiveFilters(filters) ? clearFilters : undefined}
+        />
+      ) : (
+        <div className="match-search-results">
+          {matches.map((match) => (
+            <div key={match.matchId} className={`match-card match-${match.status}`}>
+              <div className="match-card-header">
+                <span className="match-date">
+                  {new Date(match.date).toLocaleDateString()}
+                </span>
+                <span className={`match-status-badge ${match.status}`}>
+                  {t(`common.${match.status}`)}
+                </span>
+              </div>
+
+              <div className="match-card-body">
+                <div className="match-participants">
+                  {match.participants.map((pid, i) => (
+                    <span key={pid}>
+                      {i > 0 && <span className="match-vs"> {t('common.vs')} </span>}
+                      <span className={
+                        match.winners?.includes(pid) ? 'match-winner' :
+                        match.losers?.includes(pid) ? 'match-loser' : ''
+                      }>
+                        {getPlayerName(pid)}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+
+                <div className="match-meta">
+                  {match.matchFormat && (
+                    <span className="match-tag">{match.matchFormat}</span>
+                  )}
+                  {match.stipulationId && stipulationMap.get(match.stipulationId) && (
+                    <span className="match-tag">{stipulationMap.get(match.stipulationId)!.name}</span>
+                  )}
+                  {match.championshipId && championshipMap.get(match.championshipId) && (
+                    <span className="match-tag championship-tag">
+                      {championshipMap.get(match.championshipId)!.name}
+                    </span>
+                  )}
+                  {match.seasonId && seasonMap.get(match.seasonId) && (
+                    <span className="match-tag season-tag">
+                      {seasonMap.get(match.seasonId)!.name}
+                    </span>
+                  )}
+                  {match.starRating != null && match.starRating > 0 && (
+                    <span className="match-tag star-tag">
+                      {'★'.repeat(match.starRating)}
+                    </span>
+                  )}
+                  {match.matchOfTheNight && (
+                    <span className="match-tag motn-tag">{t('match.matchOfTheNight')}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -135,6 +135,7 @@ export default function TopBar() {
       '/championships': t('nav.championships'),
       '/tournaments': t('nav.tournaments'),
       '/events': t('nav.events'),
+      '/matches': t('nav.matchSearch'),
       '/contenders': t('nav.contenders'),
       '/challenges': t('nav.challenges'),
       '/promos': t('nav.promos'),

--- a/frontend/src/components/__tests__/App.test.tsx
+++ b/frontend/src/components/__tests__/App.test.tsx
@@ -166,13 +166,14 @@ describe('App', () => {
     });
   });
 
-  it('redirects /matches to /events', async () => {
+  it('renders /matches as MatchSearch page', async () => {
     mockUseAuth.mockReturnValue(authenticatedAuth());
     testEntries = ['/matches'];
     render(<App />);
 
+    // /matches should render the MatchSearch component, not redirect
     await waitFor(() => {
-      expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/events');
+      expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/__tests__/MatchSearch.test.tsx
+++ b/frontend/src/components/__tests__/MatchSearch.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// --- Hoisted mocks ---
+const {
+  mockGetAllMatches,
+  mockGetAllPlayers,
+  mockGetAllSeasons,
+  mockGetAllChampionships,
+  mockGetAllStipulations,
+  mockGetAllMatchTypes,
+} = vi.hoisted(() => ({
+  mockGetAllMatches: vi.fn(),
+  mockGetAllPlayers: vi.fn(),
+  mockGetAllSeasons: vi.fn(),
+  mockGetAllChampionships: vi.fn(),
+  mockGetAllStipulations: vi.fn(),
+  mockGetAllMatchTypes: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+  matchesApi: { getAll: mockGetAllMatches },
+  playersApi: { getAll: mockGetAllPlayers },
+  seasonsApi: { getAll: mockGetAllSeasons },
+  championshipsApi: { getAll: mockGetAllChampionships },
+  stipulationsApi: { getAll: mockGetAllStipulations },
+  matchTypesApi: { getAll: mockGetAllMatchTypes },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        'matchSearch.title': 'Match Search',
+        'matchSearch.filtersLabel': 'Match filters',
+        'matchSearch.filters.player': 'Player',
+        'matchSearch.filters.matchType': 'Match Type',
+        'matchSearch.filters.stipulation': 'Stipulation',
+        'matchSearch.filters.status': 'Status',
+        'matchSearch.filters.championship': 'Championship',
+        'matchSearch.filters.season': 'Season',
+        'matchSearch.filters.dateFrom': 'From',
+        'matchSearch.filters.dateTo': 'To',
+        'matchSearch.filters.clearAll': 'Clear Filters',
+        'matchSearch.resultsCount': `${opts?.count ?? 0} match(es) found`,
+        'matchSearch.noResults': 'No Matches Found',
+        'matchSearch.noResultsFiltered': 'No matches match your current filters.',
+        'matchSearch.noMatches': 'No matches have been recorded yet.',
+        'common.all': 'All',
+        'common.scheduled': 'Scheduled',
+        'common.completed': 'Completed',
+        'common.error': 'Error',
+        'common.retry': 'Retry',
+        'common.vs': 'vs',
+        'match.matchOfTheNight': 'Match of the Night',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('../MatchSearch.css', () => ({}));
+vi.mock('../ui/Skeleton', () => ({
+  default: () => <div data-testid="skeleton">Loading...</div>,
+}));
+vi.mock('../ui/EmptyState', () => ({
+  default: ({ title, description, actionLabel, onAction }: {
+    title: string; description: string; actionLabel?: string; onAction?: () => void;
+  }) => (
+    <div data-testid="empty-state">
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {actionLabel && onAction && <button onClick={onAction}>{actionLabel}</button>}
+    </div>
+  ),
+}));
+
+import MatchSearch from '../MatchSearch';
+
+// --- Test data ---
+const mockPlayers = [
+  { playerId: 'p1', name: 'John Cena', currentWrestler: 'John Cena', wins: 10, losses: 5, draws: 0, createdAt: '', updatedAt: '' },
+  { playerId: 'p2', name: 'The Rock', currentWrestler: 'The Rock', wins: 8, losses: 3, draws: 1, createdAt: '', updatedAt: '' },
+];
+
+const mockSeasons = [
+  { seasonId: 's1', name: 'Season 1', startDate: '2024-01-01', status: 'completed' as const, createdAt: '', updatedAt: '' },
+];
+
+const mockChampionships = [
+  { championshipId: 'c1', name: 'World Title', type: 'singles' as const, createdAt: '', isActive: true },
+];
+
+const mockStipulations = [
+  { stipulationId: 'st1', name: 'Ladder Match', createdAt: '', updatedAt: '' },
+];
+
+const mockMatchTypes = [
+  { matchTypeId: 'mt1', name: 'Singles', createdAt: '', updatedAt: '' },
+  { matchTypeId: 'mt2', name: 'Tag Team', createdAt: '', updatedAt: '' },
+];
+
+const mockMatches = [
+  {
+    matchId: 'm1',
+    date: '2024-03-15T20:00:00Z',
+    matchFormat: 'Singles',
+    participants: ['p1', 'p2'],
+    winners: ['p1'],
+    losers: ['p2'],
+    isChampionship: false,
+    status: 'completed' as const,
+    createdAt: '2024-03-15',
+  },
+  {
+    matchId: 'm2',
+    date: '2024-04-01T20:00:00Z',
+    matchFormat: 'Singles',
+    participants: ['p1', 'p2'],
+    isChampionship: true,
+    championshipId: 'c1',
+    status: 'scheduled' as const,
+    createdAt: '2024-04-01',
+  },
+];
+
+function renderWithRouter(initialEntries = ['/matches']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <MatchSearch />
+    </MemoryRouter>,
+  );
+}
+
+// --- Tests ---
+
+describe('MatchSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAllPlayers.mockResolvedValue(mockPlayers);
+    mockGetAllSeasons.mockResolvedValue(mockSeasons);
+    mockGetAllChampionships.mockResolvedValue(mockChampionships);
+    mockGetAllStipulations.mockResolvedValue(mockStipulations);
+    mockGetAllMatchTypes.mockResolvedValue(mockMatchTypes);
+    mockGetAllMatches.mockResolvedValue(mockMatches);
+  });
+
+  it('renders loading state initially', () => {
+    mockGetAllMatches.mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithRouter();
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('renders match cards after loading', async () => {
+    renderWithRouter();
+    await waitFor(() => {
+      expect(screen.getByText('Match Search')).toBeInTheDocument();
+    });
+    // Both matches should be rendered (names appear in multiple cards)
+    await waitFor(() => {
+      expect(screen.getAllByText(/John Cena/).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(/The Rock/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('renders filter dropdowns with options', async () => {
+    renderWithRouter();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Player')).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText('Match Type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+    expect(screen.getByLabelText('Championship')).toBeInTheDocument();
+    expect(screen.getByLabelText('Season')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stipulation')).toBeInTheDocument();
+    expect(screen.getByLabelText('From')).toBeInTheDocument();
+    expect(screen.getByLabelText('To')).toBeInTheDocument();
+  });
+
+  it('populates player dropdown with fetched players', async () => {
+    renderWithRouter();
+    await waitFor(() => {
+      const playerSelect = screen.getByLabelText('Player') as HTMLSelectElement;
+      const options = Array.from(playerSelect.options).map((o) => o.text);
+      expect(options).toContain('John Cena');
+      expect(options).toContain('The Rock');
+    });
+  });
+
+  it('calls matchesApi.getAll when a filter is changed', async () => {
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Status')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'completed' } });
+
+    await waitFor(() => {
+      // Should be called at least twice: once on mount, once after filter change
+      expect(mockGetAllMatches.mock.calls.length).toBeGreaterThanOrEqual(2);
+      // Last call should include the status filter
+      const lastCall = mockGetAllMatches.mock.calls[mockGetAllMatches.mock.calls.length - 1];
+      expect(lastCall[0]).toEqual(expect.objectContaining({ status: 'completed' }));
+    });
+  });
+
+  it('shows empty state when no matches exist', async () => {
+    mockGetAllMatches.mockResolvedValue([]);
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.getByText('No Matches Found')).toBeInTheDocument();
+    });
+  });
+
+  it('shows filtered empty state with clear button', async () => {
+    mockGetAllMatches.mockResolvedValue([]);
+    renderWithRouter(['/matches?status=completed']);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.getByText('No matches match your current filters.')).toBeInTheDocument();
+      // Clear Filters appears both in the filter panel and the empty state
+      expect(screen.getAllByText('Clear Filters').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('shows error state when API fails', async () => {
+    mockGetAllMatches.mockRejectedValue(new Error('API Error'));
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+  });
+
+  it('displays match status badges', async () => {
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Completed').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('Scheduled').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('highlights winners with match-winner class', async () => {
+    renderWithRouter();
+
+    await waitFor(() => {
+      const winnerElements = screen.getAllByText('John Cena');
+      const hasWinnerClass = winnerElements.some((el) => el.className.includes('match-winner'));
+      expect(hasWinnerClass).toBe(true);
+    });
+  });
+});

--- a/frontend/src/config/navConfig.ts
+++ b/frontend/src/config/navConfig.ts
@@ -35,6 +35,7 @@ export const USER_NAV_GROUPS: NavGroup[] = [
       { path: '/activity', i18nKey: 'nav.activity' },
       { path: '/championships', i18nKey: 'nav.championships' },
       { path: '/events', i18nKey: 'nav.events' },
+      { path: '/matches', i18nKey: 'nav.matchSearch' },
       { path: '/tournaments', i18nKey: 'nav.tournaments' },
       { path: '/contenders', i18nKey: 'nav.contenders', feature: 'contenders' },
       { path: '/stats', i18nKey: 'nav.statistics', feature: 'statistics' },
@@ -120,7 +121,7 @@ export const ADMIN_NAV_GROUPS: NavGroup[] = [
 
 /** Path → group key for user nav (for auto-expand) */
 export function getUserGroupForPath(pathname: string): string | null {
-  const core = ['/', '/standings', '/activity', '/championships', '/events', '/tournaments', '/contenders', '/stats'];
+  const core = ['/', '/standings', '/activity', '/championships', '/events', '/matches', '/tournaments', '/contenders', '/stats'];
   const wrestler = ['/profile', '/challenges', '/promos'];
   if (core.some((p) => pathname === p) || pathname.startsWith('/events/') || pathname.startsWith('/stats/') || pathname.startsWith('/contenders/')) return 'core';
   if (wrestler.some((p) => pathname === p || pathname.startsWith(p + '/'))) return 'wrestler';

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -108,6 +108,7 @@
     "wiki": "Wiki",
     "admin": "Admin",
     "contenders": "Herausforderer",
+    "matchSearch": "Kampf-Suche",
     "profile": "Mein Profil",
     "groups": {
       "core": "Liga",
@@ -314,6 +315,25 @@
     "matchOfTheNight": "Match of the Night",
     "matchOfTheNightBadge": "Match of the Night",
     "clearRating": "Bewertung löschen"
+  },
+  "matchSearch": {
+    "title": "Kampf-Suche",
+    "filtersLabel": "Kampffilter",
+    "filters": {
+      "player": "Spieler",
+      "matchType": "Kampftyp",
+      "stipulation": "Stipulation",
+      "status": "Status",
+      "championship": "Meisterschaft",
+      "season": "Saison",
+      "dateFrom": "Von",
+      "dateTo": "Bis",
+      "clearAll": "Filter zurücksetzen"
+    },
+    "resultsCount": "{{count}} Kampf/Kämpfe gefunden",
+    "noResults": "Keine Kämpfe gefunden",
+    "noResultsFiltered": "Keine Kämpfe entsprechen den aktuellen Filtern. Versuchen Sie, die Filter anzupassen oder zurückzusetzen.",
+    "noMatches": "Es wurden noch keine Kämpfe aufgezeichnet."
   },
   "recordResult": {
     "title": "Kampfergebnisse eintragen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -108,6 +108,7 @@
     "wiki": "Wiki",
     "admin": "Admin",
     "contenders": "Contenders",
+    "matchSearch": "Match Search",
     "profile": "My Profile",
     "groups": {
       "core": "League",
@@ -314,6 +315,25 @@
     "matchOfTheNight": "Match of the Night",
     "matchOfTheNightBadge": "Match of the Night",
     "clearRating": "Clear rating"
+  },
+  "matchSearch": {
+    "title": "Match Search",
+    "filtersLabel": "Match filters",
+    "filters": {
+      "player": "Player",
+      "matchType": "Match Type",
+      "stipulation": "Stipulation",
+      "status": "Status",
+      "championship": "Championship",
+      "season": "Season",
+      "dateFrom": "From",
+      "dateTo": "To",
+      "clearAll": "Clear Filters"
+    },
+    "resultsCount": "{{count}} match(es) found",
+    "noResults": "No Matches Found",
+    "noResultsFiltered": "No matches match your current filters. Try adjusting or clearing the filters.",
+    "noMatches": "No matches have been recorded yet."
   },
   "recordResult": {
     "title": "Record Match Results",

--- a/frontend/src/services/api/matches.api.ts
+++ b/frontend/src/services/api/matches.api.ts
@@ -1,10 +1,14 @@
-import type { Match, ScheduleMatchInput } from '../../types';
+import type { Match, MatchFilters, ScheduleMatchInput } from '../../types';
 import { API_BASE_URL, fetchWithAuth } from './apiClient';
 
 export const matchesApi = {
-  getAll: async (filters?: { status?: string }, signal?: AbortSignal): Promise<Match[]> => {
+  getAll: async (filters?: MatchFilters, signal?: AbortSignal): Promise<Match[]> => {
     const params = new URLSearchParams();
-    if (filters?.status) params.set('status', filters.status);
+    if (filters) {
+      for (const [key, value] of Object.entries(filters)) {
+        if (value) params.set(key, value);
+      }
+    }
     const query = params.toString();
     return fetchWithAuth(`${API_BASE_URL}/matches${query ? `?${query}` : ''}`, {}, signal);
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -216,6 +216,17 @@ export interface MatchType {
   updatedAt: string;
 }
 
+export interface MatchFilters {
+  status?: string;
+  playerId?: string;
+  matchType?: string;
+  stipulationId?: string;
+  championshipId?: string;
+  seasonId?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
 /** Activity feed item from GET /activity */
 export type ActivityItemType =
   | 'match_result'


### PR DESCRIPTION
Implements issue #205.

## Changes
- **Backend:** Extended `GET /matches` with 7 combinable query params (playerId, matchType, stipulationId, championshipId, seasonId, dateFrom/dateTo) using AND logic with dynamic DynamoDB FilterExpression
- **Frontend:** New `MatchSearch` component with filter panel, URL-persisted filters via `useSearchParams`, match result cards with winner highlighting, empty states
- **i18n:** EN + DE keys for all filter labels and states
- **Tests:** 14 backend + 10 frontend tests