### PR TITLE
Refactor remaining issue209 handlers to shared router

### DIFF
--- a/backend/functions/admin/__tests__/handler.test.ts
+++ b/backend/functions/admin/__tests__/handler.test.ts
@@ -29,7 +29,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {} as APIGatewayProxyEvent['requestContext'],
-    resource: '',
+    resource: '/site-config',
     ...overrides,
   };
 }
@@ -44,7 +44,7 @@ describe('admin router handler', () => {
   });
 
   it('GET path containing site-config calls getSiteConfig', async () => {
-    const event = makeEvent({ httpMethod: 'GET', path: '/site-config' });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/site-config' });
     await handler(event, ctx, noopCb);
     expect(mockGetSiteConfig).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockUpdateSiteConfig).not.toHaveBeenCalled();
@@ -53,28 +53,28 @@ describe('admin router handler', () => {
   });
 
   it('PUT path containing site-config calls updateSiteConfig', async () => {
-    const event = makeEvent({ httpMethod: 'PUT', path: '/admin/site-config' });
+    const event = makeEvent({ httpMethod: 'PUT', resource: '/admin/site-config' });
     await handler(event, ctx, noopCb);
     expect(mockUpdateSiteConfig).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockGetSiteConfig).not.toHaveBeenCalled();
   });
 
   it('DELETE path containing clear-all calls clearAll', async () => {
-    const event = makeEvent({ httpMethod: 'DELETE', path: '/admin/clear-all' });
+    const event = makeEvent({ httpMethod: 'DELETE', resource: '/admin/clear-all' });
     await handler(event, ctx, noopCb);
     expect(mockClearAll).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockSeedData).not.toHaveBeenCalled();
   });
 
   it('POST path containing seed-data calls seedData', async () => {
-    const event = makeEvent({ httpMethod: 'POST', path: '/admin/seed-data' });
+    const event = makeEvent({ httpMethod: 'POST', resource: '/admin/seed-data' });
     await handler(event, ctx, noopCb);
     expect(mockSeedData).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockClearAll).not.toHaveBeenCalled();
   });
 
   it('unknown route returns 405 Method Not Allowed', async () => {
-    const event = makeEvent({ httpMethod: 'PATCH', path: '/admin/other' });
+    const event = makeEvent({ httpMethod: 'PATCH', resource: '/admin/other' });
     const result = await handler(event, ctx, noopCb);
     expect(result).toBeDefined();
     expect(result!.statusCode).toBe(405);

--- a/backend/functions/admin/handler.ts
+++ b/backend/functions/admin/handler.ts
@@ -1,44 +1,35 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as getSiteConfigHandler } from './getSiteConfig';
 import { handler as updateSiteConfigHandler } from './updateSiteConfig';
 import { handler as clearAllHandler } from './clearAll';
 import { handler as seedDataHandler } from './seedData';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for admin: routes by HTTP method and path.
+ * Single Lambda for admin: routes by HTTP method and resource.
  * Replaces getSiteConfig, updateSiteConfig, clearAll, seedData.
  * Timeout 29s for clearAll and seedData (set in serverless.yml).
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const path = event.path ?? '';
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/site-config',
+    method: 'GET',
+    handler: getSiteConfigHandler,
+  },
+  {
+    resource: '/admin/site-config',
+    method: 'PUT',
+    handler: updateSiteConfigHandler,
+  },
+  {
+    resource: '/admin/clear-all',
+    method: 'DELETE',
+    handler: clearAllHandler,
+  },
+  {
+    resource: '/admin/seed-data',
+    method: 'POST',
+    handler: seedDataHandler,
+  },
+];
 
