### PR TITLE
fix(standings): exclude Fantasy-only users from player listings

### DIFF
--- a/backend/functions/dashboard/getDashboard.ts
+++ b/backend/functions/dashboard/getDashboard.ts
@@ -91,8 +91,11 @@ export const handler: APIGatewayProxyHandler = async () => {
         }),
       ]);
 
+    // Only include players who have a wrestler assigned (exclude Fantasy-only users)
+    const wrestlerPlayers = (players as Record<string, unknown>[]).filter((p) => p.currentWrestler);
+
     const playerMap = new Map<string, Record<string, unknown>>();
-    for (const p of players as Record<string, unknown>[]) {
+    for (const p of wrestlerPlayers) {
       const id = p.playerId as string;
       if (id) playerMap.set(id, p);
     }
@@ -262,7 +265,7 @@ export const handler: APIGatewayProxyHandler = async () => {
       }
     } else {
       let maxWins = 0;
-      for (const p of players as Record<string, unknown>[]) {
+      for (const p of wrestlerPlayers) {
         const w = (p.wins as number) ?? 0;
         if (w > maxWins) {
           maxWins = w;
@@ -275,7 +278,7 @@ export const handler: APIGatewayProxyHandler = async () => {
     }
 
     const quickStats: DashboardQuickStats = {
-      totalPlayers: players.length,
+      totalPlayers: wrestlerPlayers.length,
       totalMatches,
       activeChampionships: (championships as Record<string, unknown>[]).filter(
         (c) => c.isActive !== false

--- a/backend/functions/players/getPlayers.ts
+++ b/backend/functions/players/getPlayers.ts
@@ -8,7 +8,10 @@ export const handler: APIGatewayProxyHandler = async () => {
       TableName: TableNames.PLAYERS,
     });
 
-    return success(result.Items || []);
+    // Only include players who have a wrestler assigned (exclude Fantasy-only users)
+    const wrestlers = (result.Items || []).filter((p) => p.currentWrestler);
+
+    return success(wrestlers);
   } catch (err) {
     console.error('Error fetching players:', err);
     return serverError('Failed to fetch players');

--- a/backend/functions/rivalries/getRivalries.ts
+++ b/backend/functions/rivalries/getRivalries.ts
@@ -54,7 +54,8 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
     ]);
 
-    const players = playersResult as unknown as PlayerRecord[];
+    // Only include players who have a wrestler assigned (exclude Fantasy-only users)
+    const players = (playersResult as unknown as PlayerRecord[]).filter((p) => p.currentWrestler);
     const allMatches = matchesResult as unknown as MatchRecord[];
     let completed = allMatches.filter((m) => m.status === 'completed');
     if (seasonId) {

--- a/backend/functions/standings/getStandings.ts
+++ b/backend/functions/standings/getStandings.ts
@@ -73,9 +73,12 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       });
 
       // Get all player details with pagination support
-      const players = await dynamoDb.scanAll({
+      const allPlayers = await dynamoDb.scanAll({
         TableName: TableNames.PLAYERS,
       });
+
+      // Only include players who have a wrestler assigned (exclude Fantasy-only users)
+      const players = allPlayers.filter((p) => p.currentWrestler);
 
       // Build a map of season standings by playerId
       const standingsMap = new Map(
@@ -119,8 +122,11 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       TableName: TableNames.PLAYERS,
     });
 
+    // Only include players who have a wrestler assigned (exclude Fantasy-only users)
+    const wrestlers = allPlayers.filter((p) => p.currentWrestler);
+
     // Sort players by wins descending, then by losses ascending
-    const players = allPlayers.sort((a, b) => {
+    const players = wrestlers.sort((a, b) => {
       const aWins = (a.wins as number) || 0;
       const bWins = (b.wins as number) || 0;
       const aLosses = (a.losses as number) || 0;

--- a/backend/functions/statistics/getStatistics.ts
+++ b/backend/functions/statistics/getStatistics.ts
@@ -205,7 +205,8 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
     ]);
 
-    const players = playersResult as unknown as PlayerRecord[];
+    // Only include players who have a wrestler assigned (exclude Fantasy-only users)
+    const players = (playersResult as unknown as PlayerRecord[]).filter((p) => p.currentWrestler);
     const allMatches = matchesResult as unknown as MatchRecord[];
     const allCompletedMatches = allMatches.filter((m) => m.status === 'completed');
     const completedMatches = seasonId ? allCompletedMatches.filter((m) => m.seasonId === seasonId) : allCompletedMatches;


### PR DESCRIPTION
## Summary
- Fantasy-role users without a wrestler name (`currentWrestler`) were appearing in standings, dashboard stats, statistics, rivalries, and player lists
- Added `filter((p) => p.currentWrestler)` across 5 backend handlers to exclude Fantasy-only users from all player-facing listings
- Affected files: `getStandings.ts`, `getPlayers.ts`, `getDashboard.ts`, `getStatistics.ts`, `getRivalries.ts`

## Test plan
- [ ] Verify Fantasy-only users (no `currentWrestler`) no longer appear in standings page
- [ ] Verify dashboard quick stats `totalPlayers` count excludes Fantasy-only users
- [ ] Verify statistics dropdowns and leaderboards exclude Fantasy-only users
- [ ] Verify rivalries page excludes Fantasy-only users
- [ ] Verify GET /players endpoint excludes Fantasy-only users
- [ ] Confirm actual wrestlers with `currentWrestler` set still appear correctly everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)