### PR TITLE
feat: improve wiki onboarding, UX guidance, and routing consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A serverless web application for managing a WWE 2K league with standings, champi
 | **Promos** | View wrestler promos with emoji reactions |
 | **Contender Rankings** | Automatic #1 contender tracking per championship based on recent performance |
 | **Challenges** | View open and completed match challenges between wrestlers |
-| **Help (Wiki)** | Help at `/guide` (redirects to wiki index) and wiki articles at `/guide/wiki`. Wiki content lives in `frontend/public/wiki/` (markdown + `index.json`); see CLAUDE.md for how to add articles. |
+| **Help (Wiki)** | Help at `/guide` (redirects to wiki index) and wiki articles at `/guide/wiki`. Includes **User Quickstart** and **Admin Quickstart** onboarding paths. Wiki content lives in `frontend/public/wiki/` (markdown + `index.json`); see CLAUDE.md for how to add articles. |
 | **Internationalization** | Full English and German language support |
 
 ### Wrestler Features (Wrestler Auth Required)

--- a/backend/functions/matchTypes/handler.ts
+++ b/backend/functions/matchTypes/handler.ts
@@ -1,36 +1,33 @@
-import { APIGatewayProxyEvent, APIGatewayProxyHandler, APIGatewayProxyResult, Context } from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
+import { createRouter, type RouteConfig } from '../../lib/router';
 import { handler as getMatchTypesHandler } from './getMatchTypes';
 import { handler as createMatchTypeHandler } from './createMatchType';
 import { handler as updateMatchTypeHandler } from './updateMatchType';
 import { handler as deleteMatchTypeHandler } from './deleteMatchType';
 
-const noopCallback = () => {};
-
 /**
- * Single Lambda for match types: routes by HTTP method and path params.
- * Replaces getMatchTypes, createMatchType, updateMatchType, deleteMatchType.
+ * Single Lambda for match types: routes by method + resource.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/match-types',
+    method: 'GET',
+    handler: getMatchTypesHandler,
+  },
+  {
+    resource: '/match-types',
+    method: 'POST',
+    handler: createMatchTypeHandler,
+  },
+  {
+    resource: '/match-types/{matchTypeId}',
+    method: 'PUT',
+    handler: updateMatchTypeHandler,
+  },
+  {
+    resource: '/match-types/{matchTypeId}',
+    method: 'DELETE',
+    handler: deleteMatchTypeHandler,
+  },
+];
 
-  if (method === 'GET' && !pathParams.matchTypeId) {
-    return (await getMatchTypesHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.matchTypeId) {
-    return (await createMatchTypeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'PUT' && pathParams.matchTypeId) {
-    return (await updateMatchTypeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'DELETE' && pathParams.matchTypeId) {
-    return (await deleteMatchTypeHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/seasons/handler.ts
+++ b/backend/functions/seasons/handler.ts
@@ -1,36 +1,33 @@
-import { APIGatewayProxyEvent, APIGatewayProxyHandler, APIGatewayProxyResult, Context } from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
+import { createRouter, type RouteConfig } from '../../lib/router';
 import { handler as getSeasonsHandler } from './getSeasons';
 import { handler as createSeasonHandler } from './createSeason';
 import { handler as updateSeasonHandler } from './updateSeason';
 import { handler as deleteSeasonHandler } from './deleteSeason';
 
-const noopCallback = () => {};
-
 /**
- * Single Lambda for seasons: routes by HTTP method and path params.
- * Replaces getSeasons, createSeason, updateSeason, deleteSeason.
+ * Single Lambda for seasons: routes by method + resource.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/seasons',
+    method: 'GET',
+    handler: getSeasonsHandler,
+  },
+  {
+    resource: '/seasons',
+    method: 'POST',
+    handler: createSeasonHandler,
+  },
+  {
+    resource: '/seasons/{seasonId}',
+    method: 'PUT',
+    handler: updateSeasonHandler,
+  },
+  {
+    resource: '/seasons/{seasonId}',
+    method: 'DELETE',
+    handler: deleteSeasonHandler,
+  },
+];
 
-  if (method === 'GET' && !pathParams.seasonId) {
-    return (await getSeasonsHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.seasonId) {
-    return (await createSeasonHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'PUT' && pathParams.seasonId) {
-    return (await updateSeasonHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'DELETE' && pathParams.seasonId) {
-    return (await deleteSeasonHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/backend/functions/stipulations/handler.ts
+++ b/backend/functions/stipulations/handler.ts
@@ -1,36 +1,33 @@
-import { APIGatewayProxyEvent, APIGatewayProxyHandler, APIGatewayProxyResult, Context } from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
+import { createRouter, type RouteConfig } from '../../lib/router';
 import { handler as getStipulationsHandler } from './getStipulations';
 import { handler as createStipulationHandler } from './createStipulation';
 import { handler as updateStipulationHandler } from './updateStipulation';
 import { handler as deleteStipulationHandler } from './deleteStipulation';
 
-const noopCallback = () => {};
-
 /**
- * Single Lambda for stipulations: routes by HTTP method and path params.
- * Replaces getStipulations, createStipulation, updateStipulation, deleteStipulation.
+ * Single Lambda for stipulations: routes by method + resource.
  */