-  if (path.includes('seed-data') && method === 'POST') {
-    return (await seedDataHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (path.includes('clear-all') && method === 'DELETE') {
-    return (await clearAllHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (path.includes('site-config')) {
-    if (method === 'GET') {
-      return (await getSiteConfigHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-    }
-    if (method === 'PUT') {
-      return (await updateSiteConfigHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-    }
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/matches/__tests__/handler.test.ts
+++ b/backend/functions/matches/__tests__/handler.test.ts
@@ -27,7 +27,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {} as APIGatewayProxyEvent['requestContext'],
-    resource: '',
+    resource: '/matches',
     ...overrides,
   };
 }
@@ -41,7 +41,7 @@ describe('matches router handler', () => {
   });
 
   it('GET without matchId calls getMatches', async () => {
-    const event = makeEvent({ httpMethod: 'GET', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/matches', pathParameters: null });
     await handler(event, ctx, noopCb);
     expect(mockGetMatches).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockScheduleMatch).not.toHaveBeenCalled();
@@ -49,7 +49,7 @@ describe('matches router handler', () => {
   });
 
   it('POST without matchId calls scheduleMatch', async () => {
-    const event = makeEvent({ httpMethod: 'POST', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'POST', resource: '/matches', pathParameters: null });
     await handler(event, ctx, noopCb);
     expect(mockScheduleMatch).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockGetMatches).not.toHaveBeenCalled();
@@ -59,6 +59,7 @@ describe('matches router handler', () => {
   it('PUT with matchId calls recordResult', async () => {
     const event = makeEvent({
       httpMethod: 'PUT',
+      resource: '/matches/{matchId}/result',
       pathParameters: { matchId: 'm1' },
     });
     await handler(event, ctx, noopCb);
@@ -68,7 +69,7 @@ describe('matches router handler', () => {
   });
 
   it('PATCH returns 405 Method Not Allowed', async () => {
-    const event = makeEvent({ httpMethod: 'PATCH' });
+    const event = makeEvent({ httpMethod: 'PATCH', resource: '/matches' });
     const result = await handler(event, ctx, noopCb);
     expect(result).toBeDefined();
     expect(result!.statusCode).toBe(405);

--- a/backend/functions/matches/handler.ts
+++ b/backend/functions/matches/handler.ts
@@ -1,37 +1,28 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as getMatchesHandler } from './getMatches';
 import { handler as scheduleMatchHandler } from './scheduleMatch';
 import { handler as recordResultHandler } from './recordResult';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for matches: routes by HTTP method and path params.
+ * Single Lambda for matches: routes by HTTP method and resource.
  * Replaces getMatches, scheduleMatch, recordResult.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/matches',
+    method: 'GET',
+    handler: getMatchesHandler,
+  },
+  {
+    resource: '/matches',
+    method: 'POST',
+    handler: scheduleMatchHandler,
+  },
+  {
+    resource: '/matches/{matchId}/result',
+    method: 'PUT',
+    handler: recordResultHandler,
+  },
+];
 
-  if (method === 'GET' && !pathParams.matchId) {
-    return (await getMatchesHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.matchId) {
-    return (await scheduleMatchHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'PUT' && pathParams.matchId) {
-    return (await recordResultHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/promos/__tests__/handler.test.ts
+++ b/backend/functions/promos/__tests__/handler.test.ts
@@ -68,7 +68,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
-    resource: '',
+    resource: '/promos',
     requestContext: { authorizer: {} } as any,
     ...overrides,
   };
@@ -80,7 +80,7 @@ describe('promos router', () => {
   it('GET /promos routes to getPromos and returns 200', async () => {
     mockScanAll.mockResolvedValue([{ promoId: 'pr1', playerId: 'p1', content: 'Hello world', promoType: 'open-mic' }]);
     mockGet.mockResolvedValue({ Item: { playerId: 'p1', name: 'John' } });
-    const event = makeEvent({ httpMethod: 'GET', path: '/dev/promos', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/promos', pathParameters: null });
     const result = await handler(event, ctx, cb);
     expect(result!.statusCode).toBe(200);
     expect(JSON.parse(result!.body)).toHaveLength(1);
@@ -95,7 +95,7 @@ describe('promos router', () => {
     mockScanAll.mockResolvedValue([]);
     const event = makeEvent({
       httpMethod: 'GET',
-      path: '/dev/promos/pr1',
+      resource: '/promos/{promoId}',
       pathParameters: { promoId: 'pr1' },
     });
     const result = await handler(event, ctx, cb);
@@ -108,7 +108,7 @@ describe('promos router', () => {
     mockPut.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/promos',
+      resource: '/promos',
       pathParameters: null,
       body: JSON.stringify({
         promoType: 'open-mic',
@@ -128,7 +128,7 @@ describe('promos router', () => {
     mockUpdate.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/promos/pr1/react',
+      resource: '/promos/{promoId}/react',
       pathParameters: { promoId: 'pr1' },
       body: JSON.stringify({ reaction: 'fire' }),
     });
@@ -143,7 +143,7 @@ describe('promos router', () => {
     mockUpdate.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'PUT',
-      path: '/dev/admin/promos/pr1',
+      resource: '/admin/promos/{promoId}',
       pathParameters: { promoId: 'pr1' },
       body: JSON.stringify({ isPinned: true }),
     });
@@ -156,7 +156,7 @@ describe('promos router', () => {
     mockDelete.mockResolvedValue({});
     const event = makeEvent({
       httpMethod: 'DELETE',
-      path: '/dev/admin/promos/pr1',
+      resource: '/admin/promos/{promoId}',
       pathParameters: { promoId: 'pr1' },
     });
     const result = await handler(event, ctx, cb);
@@ -167,7 +167,7 @@ describe('promos router', () => {
     mockScanAll.mockResolvedValue([]);
     const event = makeEvent({
       httpMethod: 'POST',
-      path: '/dev/admin/promos/bulk-delete',
+      resource: '/admin/promos/bulk-delete',
       pathParameters: null,
       body: JSON.stringify({ isHidden: true }),
     });
@@ -179,7 +179,7 @@ describe('promos router', () => {
   it('returns 405 for unsupported method/path', async () => {
     const event = makeEvent({
       httpMethod: 'PATCH',
-      path: '/dev/promos',
+      resource: '/promos',
       pathParameters: null,
     });
     const result = await handler(event, ctx, cb);

--- a/backend/functions/promos/handler.ts
+++ b/backend/functions/promos/handler.ts
@@ -1,10 +1,3 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as getPromosHandler } from './getPromos';
 import { handler as getPromoHandler } from './getPromo';
 import { handler as createPromoHandler } from './createPromo';
@@ -12,45 +5,48 @@ import { handler as reactToPromoHandler } from './reactToPromo';
 import { handler as adminUpdatePromoHandler } from './adminUpdatePromo';
 import { handler as deletePromoHandler } from './deletePromo';
 import { handler as bulkDeletePromosHandler } from './bulkDeletePromos';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for promos: routes by HTTP method and path.
+ * Single Lambda for promos: routes by HTTP method and resource.
  * Replaces getPromos, getPromo, create, react, adminUpdate, delete, bulkDelete.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const path = event.path ?? '';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/promos',
+    method: 'GET',
+    handler: getPromosHandler,
+  },
+  {
+    resource: '/promos/{promoId}',
+    method: 'GET',
+    handler: getPromoHandler,
+  },
+  {
+    resource: '/promos',
+    method: 'POST',
+    handler: createPromoHandler,
+  },
+  {
+    resource: '/promos/{promoId}/react',
+    method: 'POST',
+    handler: reactToPromoHandler,
+  },
+  {
+    resource: '/admin/promos/{promoId}',
+    method: 'PUT',
+    handler: adminUpdatePromoHandler,
+  },
+  {
+    resource: '/admin/promos/{promoId}',
+    method: 'DELETE',
+    handler: deletePromoHandler,
+  },
+  {
+    resource: '/admin/promos/bulk-delete',
+    method: 'POST',
+    handler: bulkDeletePromosHandler,
+  },
+];
 
-  if (path.includes('admin/promos/bulk-delete') && method === 'POST') {
-    return (await bulkDeletePromosHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (path.includes('admin/promos/') && pathParams.promoId) {
-    if (method === 'PUT') {
-      return (await adminUpdatePromoHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-    }
-    if (method === 'DELETE') {
-      return (await deletePromoHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-    }
-  }
-  if (path.includes('/react') && method === 'POST' && pathParams.promoId) {
-    return (await reactToPromoHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'GET' && !pathParams.promoId) {
-    return (await getPromosHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'GET' && pathParams.promoId) {
-    return (await getPromoHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.promoId) {
-    return (await createPromoHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/tournaments/__tests__/handler.test.ts
+++ b/backend/functions/tournaments/__tests__/handler.test.ts
@@ -27,7 +27,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {} as APIGatewayProxyEvent['requestContext'],
-    resource: '',
+    resource: '/tournaments',
     ...overrides,
   };
 }
@@ -41,7 +41,7 @@ describe('tournaments router handler', () => {
   });
 
   it('GET without tournamentId calls getTournaments', async () => {
-    const event = makeEvent({ httpMethod: 'GET', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/tournaments', pathParameters: null });
     await handler(event, ctx, noopCb);
     expect(mockGetTournaments).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockCreateTournament).not.toHaveBeenCalled();
@@ -49,7 +49,7 @@ describe('tournaments router handler', () => {
   });
 
   it('POST without tournamentId calls createTournament', async () => {
-    const event = makeEvent({ httpMethod: 'POST', pathParameters: null });
+    const event = makeEvent({ httpMethod: 'POST', resource: '/tournaments', pathParameters: null });
     await handler(event, ctx, noopCb);
     expect(mockCreateTournament).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockGetTournaments).not.toHaveBeenCalled();
@@ -59,6 +59,7 @@ describe('tournaments router handler', () => {
   it('PUT with tournamentId calls updateTournament', async () => {
     const event = makeEvent({
       httpMethod: 'PUT',
+      resource: '/tournaments/{tournamentId}',
       pathParameters: { tournamentId: 't1' },
     });
     await handler(event, ctx, noopCb);
@@ -68,7 +69,7 @@ describe('tournaments router handler', () => {
   });
 
   it('DELETE returns 405 Method Not Allowed', async () => {
-    const event = makeEvent({ httpMethod: 'DELETE' });
+    const event = makeEvent({ httpMethod: 'DELETE', resource: '/tournaments' });
     const result = await handler(event, ctx, noopCb);
     expect(result).toBeDefined();
     expect(result!.statusCode).toBe(405);

--- a/backend/functions/tournaments/handler.ts
+++ b/backend/functions/tournaments/handler.ts
@@ -1,37 +1,28 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as getTournamentsHandler } from './getTournaments';
 import { handler as createTournamentHandler } from './createTournament';
 import { handler as updateTournamentHandler } from './updateTournament';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for tournaments: routes by HTTP method and path params.
+ * Single Lambda for tournaments: routes by HTTP method and resource.
  * Replaces getTournaments, createTournament, updateTournament.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/tournaments',
+    method: 'GET',
+    handler: getTournamentsHandler,
+  },
+  {
+    resource: '/tournaments',
+    method: 'POST',
+    handler: createTournamentHandler,
+  },
+  {
+    resource: '/tournaments/{tournamentId}',
+    method: 'PUT',
+    handler: updateTournamentHandler,
+  },
+];
 
-  if (method === 'GET' && !pathParams.tournamentId) {
-    return (await getTournamentsHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.tournamentId) {
-    return (await createTournamentHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'PUT' && pathParams.tournamentId) {
-    return (await updateTournamentHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/users/__tests__/handler.test.ts
+++ b/backend/functions/users/__tests__/handler.test.ts
@@ -27,7 +27,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {} as APIGatewayProxyEvent['requestContext'],
-    resource: '',
+    resource: '/admin/users',
     ...overrides,
   };
 }
@@ -41,7 +41,7 @@ describe('users router handler', () => {
   });
 
   it('GET admin/users calls listUsers', async () => {
-    const event = makeEvent({ httpMethod: 'GET', path: '/admin/users' });
+    const event = makeEvent({ httpMethod: 'GET', resource: '/admin/users' });
     await handler(event, ctx, noopCb);
     expect(mockListUsers).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockUpdateUserRole).not.toHaveBeenCalled();
@@ -49,7 +49,7 @@ describe('users router handler', () => {
   });
 
   it('POST admin/users/role calls updateUserRole', async () => {
-    const event = makeEvent({ httpMethod: 'POST', path: '/admin/users/role' });
+    const event = makeEvent({ httpMethod: 'POST', resource: '/admin/users/role' });
     await handler(event, ctx, noopCb);
     expect(mockUpdateUserRole).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockListUsers).not.toHaveBeenCalled();
@@ -57,7 +57,7 @@ describe('users router handler', () => {
   });
 
   it('POST admin/users/toggle-enabled calls toggleUserEnabled', async () => {
-    const event = makeEvent({ httpMethod: 'POST', path: '/admin/users/toggle-enabled' });
+    const event = makeEvent({ httpMethod: 'POST', resource: '/admin/users/toggle-enabled' });
     await handler(event, ctx, noopCb);
     expect(mockToggleUserEnabled).toHaveBeenCalledWith(event, ctx, noopCb);
     expect(mockListUsers).not.toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe('users router handler', () => {
   });
 
   it('PATCH returns 405 Method Not Allowed', async () => {
-    const event = makeEvent({ httpMethod: 'PATCH', path: '/admin/users' });
+    const event = makeEvent({ httpMethod: 'PATCH', resource: '/admin/users' });
     const result = await handler(event, ctx, noopCb);
     expect(result).toBeDefined();
     expect(result!.statusCode).toBe(405);

--- a/backend/functions/users/handler.ts
+++ b/backend/functions/users/handler.ts
@@ -1,37 +1,28 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyHandler,
-  APIGatewayProxyResult,
-  Context,
-} from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
 import { handler as listUsersHandler } from './listUsers';
 import { handler as updateUserRoleHandler } from './updateUserRole';
 import { handler as toggleUserEnabledHandler } from './toggleUserEnabled';
-
-const noopCallback = () => {};
+import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
- * Single Lambda for users (admin): routes by HTTP method and path.
+ * Single Lambda for users (admin): routes by HTTP method and resource.
  * Replaces listUsers, updateUserRole, toggleUserEnabled.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const path = event.path ?? '';
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/admin/users',
+    method: 'GET',
+    handler: listUsersHandler,
+  },
+  {
+    resource: '/admin/users/role',
+    method: 'POST',
+    handler: updateUserRoleHandler,
+  },
+  {
+    resource: '/admin/users/toggle-enabled',
+    method: 'POST',
+    handler: toggleUserEnabledHandler,
+  },
+];
 
-  if (method === 'GET' && path.includes('users') && !path.includes('role') && !path.includes('toggle-enabled')) {
-    return (await listUsersHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && path.includes('role')) {
-    return (await updateUserRoleHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && path.includes('toggle-enabled')) {
-    return (await toggleUserEnabledHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);


### PR DESCRIPTION
## Summary
- migrate `matches`, `tournaments`, `admin`, `users`, and `promos` handlers to `createRouter()` route tables
- replace path-based branching with explicit API Gateway `method + resource` route mapping
- update all corresponding handler tests to assert `event.resource` dispatch behavior

## Test plan
- [x] `npm run test -- functions/matches/__tests__/handler.test.ts functions/tournaments/__tests__/handler.test.ts functions/admin/__tests__/handler.test.ts functions/users/__tests__/handler.test.ts functions/promos/__tests__/handler.test.ts`
- [x] `npx eslint functions/matches/handler.ts functions/tournaments/handler.ts functions/admin/handler.ts functions/users/handler.ts functions/promos/handler.ts functions/matches/__tests__/handler.test.ts functions/tournaments/__tests__/handler.test.ts functions/admin/__tests__/handler.test.ts functions/users/__tests__/handler.test.ts functions/promos/__tests__/handler.test.ts`

Part of #209

Made with [Cursor](https://cursor.com)