### PR TITLE
fix(announcements): inline video playback in HTML body

### DIFF
--- a/frontend/src/components/AnnouncementModal.tsx
+++ b/frontend/src/components/AnnouncementModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { announcementsApi } from '../services/api';
@@ -48,6 +48,17 @@ export default function AnnouncementModal() {
   const { isAuthenticated, isLoading } = useAuth();
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const initInlineVideos = useCallback(() => {
+    if (!bodyRef.current) return;
+    const videos = bodyRef.current.querySelectorAll('video');
+    videos.forEach((video) => video.load());
+  }, []);
+
+  useEffect(() => {
+    initInlineVideos();
+  }, [currentIndex, initInlineVideos]);
 
   useEffect(() => {
     if (!isAuthenticated || isLoading) return;
@@ -115,6 +126,7 @@ export default function AnnouncementModal() {
         </h2>
         <div
           className="announcement-modal-body"
+          ref={bodyRef}
           dangerouslySetInnerHTML={{ __html: current.body }}
         />
         {current.videoUrl && (


### PR DESCRIPTION
## Summary
- Video tags embedded in announcement HTML bodies (via `dangerouslySetInnerHTML`) don't auto-initialize their media loading in browsers
- Added a ref + `useEffect` that calls `.load()` on any `<video>` elements found in the body after render
- Allows announcements to include inline video players directly in the HTML content

## Test plan
- [ ] Create an announcement with a `<video>` tag in the HTML body
- [ ] Verify the video loads and plays in the announcement modal
- [ ] Verify the existing `videoUrl` field still works as before
- [ ] Verify multi-announcement navigation still initializes videos on each slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)