-export const handler: APIGatewayProxyHandler = async (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback: Parameters<APIGatewayProxyHandler>[2]
-): Promise<APIGatewayProxyResult> => {
-  const method = event.httpMethod?.toUpperCase() ?? 'GET';
-  const pathParams = event.pathParameters ?? {};
+const routes: ReadonlyArray<RouteConfig> = [
+  {
+    resource: '/stipulations',
+    method: 'GET',
+    handler: getStipulationsHandler,
+  },
+  {
+    resource: '/stipulations',
+    method: 'POST',
+    handler: createStipulationHandler,
+  },
+  {
+    resource: '/stipulations/{stipulationId}',
+    method: 'PUT',
+    handler: updateStipulationHandler,
+  },
+  {
+    resource: '/stipulations/{stipulationId}',
+    method: 'DELETE',
+    handler: deleteStipulationHandler,
+  },
+];
 
-  if (method === 'GET' && !pathParams.stipulationId) {
-    return (await getStipulationsHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'POST' && !pathParams.stipulationId) {
-    return (await createStipulationHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'PUT' && pathParams.stipulationId) {
-    return (await updateStipulationHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-  if (method === 'DELETE' && pathParams.stipulationId) {
-    return (await deleteStipulationHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
-  }
-
-  return methodNotAllowed();
-};
+export const handler = createRouter(routes);

--- a/frontend/public/wiki/admin-fantasy-config.md
+++ b/frontend/public/wiki/admin-fantasy-config.md
@@ -1,0 +1,22 @@
+# Admin: Fantasy Config
+
+Use **Fantasy Config** to set global fantasy rules used across the league.
+
+## What this controls
+
+- default budget and picks per division
+- points model (wins, bonuses, streaks, underdog multiplier)
+- cost fluctuation behavior
+- season cost reset strategy
+
+## Recommended setup order
+
+1. Set default budget and picks/division.
+2. Configure core point values and bonuses.
+3. Review cost fluctuation and reset strategy.
+4. Save changes and verify on an upcoming event.
+
+## Related pages
+
+- [Fantasy Shows](admin-fantasy-shows) for event-specific overrides.
+- [Events](admin-events) for assigning events to seasons and status flow.

--- a/frontend/public/wiki/admin-fantasy-shows.md
+++ b/frontend/public/wiki/admin-fantasy-shows.md
@@ -1,0 +1,22 @@
+# Admin: Fantasy Shows
+
+Use **Fantasy Shows** to tune fantasy settings per event without changing global defaults.
+
+## Event-level controls
+
+For each event you can:
+- lock or unlock fantasy picks
+- set event-specific fantasy budget
+- set picks per division
+
+## Recommended workflow
+
+1. Confirm event is in the correct season.
+2. Set budget and picks/division for that event.
+3. Lock picks before the event starts.
+4. Keep completed events read-only for historical integrity.
+
+## Notes
+
+- These settings apply to the selected event only.
+- Global fantasy rules remain in [Fantasy Config](admin-fantasy-config).

--- a/frontend/public/wiki/admin-match-config.md
+++ b/frontend/public/wiki/admin-match-config.md
@@ -1,0 +1,20 @@
+# Admin: Match Config
+
+Use **Match Config** to control the match options available when scheduling matches.
+
+## What you can manage
+
+- **Match Types**: base formats (Singles, Tag Team, Triple Threat, etc.)
+- **Stipulations**: modifiers and special rules (Ladder, Cage, No DQ, etc.)
+
+## Recommended workflow
+
+1. Add or update **Match Types** first.
+2. Add **Stipulations** used most often by your league.
+3. Validate options in [Schedule Match](admin-schedule-match).
+
+## Best practices
+
+- Keep names short and consistent.
+- Avoid duplicate or near-duplicate entries.
+- Add descriptions for non-obvious terms so other admins understand intent.

--- a/frontend/public/wiki/admin-quickstart.md
+++ b/frontend/public/wiki/admin-quickstart.md
@@ -24,6 +24,10 @@ New admin? Follow these steps to set up your league from scratch.
 
 10. **Configure Contenders** — Go to **Contender Config** to set up automatic #1 contender rankings for each championship. Configure ranking period, minimum matches, division restrictions, and recalculate as needed.
 
+11. **Set Match Config** — Go to **Match Config** and define your match types and stipulations so schedulers use consistent options.
+
+12. **Optional Fantasy Setup** — If your league uses fantasy features, configure global rules in **Fantasy Config** and event-specific settings in **Fantasy Shows**.
+
 ## Quick Demo Mode
 
 Want to try things out first? Go to the **Danger Zone** tab and click **Generate Sample Data** to populate the league with 12 players, 3 divisions, 4 championships, 12 matches, 2 tournaments, and a full season of standings.

--- a/frontend/public/wiki/admin-season-awards.md
+++ b/frontend/public/wiki/admin-season-awards.md
@@ -1,0 +1,24 @@
+# Admin: Season Awards
+
+Use **Season Awards** to review auto-generated awards and add your own custom awards for a selected season.
+
+## How it works
+
+- Select a season first.
+- The page shows:
+  - **Auto Awards** (calculated from season data)
+  - **Custom Awards** (manually created by admins)
+
+## Add a custom award
+
+1. Pick a season.
+2. Click **Create Award**.
+3. Enter award name, player, and optional description.
+4. Save and verify it appears in the custom awards list.
+
+## Delete a custom award
+
+- Use the delete action in the custom awards table.
+- Confirm deletion when prompted.
+
+Auto-generated awards are system-calculated and not manually deleted from this page.

--- a/frontend/public/wiki/admin.md
+++ b/frontend/public/wiki/admin.md
@@ -5,10 +5,12 @@ Use the links below to open each section of the admin guide.
 ## Setup & structure
 
 - [Quickstart](admin-quickstart) — Get your league running from scratch
+- [Match Config](admin-match-config) — Manage match types and stipulations used in scheduling
 - [User Management](admin-user-management) — Roles and assigning Wrestler, Fantasy, Admin, Moderator
 - [Divisions](admin-divisions) — Create and manage divisions, assign players
 - [Manage Players](admin-manage-players) — Edit wrestlers, images, divisions; delete players
 - [Seasons](admin-seasons) — Create, end, and delete seasons; season standings
+- [Season Awards](admin-season-awards) — Review auto-awards and add custom season awards
 
 ## Titles & events
 
@@ -26,5 +28,7 @@ Use the links below to open each section of the admin guide.
 
 ## Data & workflow
 
+- [Fantasy Shows](admin-fantasy-shows) — Event-level fantasy locks, budgets, and picks/division
+- [Fantasy Config](admin-fantasy-config) — Global fantasy scoring, defaults, and cost behavior
 - [Data Management](admin-data-management) — Danger Zone: sample data, clear all (super-admin only)
 - [Typical Weekly Workflow](admin-workflow) — Suggested order for running your league

--- a/frontend/public/wiki/de/admin-fantasy-config.md
+++ b/frontend/public/wiki/de/admin-fantasy-config.md
@@ -1,0 +1,22 @@
+# Admin: Fantasy-Konfiguration
+
+Nutze **Fantasy-Konfiguration**, um globale Fantasy-Regeln für die Liga festzulegen.
+
+## Was hier gesteuert wird
+
+- Standard-Budget und Picks pro Division
+- Punkte-Modell (Siege, Boni, Serien, Underdog-Multiplikator)
+- Kostenveränderung über die Zeit
+- Kosten-Reset-Strategie zwischen Saisons
+
+## Empfohlene Reihenfolge
+
+1. Standard-Budget und Picks/Division festlegen.
+2. Kern-Punktewerte und Boni konfigurieren.
+3. Kostenveränderung und Reset-Strategie prüfen.
+4. Speichern und bei einem kommenden Event gegenprüfen.
+
+## Verwandte Seiten
+
+- [Fantasy Shows](admin-fantasy-shows) für event-spezifische Overrides.
+- [Events](admin-events) für Saisonzuteilung und Statusablauf.

--- a/frontend/public/wiki/de/admin-fantasy-shows.md
+++ b/frontend/public/wiki/de/admin-fantasy-shows.md
@@ -1,0 +1,22 @@
+# Admin: Fantasy Shows
+
+Nutze **Fantasy Shows**, um Fantasy-Einstellungen pro Event anzupassen, ohne globale Standardwerte zu ändern.
+
+## Event-spezifische Steuerung
+
+Pro Event kannst du:
+- Picks sperren oder entsperren
+- ein Event-spezifisches Budget festlegen
+- Picks pro Division setzen
+
+## Empfohlener Ablauf
+
+1. Prüfen, ob das Event der richtigen Saison zugeordnet ist.
+2. Budget und Picks/Division für das Event festlegen.
+3. Picks vor Eventbeginn sperren.
+4. Abgeschlossene Events unverändert lassen.
+
+## Hinweis
+
+- Diese Einstellungen gelten nur für das gewählte Event.
+- Globale Fantasy-Regeln bleiben in [Fantasy-Konfiguration](admin-fantasy-config).

--- a/frontend/public/wiki/de/admin-match-config.md
+++ b/frontend/public/wiki/de/admin-match-config.md
@@ -1,0 +1,20 @@
+# Admin: Match-Konfiguration
+
+Nutze **Match-Konfiguration**, um verfügbare Match-Optionen für die Planung zu steuern.
+
+## Was du verwalten kannst
+
+- **Match-Typen**: Grundformate (Singles, Tag Team, Triple Threat usw.)
+- **Stipulations**: Sonderregeln (Ladder, Cage, No DQ usw.)
+
+## Empfohlener Ablauf
+
+1. Zuerst **Match-Typen** anlegen oder aktualisieren.
+2. Danach die wichtigsten **Stipulations** hinzufügen.
+3. Optionen in [Match planen](admin-schedule-match) prüfen.
+
+## Best Practices
+
+- Namen kurz und konsistent halten.
+- Doppelte oder sehr ähnliche Einträge vermeiden.
+- Für unklare Begriffe Beschreibungen hinterlegen.

--- a/frontend/public/wiki/de/admin-quickstart.md
+++ b/frontend/public/wiki/de/admin-quickstart.md
@@ -24,6 +24,10 @@ Neuer Admin? Folge diesen Schritten, um deine Liga von Grund auf einzurichten.
 
 10. **Herausforderer konfigurieren** — Gehe zu **Herausforderer-Konfig**, um die automatischen #1-Herausforderer-Ranglisten pro Meisterschaft einzurichten. Lege Ranglistenzeitraum, Mindestanzahl Matches, Divisionsbeschränkungen fest und berechne bei Bedarf neu.
 
+11. **Match-Konfiguration setzen** — Gehe zu **Match-Konfiguration** und definiere Match-Typen sowie Stipulations für eine konsistente Planung.
+
+12. **Optionale Fantasy-Einrichtung** — Wenn deine Liga Fantasy nutzt, stelle globale Regeln in **Fantasy-Konfiguration** ein und event-spezifische Werte in **Fantasy Shows**.
+
 ## Schnell-Demo
 
 Zuerst ausprobieren? Gehe zum Tab **Gefahrenzone** und klicke auf **Beispieldaten erzeugen**, um die Liga mit 12 Spielern, 3 Divisionen, 4 Meisterschaften, 12 Matches, 2 Turnieren und einer vollen Saison-Tabelle zu füllen.

--- a/frontend/public/wiki/de/admin-season-awards.md
+++ b/frontend/public/wiki/de/admin-season-awards.md
@@ -1,0 +1,24 @@
+# Admin: Saison-Auszeichnungen
+
+Nutze **Saison-Auszeichnungen**, um automatisch erzeugte Awards zu prüfen und eigene Awards für eine Saison zu erstellen.
+
+## So funktioniert es
+
+- Zuerst eine Saison auswählen.
+- Die Seite zeigt:
+  - **Auto-Awards** (aus Saisondaten berechnet)
+  - **Custom Awards** (manuell durch Admins erstellt)
+
+## Custom Award hinzufügen
+
+1. Saison auswählen.
+2. **Award erstellen** klicken.
+3. Name, Spieler und optional Beschreibung eingeben.
+4. Speichern und prüfen, ob der Award in der Liste erscheint.
+
+## Custom Award löschen
+
+- Löschaktion in der Tabelle der Custom Awards verwenden.
+- Löschung im Dialog bestätigen.
+
+Automatisch erzeugte Awards werden vom System berechnet und auf dieser Seite nicht manuell gelöscht.

--- a/frontend/public/wiki/de/admin.md
+++ b/frontend/public/wiki/de/admin.md
@@ -5,10 +5,12 @@
 ## Einrichtung & Struktur
 
 - [Schnellstart](admin-quickstart) — Liga von Grund auf einrichten
+- [Match-Konfiguration](admin-match-config) — Match-Typen und Stipulations für die Planung verwalten
 - [Benutzerverwaltung](admin-user-management) — Rollen und Zuweisung von Wrestler, Fantasy, Admin, Moderator
 - [Divisionen](admin-divisions) — Divisionen anlegen und verwalten, Spieler zuweisen
 - [Spieler verwalten](admin-manage-players) — Wrestler, Bilder, Divisionen bearbeiten; Spieler löschen
 - [Saisons](admin-seasons) — Saisons anlegen, beenden und löschen; Saison-Tabellen
+- [Saison-Auszeichnungen](admin-season-awards) — Auto-Awards prüfen und eigene Awards vergeben
 
 ## Titel & Events
 
@@ -26,5 +28,7 @@
 
 ## Daten & Ablauf
 
+- [Fantasy Shows](admin-fantasy-shows) — Event-spezifische Fantasy-Sperren, Budgets und Picks/Division
+- [Fantasy-Konfiguration](admin-fantasy-config) — Globale Fantasy-Punkte, Defaults und Kostenlogik
 - [Datenverwaltung](admin-data-management) — Gefahrenzone: Beispieldaten, Alles löschen (nur Super-Admin)
 - [Typischer Wochenablauf](admin-workflow) — Vorgeschlagene Reihenfolge für den Liga-Betrieb

--- a/frontend/public/wiki/de/getting-started.md
+++ b/frontend/public/wiki/de/getting-started.md
@@ -15,6 +15,8 @@ Willkommen auf der WWE-2K-Liga-Website. Diese kurze Anleitung hilft Ihnen bei de
 
 - Nutzen Sie **Hilfe** im Hauptmenü, um das Wiki zu durchsuchen.
 - Das Wiki enthält Artikel zu Tabelle, Saisons, Meisterschaften, Events, Turnieren und mehr sowie FAQs.
+- Starten Sie mit [Benutzer-Schnellstart](user-quickstart) für einen schnellen Ablauf ohne Admin-Fokus.
+- Für Liga-Betrieb und Verwaltung nutzen Sie [Admin-Schnellstart](admin-quickstart).
 - Wechseln Sie die Sprache über die Sprachauswahl in der Kopfzeile (English / Deutsch).
 
 ## Nächste Schritte

--- a/frontend/public/wiki/de/user-quickstart.md
+++ b/frontend/public/wiki/de/user-quickstart.md
@@ -1,0 +1,42 @@
+# Benutzer-Schnellstart
+
+Neu hier? Mit diesem kurzen Ablauf lernst du die Seite in 5 Minuten.
+
+## 1) Mit dem Dashboard starten
+
+Öffne das [Dashboard](dashboard), um zu sehen:
+- aktuelle Champions
+- kommende Events
+- letzte Ergebnisse
+- schnelle Liga-Statistiken
+
+## 2) Tabellenstand prüfen
+
+Gehe zu [Tabelle](standings):
+- nutze **Saison**, um zwischen Gesamt und Saisonstand zu wechseln
+- nutze **Division**-Filter, um Ergebnisse einzugrenzen
+
+## 3) Aktive Wettbewerbe verfolgen
+
+- [Events](events): kommende Cards und abgeschlossene Ergebnisse
+- [Meisterschaften](championships): aktuelle Champions und Titelhistorie
+- [Turniere](tournaments): Brackets und Rundensystem-Standings
+- [Aktivität](activity): alle neuesten Liga-Aktionen im Feed
+
+## 4) Optionale Wrestler-Funktionen (Login erforderlich)
+
+Wenn dein Account Wrestler-Zugriff hat:
+- [Mein Profil](profile)
+- [Herausforderungen](challenges)
+- [Promos](promos)
+
+## 5) Optionale Fantasy-Funktionen (falls aktiviert)
+
+Wenn Fantasy für deine Rolle aktiviert ist:
+- [Fantasy](fantasy), um Picks abzugeben und die Rangliste zu verfolgen
+
+## 6) Schnell Hilfe finden
+
+- [FAQs](faqs) durchsuchen
+- [Tipps](tips) nutzen
+- [Admin-Schnellstart](admin-quickstart) öffnen, wenn du Liga-Administration übernimmst

--- a/frontend/public/wiki/getting-started.md
+++ b/frontend/public/wiki/getting-started.md
@@ -15,6 +15,8 @@ Welcome to the WWE 2K League site. This short guide helps you find your way arou
 
 - Use **Help** in the main menu to browse the Wiki.
 - The Wiki has articles on standings, seasons, championships, events, tournaments, and more, plus FAQs.
+- Start with [User Quickstart](user-quickstart) for a fast non-admin walkthrough.
+- If you run league operations, use [Admin Quickstart](admin-quickstart).
 - Switch language with the language control in the header (English / Deutsch).
 
 ## Next steps

--- a/frontend/public/wiki/index.json
+++ b/frontend/public/wiki/index.json
@@ -1,5 +1,6 @@
 [
   {"slug":"getting-started","titleKey":"wiki.articles.gettingStarted","file":"getting-started.md"},
+  {"slug":"user-quickstart","titleKey":"wiki.articles.userQuickstart","file":"user-quickstart.md"},
   {"slug":"faqs","titleKey":"wiki.articles.faqs","file":"faqs.md"},
   {"slug":"standings","titleKey":"wiki.articles.standings","file":"standings.md"},
   {"slug":"seasons","titleKey":"wiki.articles.seasons","file":"seasons.md"},
@@ -18,6 +19,10 @@
   {"slug":"statistics","titleKey":"wiki.articles.statistics","file":"statistics.md"},
   {"slug":"admin","titleKey":"wiki.articles.adminGuide","file":"admin.md","adminOnly":true},
   {"slug":"admin-quickstart","titleKey":"wiki.articles.adminQuickstart","file":"admin-quickstart.md","adminOnly":true},
+  {"slug":"admin-match-config","titleKey":"wiki.articles.adminMatchConfig","file":"admin-match-config.md","adminOnly":true},
+  {"slug":"admin-season-awards","titleKey":"wiki.articles.adminSeasonAwards","file":"admin-season-awards.md","adminOnly":true},
+  {"slug":"admin-fantasy-shows","titleKey":"wiki.articles.adminFantasyShows","file":"admin-fantasy-shows.md","adminOnly":true},
+  {"slug":"admin-fantasy-config","titleKey":"wiki.articles.adminFantasyConfig","file":"admin-fantasy-config.md","adminOnly":true},
   {"slug":"admin-user-management","titleKey":"wiki.articles.adminUserManagement","file":"admin-user-management.md","adminOnly":true},
   {"slug":"admin-divisions","titleKey":"wiki.articles.adminDivisions","file":"admin-divisions.md","adminOnly":true},
   {"slug":"admin-manage-players","titleKey":"wiki.articles.adminManagePlayers","file":"admin-manage-players.md","adminOnly":true},

--- a/frontend/public/wiki/user-quickstart.md
+++ b/frontend/public/wiki/user-quickstart.md
@@ -1,0 +1,42 @@
+# User Quickstart
+
+New here? Use this short path to learn the site in 5 minutes.
+
+## 1) Start at Dashboard
+
+Open the [Dashboard](dashboard) to see:
+- current champions
+- upcoming events
+- recent results
+- quick league stats
+
+## 2) Check where you stand
+
+Go to [Standings](standings):
+- use **Season** to switch between all-time and season standings
+- use **Division** filters to narrow results
+
+## 3) Follow active competition
+
+- [Events](events): see upcoming cards and completed results
+- [Championships](championships): current champions and title history
+- [Tournaments](tournaments): brackets and round-robin standings
+- [Activity](activity): latest league actions in one feed
+
+## 4) Optional wrestler features (login required)
+
+If your account has wrestler access:
+- [My Profile](profile)
+- [Challenges](challenges)
+- [Promos](promos)
+
+## 5) Optional fantasy features (if enabled)
+
+If fantasy is enabled for your role:
+- [Fantasy](fantasy) to make picks and track leaderboard progress
+
+## 6) Need help fast?
+
+- Browse [FAQs](faqs)
+- Use [Tips](tips)
+- Open the full [Admin Quickstart](admin-quickstart) if you run league operations

--- a/frontend/src/components/Dashboard.css
+++ b/frontend/src/components/Dashboard.css
@@ -23,6 +23,23 @@
   margin: 0;
 }
 
+.dashboard-empty-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-start;
+}
+
+.dashboard-empty-action {
+  font-size: 0.85rem;
+  color: #d4af37;
+  text-decoration: none;
+}
+
+.dashboard-empty-action:hover {
+  text-decoration: underline;
+}
+
 /* Champions strip: horizontal scroll */
 .dashboard-champions-strip {
   display: flex;

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -199,7 +199,12 @@ export default function Dashboard() {
       <section className="dashboard-section">
         <h3>{t('dashboard.champions')}</h3>
         {data.currentChampions.length === 0 ? (
-          <p className="dashboard-empty">{t('dashboard.noChampions')}</p>
+          <div className="dashboard-empty-block">
+            <p className="dashboard-empty">{t('dashboard.noChampions')}</p>
+            <Link className="dashboard-empty-action" to="/championships">
+              {t('dashboard.emptyActions.viewChampionships', 'View championships')}
+            </Link>
+          </div>
         ) : (
           <div className="dashboard-champions-strip">
             {data.currentChampions.map((c) => (
@@ -220,7 +225,12 @@ export default function Dashboard() {
       <section className="dashboard-section">
         <h3>{t('dashboard.upcomingEvents')}</h3>
         {data.upcomingEvents.length === 0 ? (
-          <p className="dashboard-empty">{t('dashboard.noUpcomingEvents')}</p>
+          <div className="dashboard-empty-block">
+            <p className="dashboard-empty">{t('dashboard.noUpcomingEvents')}</p>
+            <Link className="dashboard-empty-action" to="/events">
+              {t('dashboard.emptyActions.viewEvents', 'View events')}
+            </Link>
+          </div>
         ) : (
           <div className="dashboard-events-grid">
             {data.upcomingEvents.map((e: DashboardEvent) => (
@@ -237,7 +247,12 @@ export default function Dashboard() {
       <section className="dashboard-section">
         <h3>{t('dashboard.recentResults')}</h3>
         {data.recentResults.length === 0 ? (
-          <p className="dashboard-empty">{t('dashboard.noRecentResults')}</p>
+          <div className="dashboard-empty-block">
+            <p className="dashboard-empty">{t('dashboard.noRecentResults')}</p>
+            <Link className="dashboard-empty-action" to="/matches">
+              {t('dashboard.emptyActions.browseMatches', 'Browse matches')}
+            </Link>
+          </div>
         ) : (
           <RecentResultsGrouped results={data.recentResults} t={t} renderStarRating={renderStarRating} />
         )}
@@ -246,7 +261,12 @@ export default function Dashboard() {
       <section className="dashboard-section">
         <h3>{t('dashboard.seasonProgress')}</h3>
         {!data.seasonInfo ? (
-          <p className="dashboard-empty">{t('dashboard.noActiveSeason')}</p>
+          <div className="dashboard-empty-block">
+            <p className="dashboard-empty">{t('dashboard.noActiveSeason')}</p>
+            <Link className="dashboard-empty-action" to="/guide/wiki/getting-started">
+              {t('dashboard.emptyActions.seeGuide', 'See getting started')}
+            </Link>
+          </div>
         ) : (
           <div className="dashboard-season-card">
             <div className="season-name">{data.seasonInfo.name}</div>

--- a/frontend/src/components/MatchSearch.css
+++ b/frontend/src/components/MatchSearch.css
@@ -13,6 +13,16 @@
   margin: 0;
 }
 
+.match-search-help {
+  margin: 0 0 0.85rem;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.match-search-help a {
+  color: var(--color-primary);
+}
+
 /* Filter Panel */
 .match-search-filters {
   background-color: var(--color-surface);

--- a/frontend/src/components/MatchSearch.tsx
+++ b/frontend/src/components/MatchSearch.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { matchesApi, playersApi, seasonsApi, championshipsApi, stipulationsApi, matchTypesApi } from '../services/api';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -153,6 +153,13 @@ export default function MatchSearch() {
       <div className="match-search-header">
         <h2>{t('matchSearch.title')}</h2>
       </div>
+      <p className="match-search-help">
+        {t(
+          'matchSearch.filtersHelp',
+          'Filters are combined together. Use "Clear Filters" to quickly reset and broaden results.'
+        )}{' '}
+        <Link to="/guide/wiki/events">{t('matchSearch.learnMore', 'Learn more')}</Link>
+      </p>
 
       {/* Filter Panel */}
       <div className="match-search-filters" role="search" aria-label={t('matchSearch.filtersLabel')}>

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -21,6 +21,7 @@
 .season-selector {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 
@@ -42,6 +43,13 @@
 .season-selector select:focus {
   outline: none;
   border-color: var(--color-primary);
+}
+
+.season-selector-help {
+  width: 100%;
+  margin-top: 0.1rem;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
 }
 
 .season-badge {

--- a/frontend/src/components/Standings.tsx
+++ b/frontend/src/components/Standings.tsx
@@ -171,6 +171,12 @@ export default function Standings() {
                 </option>
               ))}
             </select>
+            <span className="season-selector-help">
+              {t(
+                'standings.seasonHelp',
+                'Choose a season for season-only standings, or All-Time for overall records.'
+              )}
+            </span>
           </div>
         )}
       </div>

--- a/frontend/src/components/WikiIndex.tsx
+++ b/frontend/src/components/WikiIndex.tsx
@@ -47,7 +47,7 @@ export default function WikiIndex() {
       articles.filter(
         (a) =>
           !a.adminOnly ||
-          (isAdminOrModerator && a.slug === 'admin')
+          isAdminOrModerator
       ),
     [articles, isAdminOrModerator]
   );

--- a/frontend/src/components/WikiSidebar.tsx
+++ b/frontend/src/components/WikiSidebar.tsx
@@ -30,7 +30,7 @@ export default function WikiSidebar() {
       articles.filter(
         (a) =>
           !a.adminOnly ||
-          (isAdminOrModerator && a.slug === 'admin')
+          isAdminOrModerator
       ),
     [articles, isAdminOrModerator]
   );

--- a/frontend/src/components/admin/AdminPanel.css
+++ b/frontend/src/components/admin/AdminPanel.css
@@ -5,3 +5,22 @@
 .admin-content {
   padding: 1rem 0;
 }
+
+.admin-onboarding-banner {
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #444;
+  border-left: 3px solid #d4af37;
+  border-radius: 6px;
+  background: #1a1a1a;
+}
+
+.admin-onboarding-banner p {
+  margin: 0;
+  color: #bbb;
+  font-size: 0.9rem;
+}
+
+.admin-onboarding-banner a {
+  color: #d4af37;
+}

--- a/frontend/src/components/admin/AdminPanel.tsx
+++ b/frontend/src/components/admin/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { Navigate } from 'react-router-dom';
 
@@ -63,32 +63,43 @@ export default function AdminPanel() {
     );
   }
 
+  const tabContent: Record<AdminTab, JSX.Element> = {
+    users: <ManageUsers />,
+    features: <ManageFeatures />,
+    players: <ManagePlayers />,
+    divisions: <ManageDivisions />,
+    'match-config': <ManageMatchConfig />,
+    schedule: <ScheduleMatch />,
+    results: <RecordResult />,
+    championships: <ManageChampionships />,
+    tournaments: <CreateTournament />,
+    challenges: <AdminChallenges />,
+    promos: <AdminPromos />,
+    seasons: <ManageSeasons />,
+    'season-awards': <ManageSeasonAwards />,
+    events: (
+      <>
+        <CreateEvent />
+        <MatchCardBuilder />
+      </>
+    ),
+    'fantasy-shows': <ManageFantasyShows />,
+    'fantasy-config': <FantasyConfig />,
+    'contender-config': <AdminContenderConfig />,
+    danger: <ClearAllData />,
+  };
+
   return (
     <div className="admin-panel">
+      <div className="admin-onboarding-banner">
+        <p>
+          New to admin workflows? Start with{' '}
+          <Link to="/guide/wiki/admin-quickstart">Admin Quickstart</Link> and then review{' '}
+          <Link to="/guide/wiki/admin-workflow">Typical Weekly Workflow</Link>.
+        </p>
+      </div>
       <div className="admin-content">
-        {activeTab === 'users' && <ManageUsers />}
-        {activeTab === 'features' && <ManageFeatures />}
-        {activeTab === 'players' && <ManagePlayers />}
-        {activeTab === 'divisions' && <ManageDivisions />}
-        {activeTab === 'match-config' && <ManageMatchConfig />}
-        {activeTab === 'schedule' && <ScheduleMatch />}
-        {activeTab === 'results' && <RecordResult />}
-        {activeTab === 'championships' && <ManageChampionships />}
-        {activeTab === 'tournaments' && <CreateTournament />}
-        {activeTab === 'challenges' && <AdminChallenges />}
-        {activeTab === 'promos' && <AdminPromos />}
-        {activeTab === 'seasons' && <ManageSeasons />}
-        {activeTab === 'season-awards' && <ManageSeasonAwards />}
-        {activeTab === 'events' && (
-          <>
-            <CreateEvent />
-            <MatchCardBuilder />
-          </>
-        )}
-        {activeTab === 'fantasy-shows' && <ManageFantasyShows />}
-        {activeTab === 'fantasy-config' && <FantasyConfig />}
-        {activeTab === 'contender-config' && <AdminContenderConfig />}
-        {activeTab === 'danger' && <ClearAllData />}
+        {tabContent[activeTab]}
       </div>
     </div>
   );

--- a/frontend/src/components/admin/ManagePlayers.css
+++ b/frontend/src/components/admin/ManagePlayers.css
@@ -9,6 +9,16 @@
   margin-bottom: 2rem;
 }
 
+.players-subtext {
+  margin: 0.35rem 0 0;
+  color: #9ca3af;
+  font-size: 0.85rem;
+}
+
+.players-subtext a {
+  color: #d4af37;
+}
+
 .player-form-container {
   background-color: #1a1a1a;
   border: 2px solid #d4af37;

--- a/frontend/src/components/admin/ManagePlayers.tsx
+++ b/frontend/src/components/admin/ManagePlayers.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import { Link } from 'react-router-dom';
 import { playersApi, imagesApi, divisionsApi } from '../../services/api';
 import { sanitizeName } from '../../utils/sanitize';
 import { logger } from '../../utils/logger';
@@ -237,7 +238,13 @@ export default function ManagePlayers() {
   return (
     <div className="manage-players">
       <div className="players-header">
-        <h2>Manage Players</h2>
+        <div>
+          <h2>Manage Players</h2>
+          <p className="players-subtext">
+            Edit existing players, assign divisions, and keep wrestler profiles current. Need process
+            details? <Link to="/guide/wiki/admin-manage-players">Learn more</Link>.
+          </p>
+        </div>
       </div>
 
       {error && <div className="error-message">{error}</div>}
@@ -366,9 +373,13 @@ export default function ManagePlayers() {
                   </td>
                   <td>
                     {player.userId ? (
-                      <span className="linked-badge">Linked</span>
+                      <span className="linked-badge" title="This player is linked to a user account">
+                        Linked
+                      </span>
                     ) : (
-                      <span className="unlinked-badge">Manual</span>
+                      <span className="unlinked-badge" title="This player was created manually and is not linked to a user account">
+                        Manual
+                      </span>
                     )}
                   </td>
                   <td>

--- a/frontend/src/components/admin/RecordResult.css
+++ b/frontend/src/components/admin/RecordResult.css
@@ -19,6 +19,23 @@
   white-space: nowrap;
 }
 
+.event-filter-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 260px;
+}
+
+.event-filter-labels small {
+  color: #999;
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+
+.event-filter-labels a {
+  color: #d4af37;
+}
+
 .event-filter-bar select {
   flex: 1;
   padding: 0.5rem 0.75rem;

--- a/frontend/src/components/admin/RecordResult.tsx
+++ b/frontend/src/components/admin/RecordResult.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { matchesApi, playersApi, eventsApi, stipulationsApi } from '../../services/api';
 import type { Match, Player, Stipulation } from '../../types';
@@ -240,7 +241,13 @@ export default function RecordResult() {
       {success && <div className="success-message">{success}</div>}
 
       <div className="event-filter-bar">
-        <label htmlFor="eventFilter">Event</label>
+        <div className="event-filter-labels">
+          <label htmlFor="eventFilter">Event</label>
+          <small>
+            Select an event to record card results, or use standalone matches for unslotted bouts.{' '}
+            <Link to="/guide/wiki/admin-record-results">Learn more</Link>
+          </small>
+        </div>
         <SearchableSelect
           id="eventFilter"
           value={selectedEventFilter}

--- a/frontend/src/components/admin/ScheduleMatch.css
+++ b/frontend/src/components/admin/ScheduleMatch.css
@@ -4,6 +4,16 @@
   margin: 0 auto;
 }
 
+.schedule-match-help {
+  margin: 0.5rem 0 0;
+  color: #9ca3af;
+  font-size: 0.85rem;
+}
+
+.schedule-match-help a {
+  color: #d4af37;
+}
+
 .match-form {
   background-color: #1a1a1a;
   border: 2px solid #333;

--- a/frontend/src/components/admin/ScheduleMatch.tsx
+++ b/frontend/src/components/admin/ScheduleMatch.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FormEvent } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { matchesApi, playersApi, championshipsApi, tournamentsApi, seasonsApi, eventsApi, stipulationsApi, matchTypesApi } from '../../services/api';
 import type { Player, Championship, Tournament, Season, Stipulation, MatchType } from '../../types';
@@ -295,6 +295,10 @@ export default function ScheduleMatch() {
   return (
     <div className="schedule-match">
       <h2>Schedule Match</h2>
+      <p className="schedule-match-help">
+        Need a refresher on event linkage, seasons, and card positions?{' '}
+        <Link to="/guide/wiki/admin-schedule-match">Open schedule guide</Link>.
+      </p>
 
       {error && <div className="error-message">{error}</div>}
       {success && <div className="success-message">{success}</div>}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -195,6 +195,7 @@
     },
     "articles": {
       "gettingStarted": "Erste Schritte",
+      "userQuickstart": "Benutzer: Schnellstart",
       "faqs": "Häufige Fragen",
       "standings": "Tabelle",
       "seasons": "Saisons",
@@ -213,6 +214,10 @@
       "statistics": "Statistiken",
       "adminGuide": "Admin",
       "adminQuickstart": "Admin: Schnellstart",
+      "adminMatchConfig": "Admin: Match-Konfiguration",
+      "adminSeasonAwards": "Admin: Saison-Auszeichnungen",
+      "adminFantasyShows": "Admin: Fantasy Shows",
+      "adminFantasyConfig": "Admin: Fantasy-Konfiguration",
       "adminUserManagement": "Admin: Benutzerverwaltung",
       "adminDivisions": "Admin: Divisionen",
       "adminManagePlayers": "Admin: Spieler verwalten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -195,6 +195,7 @@
     },
     "articles": {
       "gettingStarted": "Getting started",
+      "userQuickstart": "User: Quickstart",
       "faqs": "FAQs",
       "standings": "Standings",
       "seasons": "Seasons",
@@ -213,6 +214,10 @@
       "statistics": "Statistics",
       "adminGuide": "Admin",
       "adminQuickstart": "Admin: Quickstart",
+      "adminMatchConfig": "Admin: Match Config",
+      "adminSeasonAwards": "Admin: Season Awards",
+      "adminFantasyShows": "Admin: Fantasy Shows",
+      "adminFantasyConfig": "Admin: Fantasy Config",
       "adminUserManagement": "Admin: User Management",
       "adminDivisions": "Admin: Divisions",
       "adminManagePlayers": "Admin: Manage Players",

--- a/frontend/src/services/api/crudFactory.ts
+++ b/frontend/src/services/api/crudFactory.ts
@@ -1,0 +1,36 @@
+import { API_BASE_URL, fetchWithAuth } from './apiClient';
+
+export type CrudApi<TEntity, TCreate> = {
+  getAll: (signal?: AbortSignal) => Promise<TEntity[]>;
+  create: (data: TCreate) => Promise<TEntity>;
+  updateById: (id: string, updates: Partial<TEntity>) => Promise<TEntity>;
+  deleteById: (id: string) => Promise<void>;
+};
+
+export function createCrudApi<TEntity, TCreate>(endpoint: string): CrudApi<TEntity, TCreate> {
+  return {
+    getAll: async (signal?: AbortSignal): Promise<TEntity[]> => {
+      return fetchWithAuth(`${API_BASE_URL}/${endpoint}`, {}, signal);
+    },
+
+    create: async (data: TCreate): Promise<TEntity> => {
+      return fetchWithAuth(`${API_BASE_URL}/${endpoint}`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+    },
+
+    updateById: async (id: string, updates: Partial<TEntity>): Promise<TEntity> => {
+      return fetchWithAuth(`${API_BASE_URL}/${endpoint}/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(updates),
+      });
+    },
+
+    deleteById: async (id: string): Promise<void> => {
+      return fetchWithAuth(`${API_BASE_URL}/${endpoint}/${id}`, {
+        method: 'DELETE',
+      });
+    },
+  };
+}

--- a/frontend/src/services/api/divisions.api.ts
+++ b/frontend/src/services/api/divisions.api.ts
@@ -1,28 +1,22 @@
 import type { Division } from '../../types';
-import { API_BASE_URL, fetchWithAuth } from './apiClient';
+import { createCrudApi } from './crudFactory';
+
+const baseDivisionsApi = createCrudApi<Division, { name: string; description?: string }>('divisions');
 
 export const divisionsApi = {
   getAll: async (signal?: AbortSignal): Promise<Division[]> => {
-    return fetchWithAuth(`${API_BASE_URL}/divisions`, {}, signal);
+    return baseDivisionsApi.getAll(signal);
   },
 
   create: async (division: { name: string; description?: string }): Promise<Division> => {
-    return fetchWithAuth(`${API_BASE_URL}/divisions`, {
-      method: 'POST',
-      body: JSON.stringify(division),
-    });
+    return baseDivisionsApi.create(division);
   },
 
   update: async (divisionId: string, updates: Partial<Division>): Promise<Division> => {
-    return fetchWithAuth(`${API_BASE_URL}/divisions/${divisionId}`, {
-      method: 'PUT',
-      body: JSON.stringify(updates),
-    });
+    return baseDivisionsApi.updateById(divisionId, updates);
   },
 
   delete: async (divisionId: string): Promise<void> => {
-    return fetchWithAuth(`${API_BASE_URL}/divisions/${divisionId}`, {
-      method: 'DELETE',
-    });
+    return baseDivisionsApi.deleteById(divisionId);
   },
 };

--- a/frontend/src/services/api/matchTypes.api.ts
+++ b/frontend/src/services/api/matchTypes.api.ts
@@ -1,28 +1,22 @@
 import type { MatchType } from '../../types';
-import { API_BASE_URL, fetchWithAuth } from './apiClient';
+import { createCrudApi } from './crudFactory';
+
+const baseMatchTypesApi = createCrudApi<MatchType, { name: string; description?: string }>('match-types');
 
 export const matchTypesApi = {
   getAll: async (signal?: AbortSignal): Promise<MatchType[]> => {
-    return fetchWithAuth(`${API_BASE_URL}/match-types`, {}, signal);
+    return baseMatchTypesApi.getAll(signal);
   },
 
   create: async (matchType: { name: string; description?: string }): Promise<MatchType> => {
-    return fetchWithAuth(`${API_BASE_URL}/match-types`, {
-      method: 'POST',
-      body: JSON.stringify(matchType),
-    });
+    return baseMatchTypesApi.create(matchType);
   },
 
   update: async (matchTypeId: string, updates: Partial<MatchType>): Promise<MatchType> => {
-    return fetchWithAuth(`${API_BASE_URL}/match-types/${matchTypeId}`, {
-      method: 'PUT',
-      body: JSON.stringify(updates),
-    });
+    return baseMatchTypesApi.updateById(matchTypeId, updates);
   },
 
   delete: async (matchTypeId: string): Promise<void> => {
-    return fetchWithAuth(`${API_BASE_URL}/match-types/${matchTypeId}`, {
-      method: 'DELETE',
-    });
+    return baseMatchTypesApi.deleteById(matchTypeId);
   },
 };

--- a/frontend/src/services/api/stipulations.api.ts
+++ b/frontend/src/services/api/stipulations.api.ts
@@ -1,28 +1,22 @@
 import type { Stipulation } from '../../types';
-import { API_BASE_URL, fetchWithAuth } from './apiClient';
+import { createCrudApi } from './crudFactory';
+
+const baseStipulationsApi = createCrudApi<Stipulation, { name: string; description?: string }>('stipulations');
 
 export const stipulationsApi = {
   getAll: async (signal?: AbortSignal): Promise<Stipulation[]> => {
-    return fetchWithAuth(`${API_BASE_URL}/stipulations`, {}, signal);
+    return baseStipulationsApi.getAll(signal);
   },
 
   create: async (stipulation: { name: string; description?: string }): Promise<Stipulation> => {
-    return fetchWithAuth(`${API_BASE_URL}/stipulations`, {
-      method: 'POST',
-      body: JSON.stringify(stipulation),
-    });
+    return baseStipulationsApi.create(stipulation);
   },
 
   update: async (stipulationId: string, updates: Partial<Stipulation>): Promise<Stipulation> => {
-    return fetchWithAuth(`${API_BASE_URL}/stipulations/${stipulationId}`, {
-      method: 'PUT',
-      body: JSON.stringify(updates),
-    });
+    return baseStipulationsApi.updateById(stipulationId, updates);
   },
 
   delete: async (stipulationId: string): Promise<void> => {
-    return fetchWithAuth(`${API_BASE_URL}/stipulations/${stipulationId}`, {
-      method: 'DELETE',
-    });
+    return baseStipulationsApi.deleteById(stipulationId);
   },
 };


### PR DESCRIPTION
## Summary
- fix admin wiki visibility so admin/mod users can access all admin-only wiki entries
- add user quickstart and expand admin wiki coverage (EN/DE), including match config, season awards, fantasy shows, and fantasy config docs
- improve in-app guidance across public/admin flows (dashboard empty states, standings/filter help text, admin onboarding/help links)
- standardize selected backend handlers to shared router config and reduce frontend CRUD API duplication with a shared factory

## Linked issues
Closes #229
Closes #230
Closes #231
Closes #232
Closes #233
Closes #234
Closes #235
Closes #236
Closes #237
Closes #238

## Test plan
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit`
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit`
- [ ] Verify wiki index/sidebar admin visibility with admin and non-admin accounts
- [ ] Verify new wiki pages load in EN and DE
- [ ] Spot-check updated onboarding/help links in public and admin UI

Made with [Cursor](https://cursor.com)