### PR TITLE
Refactor championships and challenges routing to shared router

### DIFF
--- a/backend/functions/challenges/__tests__/handler.test.ts
+++ b/backend/functions/challenges/__tests__/handler.test.ts
@@ -60,7 +60,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
-    resource: '',
+    resource: '/challenges',
     requestContext: { authorizer: {} } as any,
     ...overrides,
   };
@@ -83,7 +83,7 @@ describe('challenges router', () => {
   it('GET /challenges routes to getChallenges and returns 200', async () => {
     mockScanAll.mockResolvedValue([{ challengeId: 'ch1', challengerId: 'p1', challengedId: 'p2', status: 'pending' }]);
     mockPlayerLookup();
-    const event = makeEvent({ httpMethod: 'GET', path: '/dev/challenges', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/challenges', pathParameters: null });
     const result = await handler(event, ctx, cb);
     expect(result!.statusCode).toBe(200);
     expect(JSON.parse(result!.body)).toHaveLength(1);
@@ -102,7 +102,7 @@ describe('challenges router', () => {
     });
     const event = makeEvent({
       httpMethod: 'GET',
-      path: '/dev/challenges/ch1',
+      resource: '/challenges/{challengeId}',
       pathParameters: { challengeId: 'ch1' },
     });
     const result = await handler(event, ctx, cb);
@@ -116,7 +116,7 @@ describe('challenges router', () => {
     mockPut.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/challenges',
+      resource: '/challenges',
       pathParameters: null,
       body: JSON.stringify({ challengerId: 'p1', challengedId: 'p2', matchType: 'Singles' }),
     });
@@ -138,7 +138,7 @@ describe('challenges router', () => {
     mockUpdate.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/challenges/ch1/respond',
+      resource: '/challenges/{challengeId}/respond',
       pathParameters: { challengeId: 'ch1' },
       body: JSON.stringify({ action: 'accept' }),
     });
@@ -153,7 +153,7 @@ describe('challenges router', () => {
     mockUpdate.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/challenges/ch1/cancel',
+      resource: '/challenges/{challengeId}/cancel',
       pathParameters: { challengeId: 'ch1' },
     });
     const result = await handler(event, ctx, cb);
@@ -165,7 +165,7 @@ describe('challenges router', () => {
     mockDelete.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'DELETE',
-      path: '/dev/challenges/ch1',
+      resource: '/challenges/{challengeId}',
       pathParameters: { challengeId: 'ch1' },
     });
     const result = await handler(event, ctx, cb);
@@ -176,7 +176,7 @@ describe('challenges router', () => {
     mockQueryAll.mockResolvedValue([]);
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/challenges/bulk-delete',
+      resource: '/challenges/bulk-delete',
       pathParameters: null,
       body: JSON.stringify({ statuses: ['cancelled', 'expired'] }),
     });
@@ -187,7 +187,7 @@ describe('challenges router', () => {
   it('returns 405 for unsupported method/path', async () => {
     const event = makeEvent({
       httpMethod: 'PATCH',
-      path: '/dev/challenges',
+      resource: '/challenges',
       pathParameters: null,
     });
     const result = await handler(event, ctx, cb);

--- a/backend/functions/challenges/handler.ts
+++ b/backend/functions/challenges/handler.ts
@@ -1,10 +1,3 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as getChallengesHandler } from './getChallenges';
 import { handler as getChallengeHandler } from './getChallenge';
 import { handler as createChallengeHandler } from './createChallenge';
@@ -12,43 +5,48 @@ import { handler as respondToChallengeHandler } from './respondToChallenge';
 import { handler as cancelChallengeHandler } from './cancelChallenge';
 import { handler as deleteChallengeHandler } from './deleteChallenge';
 import { handler as bulkDeleteChallengesHandler } from './bulkDeleteChallenges';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for challenges: routes by HTTP method and path.
+ * Single Lambda for challenges: routes by HTTP method and resource.
  * Replaces getChallenges, getChallenge, create, respond, cancel, delete, bulkDelete.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const path = event.path ?? '';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/challenges',
+    method: 'GET',
+    handler: getChallengesHandler,
+  },
+  {
+    resource: '/challenges/{challengeId}',
+    method: 'GET',
+    handler: getChallengeHandler,
+  },
+  {
+    resource: '/challenges',
+    method: 'POST',
+    handler: createChallengeHandler,
+  },
+  {
+    resource: '/challenges/{challengeId}/respond',
+    method: 'POST',
+    handler: respondToChallengeHandler,
+  },
+  {
+    resource: '/challenges/{challengeId}/cancel',
+    method: 'POST',
+    handler: cancelChallengeHandler,
+  },
+  {
+    resource: '/challenges/{challengeId}',
+    method: 'DELETE',
+    handler: deleteChallengeHandler,
+  },
+  {
+    resource: '/challenges/bulk-delete',
+    method: 'POST',
+    handler: bulkDeleteChallengesHandler,
+  },
+];
 
-  if (path.includes('bulk-delete') && method === 'POST') {
-    return (await bulkDeleteChallengesHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (path.includes('/respond') && method === 'POST' && pathParams.challengeId) {
-    return (await respondToChallengeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (path.includes('/cancel') && method === 'POST' && pathParams.challengeId) {
-    return (await cancelChallengeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'GET' && !pathParams.challengeId) {
-    return (await getChallengesHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'GET' && pathParams.challengeId) {
-    return (await getChallengeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.challengeId) {
-    return (await createChallengeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'DELETE' && pathParams.challengeId) {
-    return (await deleteChallengeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/championships/__tests__/handler.test.ts
+++ b/backend/functions/championships/__tests__/handler.test.ts
@@ -58,7 +58,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
-    resource: '',
+    resource: '/championships',
     requestContext: { authorizer: {} } as any,
     ...overrides,
   };
@@ -69,7 +69,7 @@ describe('championships router', () => {
 
   it('GET /championships routes to getChampionships and returns 200', async () => {
     mockScan.mockResolvedValue({ Items: [{ championshipId: 'c1', name: 'World' }] });
-    const event = makeEvent({ httpMethod: 'GET', path: '/dev/championships', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/championships', pathParameters: null });
     const result = await handler(event, ctx, cb);
     expect(result!.statusCode).toBe(200);
     expect(JSON.parse(result!.body)).toHaveLength(1);
@@ -79,7 +79,7 @@ describe('championships router', () => {
     mockPut.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/championships',
+      resource: '/championships',
       pathParameters: null,
       body: JSON.stringify({ name: 'World', type: 'singles', divisionId: 'div-1' }),
     });
@@ -92,7 +92,7 @@ describe('championships router', () => {
     mockQuery.mockResolvedValue({ Items: [{ championshipId: 'c1', wonDate: '2025-01-01' }] });
     const event = makeEvent({
       httpMethod: 'GET',
-      path: '/dev/championships/c1/history',
+      resource: '/championships/{championshipId}/history',
       pathParameters: { championshipId: 'c1' },
     });
     const result = await handler(event, ctx, cb);
@@ -108,7 +108,7 @@ describe('championships router', () => {
     mockTransactWrite.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/championships/c1/vacate',
+      resource: '/championships/{championshipId}/vacate',
       pathParameters: { championshipId: 'c1' },
       body: JSON.stringify({ reason: 'Injury' }),
     });
@@ -121,7 +121,7 @@ describe('championships router', () => {
     mockUpdate.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'PUT',
-      path: '/dev/championships/c1',
+      resource: '/championships/{championshipId}',
       pathParameters: { championshipId: 'c1' },
       body: JSON.stringify({ name: 'World Heavyweight' }),
     });
@@ -135,7 +135,7 @@ describe('championships router', () => {
     mockDelete.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'DELETE',
-      path: '/dev/championships/c1',
+      resource: '/championships/{championshipId}',
       pathParameters: { championshipId: 'c1' },
     });
     const result = await handler(event, ctx, cb);
@@ -145,7 +145,7 @@ describe('championships router', () => {
   it('returns 405 for unsupported method/path', async () => {
     const event = makeEvent({
       httpMethod: 'PATCH',
-      path: '/dev/championships',
+      resource: '/championships',
       pathParameters: null,
     });
     const result = await handler(event, ctx, cb);

--- a/backend/functions/championships/handler.ts
+++ b/backend/functions/championships/handler.ts
@@ -1,50 +1,46 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as getChampionshipsHandler } from './getChampionships';
 import { handler as createChampionshipHandler } from './createChampionship';
 import { handler as getChampionshipHistoryHandler } from './getChampionshipHistory';
 import { handler as updateChampionshipHandler } from './updateChampionship';
 import { handler as deleteChampionshipHandler } from './deleteChampionship';
 import { handler as vacateChampionshipHandler } from './vacateChampionship';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for championships: routes by HTTP method and path.
+ * Single Lambda for championships: routes by HTTP method and resource.
  * Replaces getChampionships, createChampionship, getChampionshipHistory, updateChampionship, deleteChampionship, vacateChampionship.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const path = event.path ?? '';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/championships',
+    method: 'GET',
+    handler: getChampionshipsHandler,
+  },
+  {
+    resource: '/championships',
+    method: 'POST',
+    handler: createChampionshipHandler,
+  },
+  {
+    resource: '/championships/{championshipId}/history',
+    method: 'GET',
+    handler: getChampionshipHistoryHandler,
+  },
+  {
+    resource: '/championships/{championshipId}',
+    method: 'PUT',
+    handler: updateChampionshipHandler,
+  },
+  {
+    resource: '/championships/{championshipId}',
+    method: 'DELETE',
+    handler: deleteChampionshipHandler,
+  },
+  {
+    resource: '/championships/{championshipId}/vacate',
+    method: 'POST',
+    handler: vacateChampionshipHandler,
+  },
+];
 
-  if (path.includes('/vacate') && method === 'POST' && pathParams.championshipId) {
-    return (await vacateChampionshipHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (path.includes('/history') && method === 'GET' && pathParams.championshipId) {
-    return (await getChampionshipHistoryHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'GET' && !pathParams.championshipId) {
-    return (await getChampionshipsHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.championshipId) {
-    return (await createChampionshipHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'PUT' && pathParams.championshipId) {
-    return (await updateChampionshipHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'DELETE' && pathParams.championshipId) {
-    return (await deleteChampionshipHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);


### PR DESCRIPTION
## Summary
- migrate `backend/functions/championships/handler.ts` to `createRouter()` with explicit method/resource routes
- migrate `backend/functions/challenges/handler.ts` to `createRouter()` with explicit method/resource routes
- update both handler test suites to route by `event.resource` to match API Gateway resource-based dispatch

## Test plan
- [x] `npm run test -- functions/championships/__tests__/handler.test.ts functions/challenges/__tests__/handler.test.ts`
- [x] `npx eslint functions/championships/handler.ts functions/challenges/handler.ts functions/championships/__tests__/handler.test.ts functions/challenges/__tests__/handler.test.ts`

Part of #209

Made with [Cursor](https://cursor.com)