### PR TITLE
feat(challenges): rework challenge flow — multi-opponent + auto-schedule

### DIFF
--- a/backend/functions/challenges/__tests__/createChallenge.test.ts
+++ b/backend/functions/challenges/__tests__/createChallenge.test.ts
@@ -74,13 +74,13 @@ describe('createChallenge', () => {
     expect(mockPut).toHaveBeenCalledOnce();
   });
 
-  it('includes optional fields (stipulation, championshipId, message) when provided', async () => {
+  it('includes optional fields (stipulation, championshipId, challengeNote) when provided', async () => {
     mockQuery.mockResolvedValue({ Items: [{ playerId: 'p1', userId: 'user-sub-1' }] });
     mockGet.mockResolvedValue({ Item: { playerId: 'p2' } });
     mockPut.mockResolvedValue({});
 
     const result = await createChallenge(
-      wrestlerEvent({ challengedId: 'p2', matchType: 'Cage', stipulation: 'Steel Cage', championshipId: 'title-1', message: 'You are going down!' }),
+      wrestlerEvent({ challengedId: 'p2', matchType: 'Cage', stipulation: 'Steel Cage', championshipId: 'title-1', challengeNote: 'You are going down!' }),
       ctx, cb,
     );
 
@@ -88,7 +88,7 @@ describe('createChallenge', () => {
     const body = JSON.parse(result!.body);
     expect(body.stipulation).toBe('Steel Cage');
     expect(body.championshipId).toBe('title-1');
-    expect(body.message).toBe('You are going down!');
+    expect(body.challengeNote).toBe('You are going down!');
   });
 
   it('omits optional fields when not provided', async () => {
@@ -100,7 +100,26 @@ describe('createChallenge', () => {
     const body = JSON.parse(result!.body);
     expect(body.stipulation).toBeUndefined();
     expect(body.championshipId).toBeUndefined();
-    expect(body.message).toBeUndefined();
+    expect(body.challengeNote).toBeUndefined();
+  });
+
+  it('accepts opponentIds[] and builds a responses map', async () => {
+    mockQuery.mockResolvedValue({ Items: [{ playerId: 'p1', userId: 'user-sub-1', name: 'Challenger' }] });
+    mockGet.mockImplementation(({ Key }: { Key: { playerId: string } }) => {
+      return Promise.resolve({ Item: { playerId: Key.playerId } });
+    });
+    mockPut.mockResolvedValue({});
+
+    const result = await createChallenge(
+      wrestlerEvent({ opponentIds: ['p2', 'p3'], matchType: 'Triple Threat' }),
+      ctx, cb,
+    );
+    expect(result!.statusCode).toBe(201);
+    const body = JSON.parse(result!.body);
+    expect(body.opponentIds).toEqual(['p2', 'p3']);
+    expect(body.challengedId).toBe('p2');
+    expect(body.responses.p2.status).toBe('pending');
+    expect(body.responses.p3.status).toBe('pending');
   });
 
   it('returns 400 when user does not have Wrestler role', async () => {
@@ -122,11 +141,11 @@ describe('createChallenge', () => {
     expect(JSON.parse(result!.body).message).toBe('Invalid JSON in request body');
   });
 
-  it('returns 400 when challengedId is missing', async () => {
+  it('returns 400 when neither opponentIds nor challengedId is provided', async () => {
     mockQuery.mockResolvedValue({ Items: [{ playerId: 'p1', userId: 'user-sub-1' }] });
     const result = await createChallenge(wrestlerEvent({ matchType: 'Singles' }), ctx, cb);
     expect(result!.statusCode).toBe(400);
-    expect(JSON.parse(result!.body).message).toBe('challengedId is required');
+    expect(JSON.parse(result!.body).message).toBe('opponentIds is required');
   });
 
   it('returns 400 when matchType is missing', async () => {

--- a/backend/functions/challenges/__tests__/getChallenges.test.ts
+++ b/backend/functions/challenges/__tests__/getChallenges.test.ts
@@ -83,6 +83,7 @@ describe('getChallenges', () => {
   });
 
   it('filters challenges by playerId using both ChallengerIndex and ChallengedIndex', async () => {
+    mockScanAll.mockResolvedValue([]);
     mockQueryAll.mockImplementation(({ IndexName }: any) => {
       if (IndexName === 'ChallengerIndex') return Promise.resolve([mockChallenge1]);
       if (IndexName === 'ChallengedIndex') return Promise.resolve([mockChallenge2]);
@@ -102,6 +103,7 @@ describe('getChallenges', () => {
   });
 
   it('deduplicates challenges when same challenge appears in both indexes', async () => {
+    mockScanAll.mockResolvedValue([]);
     mockQueryAll.mockImplementation(({ IndexName }: any) => {
       if (IndexName === 'ChallengerIndex') return Promise.resolve([mockChallenge1]);
       if (IndexName === 'ChallengedIndex') return Promise.resolve([mockChallenge1]);
@@ -177,6 +179,7 @@ describe('getChallenges', () => {
   });
 
   it('playerId filter takes priority over status filter', async () => {
+    mockScanAll.mockResolvedValue([]);
     mockQueryAll.mockResolvedValue([]);
     mockGet.mockResolvedValue({ Item: undefined });
 
@@ -190,7 +193,7 @@ describe('getChallenges', () => {
     expect(mockQueryAll).toHaveBeenCalledWith(
       expect.objectContaining({ IndexName: 'ChallengerIndex' }),
     );
-    expect(mockScanAll).not.toHaveBeenCalled();
+    // StatusIndex should not be used; scanAll is only used for multi-opponent lookup
   });
 });
 

--- a/backend/functions/challenges/__tests__/respondToChallenge.test.ts
+++ b/backend/functions/challenges/__tests__/respondToChallenge.test.ts
@@ -3,16 +3,24 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockGet, mockQuery, mockUpdate, mockTransactWrite } = vi.hoisted(() => ({
-  mockGet: vi.fn(), mockQuery: vi.fn(), mockUpdate: vi.fn(), mockTransactWrite: vi.fn(),
+const { mockGet, mockQuery, mockUpdate, mockPut } = vi.hoisted(() => ({
+  mockGet: vi.fn(), mockQuery: vi.fn(), mockUpdate: vi.fn(), mockPut: vi.fn(),
 }));
 
 vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: { get: mockGet, query: mockQuery, update: mockUpdate, transactWrite: mockTransactWrite },
-  TableNames: { CHALLENGES: 'Challenges', PLAYERS: 'Players' },
+  dynamoDb: { get: mockGet, query: mockQuery, update: mockUpdate, put: mockPut },
+  TableNames: {
+    CHALLENGES: 'Challenges', PLAYERS: 'Players', TAG_TEAMS: 'TagTeams',
+    MATCHES: 'Matches', EVENTS: 'Events',
+  },
 }));
 
-vi.mock('uuid', () => ({ v4: () => 'counter-uuid-5678' }));
+vi.mock('../../../lib/notifications', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  createNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('uuid', () => ({ v4: () => 'match-uuid-9999' }));
 
 import { handler as respondToChallenge } from '../respondToChallenge';
 
@@ -23,7 +31,7 @@ const cb: Callback = () => {};
 
 function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
   return {
-    body: null, headers: {}, multiValueHeaders: {}, httpMethod: 'PUT',
+    body: null, headers: {}, multiValueHeaders: {}, httpMethod: 'POST',
     isBase64Encoded: false, path: '/', pathParameters: null,
     queryStringParameters: null, multiValueQueryStringParameters: null,
     stageVariables: null, resource: '',
@@ -45,16 +53,16 @@ function respondEvent(body: object) {
   return withAuth(makeEvent({ pathParameters: { challengeId: 'ch1' }, body: JSON.stringify(body) }), 'Wrestler');
 }
 
-const pendingChallenge = {
-  challengeId: 'ch1', challengerId: 'p1', challengedId: 'p2',
-  matchType: 'Singles', status: 'pending', createdAt: '2025-01-15T10:00:00.000Z',
+const pendingSinglesChallenge = {
+  challengeId: 'ch1',
+  challengerId: 'p1',
+  challengedId: 'p2',
+  opponentIds: ['p2'],
+  responses: { p2: { status: 'pending' } },
+  matchType: 'Singles',
+  status: 'pending',
+  createdAt: '2025-01-15T10:00:00.000Z',
 };
-
-/** Set up mocks so the challenged player (p2) is the responder */
-function setupValidResponder() {
-  mockGet.mockResolvedValue({ Item: pendingChallenge });
-  mockQuery.mockResolvedValue({ Items: [{ playerId: 'p2', userId: 'user-sub-2' }] });
-}
 
 // ─── respondToChallenge ─────────────────────────────────────────────
 
@@ -62,14 +70,14 @@ describe('respondToChallenge', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 403 when user does not have Wrestler role', async () => {
-    const event = withAuth(makeEvent({ pathParameters: { challengeId: 'ch1' }, body: JSON.stringify({ action: 'accept' }) }), 'Fantasy');
+    const event = withAuth(makeEvent({ pathParameters: { challengeId: 'ch1' }, body: JSON.stringify({ response: 'accepted' }) }), 'Fantasy');
     const result = await respondToChallenge(event, ctx, cb);
     expect(result!.statusCode).toBe(403);
     expect(JSON.parse(result!.body).message).toBe('Only wrestlers can respond to challenges');
   });
 
   it('returns 400 when challengeId is missing from path', async () => {
-    const event = withAuth(makeEvent({ body: JSON.stringify({ action: 'accept' }) }), 'Wrestler');
+    const event = withAuth(makeEvent({ body: JSON.stringify({ response: 'accepted' }) }), 'Wrestler');
     const result = await respondToChallenge(event, ctx, cb);
     expect(result!.statusCode).toBe(400);
     expect(JSON.parse(result!.body).message).toBe('challengeId is required');
@@ -89,123 +97,103 @@ describe('respondToChallenge', () => {
     expect(JSON.parse(result!.body).message).toBe('Invalid JSON in request body');
   });
 
-  it('returns 400 when action is missing or invalid', async () => {
+  it('returns 400 when response is missing or invalid', async () => {
     const r1 = await respondToChallenge(respondEvent({}), ctx, cb);
     expect(r1!.statusCode).toBe(400);
-    expect(JSON.parse(r1!.body).message).toBe('action must be accept, decline, or counter');
+    expect(JSON.parse(r1!.body).message).toBe('response must be accepted or declined');
 
     vi.clearAllMocks();
-    const r2 = await respondToChallenge(respondEvent({ action: 'destroy' }), ctx, cb);
+    const r2 = await respondToChallenge(respondEvent({ response: 'destroy' }), ctx, cb);
     expect(r2!.statusCode).toBe(400);
+  });
+
+  it('returns 400 when declining without a declineReason', async () => {
+    const result = await respondToChallenge(respondEvent({ response: 'declined' }), ctx, cb);
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toBe('declineReason is required when declining');
   });
 
   it('returns 404 when challenge does not exist', async () => {
     mockGet.mockResolvedValue({ Item: undefined });
-    const result = await respondToChallenge(respondEvent({ action: 'accept' }), ctx, cb);
+    const result = await respondToChallenge(respondEvent({ response: 'accepted' }), ctx, cb);
     expect(result!.statusCode).toBe(404);
     expect(JSON.parse(result!.body).message).toBe('Challenge not found');
   });
 
   it('returns 400 when challenge is no longer pending', async () => {
-    mockGet.mockResolvedValue({ Item: { ...pendingChallenge, status: 'accepted' } });
-    const result = await respondToChallenge(respondEvent({ action: 'accept' }), ctx, cb);
+    mockGet.mockResolvedValue({ Item: { ...pendingSinglesChallenge, status: 'declined' } });
+    const result = await respondToChallenge(respondEvent({ response: 'accepted' }), ctx, cb);
     expect(result!.statusCode).toBe(400);
     expect(JSON.parse(result!.body).message).toBe('Challenge is no longer pending');
   });
 
-  it('returns 403 when responder is not the challenged player', async () => {
-    mockGet.mockResolvedValue({ Item: pendingChallenge });
+  it('returns 403 when responder is not one of the challenged opponents', async () => {
+    mockGet.mockResolvedValue({ Item: pendingSinglesChallenge });
     mockQuery.mockResolvedValue({ Items: [{ playerId: 'p3', userId: 'user-sub-2' }] });
-    const result = await respondToChallenge(respondEvent({ action: 'accept' }), ctx, cb);
-    expect(result!.statusCode).toBe(403);
-    expect(JSON.parse(result!.body).message).toBe('Only the challenged player can respond');
-  });
-
-  it('returns 403 when responder has no player profile', async () => {
-    mockGet.mockResolvedValue({ Item: pendingChallenge });
-    mockQuery.mockResolvedValue({ Items: [] });
-    const result = await respondToChallenge(respondEvent({ action: 'accept' }), ctx, cb);
+    const result = await respondToChallenge(respondEvent({ response: 'accepted' }), ctx, cb);
     expect(result!.statusCode).toBe(403);
   });
 
-  it('accepts a challenge and updates status to accepted', async () => {
-    setupValidResponder();
+  it('auto-schedules a match when all opponents have accepted', async () => {
+    // challenge.get, then player query (responder), then challenger player.get, then event query, then match put
+    mockGet
+      .mockResolvedValueOnce({ Item: pendingSinglesChallenge }) // challenge
+      .mockResolvedValueOnce({ Item: { playerId: 'p1', userId: 'challenger-sub' } }) // challenger
+      .mockResolvedValue({ Item: { playerId: 'p1', userId: 'challenger-sub', name: 'Challenger' } }); // participant lookups
+    mockQuery
+      .mockResolvedValueOnce({ Items: [{ playerId: 'p2', userId: 'user-sub-2', name: 'Responder' }] }) // responder
+      .mockResolvedValueOnce({ Items: [{ eventId: 'ev1', name: 'Raw', date: '2026-04-10T20:00:00.000Z' }] }); // next event
     mockUpdate.mockResolvedValue({});
-    const result = await respondToChallenge(respondEvent({ action: 'accept' }), ctx, cb);
+    mockPut.mockResolvedValue({});
+
+    const result = await respondToChallenge(respondEvent({ response: 'accepted' }), ctx, cb);
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    expect(body.status).toBe('accepted');
-    expect(body.updatedAt).toBeDefined();
-    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(body.status).toBe('auto_scheduled');
+    expect(body.matchId).toBe('match-uuid-9999');
+    expect(mockPut).toHaveBeenCalledOnce(); // match created
   });
 
-  it('accepts with responseMessage and includes it in update expression', async () => {
-    setupValidResponder();
+  it('marks challenge declined when the sole opponent declines with reason', async () => {
+    mockGet
+      .mockResolvedValueOnce({ Item: pendingSinglesChallenge }) // challenge
+      .mockResolvedValueOnce({ Item: { playerId: 'p1', userId: 'challenger-sub' } }); // challenger
+    mockQuery.mockResolvedValue({ Items: [{ playerId: 'p2', userId: 'user-sub-2', name: 'Responder' }] });
     mockUpdate.mockResolvedValue({});
-    const result = await respondToChallenge(respondEvent({ action: 'accept', responseMessage: 'Bring it!' }), ctx, cb);
-    expect(result!.statusCode).toBe(200);
-    expect(JSON.parse(result!.body).responseMessage).toBe('Bring it!');
-    expect(mockUpdate.mock.calls[0][0].UpdateExpression).toContain('responseMessage');
-  });
 
-  it('declines a challenge and updates status to declined', async () => {
-    setupValidResponder();
-    mockUpdate.mockResolvedValue({});
-    const result = await respondToChallenge(respondEvent({ action: 'decline' }), ctx, cb);
-    expect(result!.statusCode).toBe(200);
-    expect(JSON.parse(result!.body).status).toBe('declined');
-    expect(mockUpdate).toHaveBeenCalledOnce();
-  });
-
-  it('returns 400 when countering without counterMatchType', async () => {
-    setupValidResponder();
-    const result = await respondToChallenge(respondEvent({ action: 'counter' }), ctx, cb);
-    expect(result!.statusCode).toBe(400);
-    expect(JSON.parse(result!.body).message).toBe('counterMatchType is required when countering');
-  });
-
-  it('counters a challenge with transactWrite creating a new reversed challenge', async () => {
-    setupValidResponder();
-    mockTransactWrite.mockResolvedValue({});
-
-    const result = await respondToChallenge(respondEvent({
-      action: 'counter', counterMatchType: 'Cage', counterStipulation: 'Steel Cage',
-      counterMessage: 'My terms!', responseMessage: 'Not good enough',
-    }), ctx, cb);
-
+    const result = await respondToChallenge(
+      respondEvent({ response: 'declined', declineReason: 'Not interested' }),
+      ctx, cb,
+    );
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    expect(body.original.status).toBe('countered');
-    expect(body.original.counteredChallengeId).toBe('counter-uuid-5678');
-    expect(body.original.responseMessage).toBe('Not good enough');
-    expect(body.counter.challengerId).toBe('p2');
-    expect(body.counter.challengedId).toBe('p1');
-    expect(body.counter.matchType).toBe('Cage');
-    expect(body.counter.stipulation).toBe('Steel Cage');
-    expect(body.counter.message).toBe('My terms!');
-    expect(body.counter.status).toBe('pending');
-    expect(body.counter.expiresAt).toBeDefined();
-    expect(mockTransactWrite).toHaveBeenCalledOnce();
-    const tx = mockTransactWrite.mock.calls[0][0];
-    expect(tx.TransactItems).toHaveLength(2);
-    expect(tx.TransactItems[0]).toHaveProperty('Update');
-    expect(tx.TransactItems[1]).toHaveProperty('Put');
+    expect(body.status).toBe('declined');
+    expect(body.responses.p2.declineReason).toBe('Not interested');
   });
 
-  it('counters without optional counterStipulation and counterMessage', async () => {
-    setupValidResponder();
-    mockTransactWrite.mockResolvedValue({});
-    const result = await respondToChallenge(respondEvent({ action: 'counter', counterMatchType: 'TLC' }), ctx, cb);
+  it('keeps challenge pending when only one of multiple opponents accepts', async () => {
+    const multiChallenge = {
+      ...pendingSinglesChallenge,
+      opponentIds: ['p2', 'p3'],
+      responses: { p2: { status: 'pending' }, p3: { status: 'pending' } },
+    };
+    mockGet
+      .mockResolvedValueOnce({ Item: multiChallenge })
+      .mockResolvedValueOnce({ Item: { playerId: 'p1', userId: 'challenger-sub' } });
+    mockQuery.mockResolvedValue({ Items: [{ playerId: 'p2', userId: 'user-sub-2', name: 'Responder' }] });
+    mockUpdate.mockResolvedValue({});
+
+    const result = await respondToChallenge(respondEvent({ response: 'accepted' }), ctx, cb);
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    expect(body.counter.matchType).toBe('TLC');
-    expect(body.counter.stipulation).toBeUndefined();
-    expect(body.counter.message).toBeUndefined();
+    expect(body.status).toBe('pending');
+    expect(body.responses.p2.status).toBe('accepted');
+    expect(body.responses.p3.status).toBe('pending');
   });
 
   it('returns 500 when an unexpected error occurs', async () => {
     mockGet.mockRejectedValue(new Error('DynamoDB failure'));
-    const result = await respondToChallenge(respondEvent({ action: 'accept' }), ctx, cb);
+    const result = await respondToChallenge(respondEvent({ response: 'accepted' }), ctx, cb);
     expect(result!.statusCode).toBe(500);
     expect(JSON.parse(result!.body).message).toBe('Failed to respond to challenge');
   });

--- a/backend/functions/challenges/createChallenge.ts
+++ b/backend/functions/challenges/createChallenge.ts
@@ -4,17 +4,27 @@ import { created, badRequest, serverError } from '../../lib/response';
 import { getAuthContext, hasRole } from '../../lib/auth';
 import { parseBody } from '../../lib/parseBody';
 import { v4 as uuidv4 } from 'uuid';
-import { createNotification, createNotifications } from '../../lib/notifications';
+import { createNotifications } from '../../lib/notifications';
 
 interface CreateChallengeBody {
-  challengedId: string;
+  challengedId?: string; // Legacy: single opponent id — preferred: opponentIds[]
+  opponentIds?: string[];
   matchType: string;
   stipulation?: string;
   championshipId?: string;
-  message?: string;
+  challengeNote?: string;
+  message?: string; // Legacy alias for challengeNote
   challengeMode?: 'singles' | 'tag_team';
   challengedTagTeamId?: string;
 }
+
+interface ResponseRecord {
+  status: 'pending' | 'accepted' | 'declined';
+  declineReason?: string;
+}
+
+const MAX_CHALLENGE_NOTE_LENGTH = 200;
+const MAX_OPPONENTS = 5;
 
 async function findPlayerActiveTagTeam(playerId: string): Promise<Record<string, unknown> | null> {
   const [player1Result, player2Result] = await Promise.all([
@@ -49,10 +59,16 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     const { data: body, error: parseError } = parseBody<CreateChallengeBody>(event);
     if (parseError) return parseError;
-    const { challengedId, matchType, stipulation, championshipId, message, challengeMode, challengedTagTeamId } = body;
+    const { challengedId, opponentIds: inputOpponentIds, matchType, stipulation, championshipId, challengeNote: inputChallengeNote, message, challengeMode, challengedTagTeamId } = body;
 
     if (!matchType) {
       return badRequest('matchType is required');
+    }
+
+    // Prefer challengeNote; fall back to legacy message field
+    const challengeNote = inputChallengeNote ?? message;
+    if (challengeNote && challengeNote.length > MAX_CHALLENGE_NOTE_LENGTH) {
+      return badRequest(`challengeNote must be ${MAX_CHALLENGE_NOTE_LENGTH} characters or less`);
     }
 
     // Find the challenger's player record via their user sub
@@ -114,7 +130,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         matchType,
         stipulation: stipulation || undefined,
         championshipId: championshipId || undefined,
-        message: message || undefined,
+        challengeNote: challengeNote || undefined,
         status: 'pending',
         expiresAt: expiresAt.toISOString(),
         createdAt: now.toISOString(),
@@ -157,33 +173,48 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return created(challenge);
     }
 
-    // --- Singles Challenge Flow (default) ---
-    if (!challengedId) {
-      return badRequest('challengedId is required');
-    }
+    // --- Singles / Multi-opponent Challenge Flow (default) ---
+    // Normalize opponent list: prefer opponentIds[], fall back to legacy challengedId
+    const opponentIds: string[] = (inputOpponentIds && inputOpponentIds.length > 0)
+      ? Array.from(new Set(inputOpponentIds))
+      : (challengedId ? [challengedId] : []);
 
-    if (challengerId === challengedId) {
+    if (opponentIds.length === 0) {
+      return badRequest('opponentIds is required');
+    }
+    if (opponentIds.length > MAX_OPPONENTS) {
+      return badRequest(`A challenge may target at most ${MAX_OPPONENTS} opponents`);
+    }
+    if (opponentIds.includes(challengerId)) {
       return badRequest('You cannot challenge yourself');
     }
 
-    // Verify the challenged player exists
-    const challengedResult = await dynamoDb.get({
-      TableName: TableNames.PLAYERS,
-      Key: { playerId: challengedId },
-    });
-    if (!challengedResult.Item) {
+    // Verify each challenged player exists
+    const opponentLookups = await Promise.all(
+      opponentIds.map((pid) =>
+        dynamoDb.get({ TableName: TableNames.PLAYERS, Key: { playerId: pid } })
+      )
+    );
+    const missing = opponentIds.filter((_, i) => !opponentLookups[i].Item);
+    if (missing.length > 0) {
       return badRequest('Challenged player not found');
     }
+
+    const responses: Record<string, ResponseRecord> = Object.fromEntries(
+      opponentIds.map((pid) => [pid, { status: 'pending' as const }])
+    );
 
     const challenge = {
       challengeId: uuidv4(),
       challengerId,
-      challengedId,
+      challengedId: opponentIds[0], // preserve for legacy GSI queries
+      opponentIds,
+      responses,
       challengeMode: 'singles' as const,
       matchType,
       stipulation: stipulation || undefined,
       championshipId: championshipId || undefined,
-      message: message || undefined,
+      challengeNote: challengeNote || undefined,
       status: 'pending',
       expiresAt: expiresAt.toISOString(),
       createdAt: now.toISOString(),
@@ -195,16 +226,20 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       Item: challenge,
     });
 
-    // Notify the challenged player if they have a linked user account
-    const challengedPlayer = challengedResult.Item as Record<string, unknown>;
-    if (challengedPlayer.userId) {
-      await createNotification({
-        userId: challengedPlayer.userId as string,
-        type: 'challenge_received',
+    // Notify each challenged player who has a linked user account
+    const notifications = opponentLookups
+      .map((r) => r.Item as Record<string, unknown> | undefined)
+      .filter((p): p is Record<string, unknown> => !!p?.userId)
+      .map((p) => ({
+        userId: p.userId as string,
+        type: 'challenge_received' as const,
         message: `${challengerPlayer.name as string} has challenged you to a match!`,
         sourceId: challenge.challengeId,
-        sourceType: 'challenge',
-      });
+        sourceType: 'challenge' as const,
+      }));
+
+    if (notifications.length > 0) {
+      await createNotifications(notifications);
     }
 
     return created(challenge);

--- a/backend/functions/challenges/getChallenge.ts
+++ b/backend/functions/challenges/getChallenge.ts
@@ -22,7 +22,9 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     // Enrich with player names
     const playerIds = new Set<string>();
     playerIds.add(challenge.challengerId as string);
-    playerIds.add(challenge.challengedId as string);
+    if (challenge.challengedId) playerIds.add(challenge.challengedId as string);
+    const oppIds = (challenge.opponentIds as string[] | undefined) || (challenge.challengedId ? [challenge.challengedId as string] : []);
+    for (const id of oppIds) playerIds.add(id);
 
     const playerMap: Record<string, { name: string; currentWrestler: string; imageUrl?: string }> = {};
     for (const pid of playerIds) {
@@ -42,8 +44,17 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const challenger = playerMap[challenge.challengerId as string];
     const challenged = playerMap[challenge.challengedId as string];
 
+    const opponents = oppIds.map((pid) => {
+      const info = playerMap[pid];
+      return info
+        ? { playerId: pid, playerName: info.name, wrestlerName: info.currentWrestler, imageUrl: info.imageUrl }
+        : { playerId: pid, playerName: 'Unknown', wrestlerName: 'Unknown' };
+    });
+
     const enriched: Record<string, unknown> = {
       ...challenge,
+      opponentIds: oppIds,
+      opponents,
       challengeMode: (challenge.challengeMode as string) || 'singles',
       challenger: challenger
         ? { playerName: challenger.name, wrestlerName: challenger.currentWrestler, imageUrl: challenger.imageUrl }

--- a/backend/functions/challenges/getChallenges.ts
+++ b/backend/functions/challenges/getChallenges.ts
@@ -48,10 +48,18 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         }),
       ]);
 
+      // Also scan for multi-opponent challenges where this player is a non-primary opponent
+      const multiOpponentResult =
+        (await dynamoDb.scanAll({
+          TableName: TableNames.CHALLENGES,
+          FilterExpression: 'contains(opponentIds, :pid)',
+          ExpressionAttributeValues: { ':pid': playerId },
+        })) || [];
+
       // Deduplicate by challengeId
       const seen = new Set<string>();
       challenges = [];
-      for (const c of [...sentResult, ...receivedResult]) {
+      for (const c of [...sentResult, ...receivedResult, ...multiOpponentResult]) {
         if (!seen.has(c.challengeId as string)) {
           seen.add(c.challengeId as string);
           challenges.push(c);
@@ -112,7 +120,11 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const playerIds = new Set<string>();
     for (const c of challenges) {
       playerIds.add(c.challengerId as string);
-      playerIds.add(c.challengedId as string);
+      if (c.challengedId) playerIds.add(c.challengedId as string);
+      const oppIds = c.opponentIds as string[] | undefined;
+      if (oppIds) {
+        for (const id of oppIds) playerIds.add(id);
+      }
     }
 
     const playerMap: Record<string, { name: string; currentWrestler: string; imageUrl?: string }> = {};
@@ -208,8 +220,18 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       const challenger = playerMap[c.challengerId as string];
       const challenged = playerMap[c.challengedId as string];
 
+      const oppIds = (c.opponentIds as string[] | undefined) || (c.challengedId ? [c.challengedId as string] : []);
+      const opponents = oppIds.map((pid) => {
+        const info = playerMap[pid];
+        return info
+          ? { playerId: pid, playerName: info.name, wrestlerName: info.currentWrestler, imageUrl: info.imageUrl }
+          : { playerId: pid, playerName: 'Unknown', wrestlerName: 'Unknown' };
+      });
+
       const base: Record<string, unknown> = {
         ...c,
+        opponentIds: oppIds,
+        opponents,
         challengeMode: (c.challengeMode as string) || 'singles',
         challenger: challenger
           ? { playerName: challenger.name, wrestlerName: challenger.currentWrestler, imageUrl: challenger.imageUrl }

--- a/backend/functions/challenges/respondToChallenge.ts
+++ b/backend/functions/challenges/respondToChallenge.ts
@@ -1,10 +1,132 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
 import { dynamoDb, TableNames } from '../../lib/dynamodb';
 import { success, badRequest, notFound, serverError, forbidden } from '../../lib/response';
 import { getAuthContext, hasRole } from '../../lib/auth';
-import { v4 as uuidv4 } from 'uuid';
+import { createNotification, createNotifications } from '../../lib/notifications';
 
-type ChallengeAction = 'accept' | 'decline' | 'counter';
+interface RespondBody {
+  response?: 'accepted' | 'declined';
+  declineReason?: string;
+  // Legacy fields (still accepted for backward-compat with older clients)
+  action?: 'accept' | 'decline';
+  responseMessage?: string;
+}
+
+interface ResponseRecord {
+  status: 'pending' | 'accepted' | 'declined';
+  declineReason?: string;
+}
+
+/**
+ * Compute the target show date for an auto-scheduled challenge match.
+ * - If accepted on Sunday, advance to Monday.
+ * - Otherwise, next calendar day.
+ */
+function computeFallbackDate(now: Date): string {
+  const target = new Date(now);
+  const day = now.getDay(); // 0 = Sunday
+  if (day === 0) {
+    target.setDate(target.getDate() + 1); // Monday
+  } else {
+    target.setDate(target.getDate() + 1);
+  }
+  target.setHours(20, 0, 0, 0);
+  return target.toISOString();
+}
+
+function earliestEligibleIso(now: Date): string {
+  // Must be on Monday or later if accepted on Sunday — i.e. strictly after Sunday.
+  const base = new Date(now);
+  const day = now.getDay();
+  if (day === 0) {
+    base.setDate(base.getDate() + 1); // Monday
+    base.setHours(0, 0, 0, 0);
+  }
+  return base.toISOString();
+}
+
+async function findNextUpcomingEvent(minDateIso: string): Promise<Record<string, unknown> | null> {
+  try {
+    const result = await dynamoDb.query({
+      TableName: TableNames.EVENTS,
+      IndexName: 'StatusIndex',
+      KeyConditionExpression: '#s = :st AND #d >= :minDate',
+      ExpressionAttributeNames: { '#s': 'status', '#d': 'date' },
+      ExpressionAttributeValues: { ':st': 'upcoming', ':minDate': minDateIso },
+      ScanIndexForward: true,
+      Limit: 1,
+    });
+    const item = result.Items?.[0];
+    return item ? (item as Record<string, unknown>) : null;
+  } catch (err) {
+    console.error('Failed to query upcoming events:', err);
+    return null;
+  }
+}
+
+async function autoScheduleMatch(
+  challenge: Record<string, unknown>,
+  challengerId: string,
+  opponentIds: string[],
+  now: Date,
+): Promise<{ matchId: string; eventId?: string; eventName?: string; date: string }> {
+  // Find next eligible event date
+  const minDateIso = earliestEligibleIso(now);
+  const nextEvent = await findNextUpcomingEvent(minDateIso);
+
+  const eventId = nextEvent?.eventId as string | undefined;
+  const eventName = nextEvent?.name as string | undefined;
+  const targetDate = (nextEvent?.date as string | undefined) || computeFallbackDate(now);
+
+  const matchId = uuidv4();
+  const nowIso = now.toISOString();
+  const match: Record<string, unknown> = {
+    matchId,
+    date: targetDate,
+    matchFormat: challenge.matchType as string,
+    participants: [challengerId, ...opponentIds],
+    isChampionship: false,
+    status: 'scheduled',
+    designation: 'pre-show',
+    challengeId: challenge.challengeId as string,
+    createdAt: nowIso,
+  };
+  if (eventId) match.eventId = eventId;
+  if (challenge.stipulation) match.stipulation = challenge.stipulation as string;
+
+  await dynamoDb.put({
+    TableName: TableNames.MATCHES,
+    Item: match,
+  });
+
+  // If event found, append to its matchCards
+  if (eventId && nextEvent) {
+    try {
+      const existingCards = (nextEvent.matchCards as unknown[] | undefined) || [];
+      const newCard = {
+        matchId,
+        position: existingCards.length + 1,
+        designation: 'pre-show',
+      };
+      await dynamoDb.update({
+        TableName: TableNames.EVENTS,
+        Key: { eventId },
+        UpdateExpression:
+          'SET matchCards = list_append(if_not_exists(matchCards, :empty), :newCard), updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':newCard': [newCard],
+          ':empty': [],
+          ':now': nowIso,
+        },
+      });
+    } catch (err) {
+      console.error('Failed to append match to event matchCards:', err);
+    }
+  }
+
+  return { matchId, eventId, eventName, date: targetDate };
+}
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
@@ -22,31 +144,34 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('Request body is required');
     }
 
-    let body;
+    let body: RespondBody;
     try {
-      body = JSON.parse(event.body);
+      body = JSON.parse(event.body) as RespondBody;
     } catch {
       return badRequest('Invalid JSON in request body');
     }
 
-    const { action, responseMessage, counterMatchType, counterStipulation, counterMessage } = body as {
-      action: ChallengeAction;
-      responseMessage?: string;
-      counterMatchType?: string;
-      counterStipulation?: string;
-      counterMessage?: string;
-    };
+    // Normalize body — accept either new `response` field or legacy `action`.
+    let responseValue: 'accepted' | 'declined' | undefined = body.response;
+    if (!responseValue && body.action) {
+      responseValue = body.action === 'accept' ? 'accepted' : body.action === 'decline' ? 'declined' : undefined;
+    }
+    const declineReason = body.declineReason;
 
-    if (!action || !['accept', 'decline', 'counter'].includes(action)) {
-      return badRequest('action must be accept, decline, or counter');
+    if (!responseValue || !['accepted', 'declined'].includes(responseValue)) {
+      return badRequest('response must be accepted or declined');
     }
 
-    // Get the challenge
+    if (responseValue === 'declined' && !declineReason) {
+      return badRequest('declineReason is required when declining');
+    }
+
+    // Fetch challenge
     const result = await dynamoDb.get({
       TableName: TableNames.CHALLENGES,
       Key: { challengeId },
     });
-    const challenge = result.Item;
+    const challenge = result.Item as Record<string, unknown> | undefined;
     if (!challenge) {
       return notFound('Challenge not found');
     }
@@ -55,124 +180,204 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('Challenge is no longer pending');
     }
 
-    // Verify the responder is allowed to respond
+    // Verify the responder
     const playerResult = await dynamoDb.query({
       TableName: TableNames.PLAYERS,
       IndexName: 'UserIdIndex',
       KeyConditionExpression: 'userId = :uid',
       ExpressionAttributeValues: { ':uid': auth.sub },
     });
-    const responderPlayer = playerResult.Items?.[0];
+    const responderPlayer = playerResult.Items?.[0] as Record<string, unknown> | undefined;
     if (!responderPlayer) {
       return forbidden('Only the challenged player can respond');
     }
+    const responderId = responderPlayer.playerId as string;
+    const responderName = (responderPlayer.currentWrestler as string) || (responderPlayer.name as string) || 'A wrestler';
 
+    const now = new Date();
+    const nowIso = now.toISOString();
+
+    // --- Tag team path (simple accept/decline; no auto-schedule) ---
     if (challenge.challengeMode === 'tag_team') {
-      // Tag team challenge: either member of the challenged tag team can respond
       const tagTeamResult = await dynamoDb.get({
         TableName: TableNames.TAG_TEAMS,
         Key: { tagTeamId: challenge.challengedTagTeamId as string },
       });
-      const tagTeam = tagTeamResult.Item;
+      const tagTeam = tagTeamResult.Item as Record<string, unknown> | undefined;
       if (!tagTeam || tagTeam.status !== 'active') {
         return badRequest('The challenged tag team has been dissolved');
       }
-      if (responderPlayer.playerId !== tagTeam.player1Id && responderPlayer.playerId !== tagTeam.player2Id) {
+      if (responderId !== tagTeam.player1Id && responderId !== tagTeam.player2Id) {
         return forbidden('Only members of the challenged tag team can respond');
       }
-    } else {
-      // Singles challenge: only the challenged player can respond
-      if (responderPlayer.playerId !== challenge.challengedId) {
-        return forbidden('Only the challenged player can respond');
-      }
-    }
 
-    const now = new Date().toISOString();
-
-    if (action === 'accept' || action === 'decline') {
-      const newStatus = action === 'accept' ? 'accepted' : 'declined';
-      const updateExpression = responseMessage
-        ? 'SET #s = :status, responseMessage = :rm, updatedAt = :now'
-        : 'SET #s = :status, updatedAt = :now';
-      const expressionValues: Record<string, unknown> = {
+      const newStatus = responseValue === 'accepted' ? 'accepted' : 'declined';
+      const exprValues: Record<string, unknown> = {
         ':status': newStatus,
-        ':now': now,
+        ':now': nowIso,
       };
-      if (responseMessage) expressionValues[':rm'] = responseMessage;
+      let updateExpr = 'SET #s = :status, updatedAt = :now';
+      if (declineReason) {
+        updateExpr += ', declineReason = :dr';
+        exprValues[':dr'] = declineReason;
+      }
 
       await dynamoDb.update({
         TableName: TableNames.CHALLENGES,
         Key: { challengeId },
-        UpdateExpression: updateExpression,
+        UpdateExpression: updateExpr,
         ExpressionAttributeNames: { '#s': 'status' },
-        ExpressionAttributeValues: expressionValues,
+        ExpressionAttributeValues: exprValues,
       });
 
-      return success({ ...challenge, status: newStatus, responseMessage, updatedAt: now });
+      return success({ ...challenge, status: newStatus, declineReason, updatedAt: nowIso });
     }
 
-    // Counter
-    if (!counterMatchType) {
-      return badRequest('counterMatchType is required when countering');
+    // --- Singles / multi-opponent path ---
+    const opponentIds: string[] =
+      (challenge.opponentIds as string[] | undefined) ||
+      (challenge.challengedId ? [challenge.challengedId as string] : []);
+
+    if (!opponentIds.includes(responderId)) {
+      return forbidden('Only the challenged player can respond');
     }
 
-    const counterChallengeId = uuidv4();
-    const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + 7);
-
-    const counterChallenge: Record<string, unknown> = {
-      challengeId: counterChallengeId,
-      challengerId: responderPlayer.playerId as string,
-      challengedId: challenge.challengerId as string,
-      matchType: counterMatchType,
-      status: 'pending',
-      expiresAt: expiresAt.toISOString(),
-      createdAt: now,
-      updatedAt: now,
+    // Normalize responses map (fallback for legacy records)
+    const responses: Record<string, ResponseRecord> = {
+      ...(challenge.responses as Record<string, ResponseRecord> | undefined ||
+        Object.fromEntries(opponentIds.map((id) => [id, { status: 'pending' as const }]))),
     };
-    if (challenge.challengeMode === 'tag_team') {
-      counterChallenge.challengeMode = 'tag_team';
-      counterChallenge.challengerTagTeamId = challenge.challengedTagTeamId;
-      counterChallenge.challengedTagTeamId = challenge.challengerTagTeamId;
+
+    if (responses[responderId]?.status !== 'pending') {
+      return badRequest('You have already responded to this challenge');
     }
-    if (counterStipulation) counterChallenge.stipulation = counterStipulation;
-    if (counterMessage) counterChallenge.message = counterMessage;
 
-    // Update original + create counter in transaction
-    const counterUpdateExpr = responseMessage
-      ? 'SET #s = :status, responseMessage = :rm, counteredChallengeId = :ccid, updatedAt = :now'
-      : 'SET #s = :status, counteredChallengeId = :ccid, updatedAt = :now';
-    const counterExprValues: Record<string, unknown> = {
-      ':status': 'countered',
-      ':ccid': counterChallengeId,
-      ':now': now,
+    responses[responderId] = {
+      status: responseValue,
+      ...(declineReason ? { declineReason } : {}),
     };
-    if (responseMessage) counterExprValues[':rm'] = responseMessage;
 
-    await dynamoDb.transactWrite({
-      TransactItems: [
-        {
-          Update: {
-            TableName: TableNames.CHALLENGES,
-            Key: { challengeId },
-            UpdateExpression: counterUpdateExpr,
-            ExpressionAttributeNames: { '#s': 'status' },
-            ExpressionAttributeValues: counterExprValues,
-          },
+    const statusList = Object.values(responses).map((r) => r.status);
+    const anyPending = statusList.some((s) => s === 'pending');
+    const anyDeclined = statusList.some((s) => s === 'declined');
+    const anyAccepted = statusList.some((s) => s === 'accepted');
+    const allAccepted = statusList.every((s) => s === 'accepted');
+
+    const challengerId = challenge.challengerId as string;
+    const challengerResult = await dynamoDb.get({
+      TableName: TableNames.PLAYERS,
+      Key: { playerId: challengerId },
+    });
+    const challengerPlayer = challengerResult.Item as Record<string, unknown> | undefined;
+    const challengerUserId = challengerPlayer?.userId as string | undefined;
+
+    // Case: all accepted → auto-schedule match
+    if (allAccepted) {
+      const scheduled = await autoScheduleMatch(challenge, challengerId, opponentIds, now);
+
+      await dynamoDb.update({
+        TableName: TableNames.CHALLENGES,
+        Key: { challengeId },
+        UpdateExpression:
+          'SET #s = :status, responses = :r, matchId = :mid, scheduledEventId = :eid, updatedAt = :now',
+        ExpressionAttributeNames: { '#s': 'status' },
+        ExpressionAttributeValues: {
+          ':status': 'auto_scheduled',
+          ':r': responses,
+          ':mid': scheduled.matchId,
+          ':eid': scheduled.eventId || null,
+          ':now': nowIso,
         },
-        {
-          Put: {
-            TableName: TableNames.CHALLENGES,
-            Item: counterChallenge,
-          },
+      });
+
+      // Notify all participants
+      const participantIds = [challengerId, ...opponentIds];
+      const playerLookups = await Promise.all(
+        participantIds.map((pid) =>
+          dynamoDb.get({ TableName: TableNames.PLAYERS, Key: { playerId: pid } })
+        )
+      );
+      const scheduleMessage = scheduled.eventName
+        ? `Your challenge match has been scheduled for ${scheduled.eventName} (Pre-Show)`
+        : 'Your challenge match has been auto-scheduled as a Pre-Show match';
+      const notifications = playerLookups
+        .map((r) => r.Item as Record<string, unknown> | undefined)
+        .filter((p): p is Record<string, unknown> => !!p?.userId)
+        .map((p) => ({
+          userId: p.userId as string,
+          type: 'challenge_scheduled' as const,
+          message: scheduleMessage,
+          sourceId: scheduled.matchId,
+          sourceType: 'match' as const,
+        }));
+      if (notifications.length > 0) {
+        await createNotifications(notifications);
+      }
+
+      return success({
+        ...challenge,
+        status: 'auto_scheduled',
+        responses,
+        matchId: scheduled.matchId,
+        scheduledEventId: scheduled.eventId,
+        matchDate: scheduled.date,
+        eventName: scheduled.eventName,
+        updatedAt: nowIso,
+      });
+    }
+
+    // Case: all responded (no pending) with at least one decline
+    if (!anyPending && anyDeclined) {
+      const newStatus = anyAccepted ? 'partially_declined' : 'declined';
+      await dynamoDb.update({
+        TableName: TableNames.CHALLENGES,
+        Key: { challengeId },
+        UpdateExpression: 'SET #s = :status, responses = :r, updatedAt = :now',
+        ExpressionAttributeNames: { '#s': 'status' },
+        ExpressionAttributeValues: {
+          ':status': newStatus,
+          ':r': responses,
+          ':now': nowIso,
         },
-      ],
+      });
+
+      if (challengerUserId) {
+        await createNotification({
+          userId: challengerUserId,
+          type: 'challenge_declined',
+          message: `${responderName} declined your challenge${declineReason ? `: "${declineReason}"` : ''}`,
+          sourceId: challengeId,
+          sourceType: 'challenge',
+        });
+      }
+
+      return success({ ...challenge, status: newStatus, responses, updatedAt: nowIso });
+    }
+
+    // Otherwise: still pending responses from others — just update the responses map.
+    await dynamoDb.update({
+      TableName: TableNames.CHALLENGES,
+      Key: { challengeId },
+      UpdateExpression: 'SET responses = :r, updatedAt = :now',
+      ExpressionAttributeValues: { ':r': responses, ':now': nowIso },
     });
 
-    return success({
-      original: { ...challenge, status: 'countered', responseMessage, counteredChallengeId: counterChallengeId, updatedAt: now },
-      counter: counterChallenge,
-    });
+    if (challengerUserId) {
+      const notifType = responseValue === 'accepted' ? 'challenge_accepted' : 'challenge_declined';
+      const verb = responseValue === 'accepted' ? 'accepted' : 'declined';
+      const msg = `${responderName} ${verb} your challenge${
+        responseValue === 'declined' && declineReason ? `: "${declineReason}"` : ''
+      }`;
+      await createNotification({
+        userId: challengerUserId,
+        type: notifType,
+        message: msg,
+        sourceId: challengeId,
+        sourceType: 'challenge',
+      });
+    }
+
+    return success({ ...challenge, status: 'pending', responses, updatedAt: nowIso });
   } catch (err) {
     console.error('Error responding to challenge:', err);
     return serverError('Failed to respond to challenge');

--- a/backend/lib/notifications.ts
+++ b/backend/lib/notifications.ts
@@ -4,6 +4,9 @@ import { dynamoDb, TableNames } from './dynamodb';
 export type NotificationType =
   | 'promo_mention'
   | 'challenge_received'
+  | 'challenge_accepted'
+  | 'challenge_declined'
+  | 'challenge_scheduled'
   | 'match_scheduled'
   | 'announcement'
   | 'stable_invitation'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import ForgotPassword from './components/auth/ForgotPassword';
 import ChallengeDetail from './components/challenges/ChallengeDetail';
 // IssueChallenge kept as a component but route redirects to PromoEditor in call-out mode
 import MyChallenges from './components/challenges/MyChallenges';
+import ChallengeResponse from './components/challenges/ChallengeResponse';
 // Promo components
 import PromoFeed from './components/promos/PromoFeed';
 import PromoThread from './components/promos/PromoThread';
@@ -157,6 +158,13 @@ function AppLayout() {
               <Navigate to="/promos/new?promoType=call-out" replace />
             } />
             <Route path="/challenges/my" element={<Navigate to="/challenges" replace />} />
+            <Route path="/challenges/:challengeId/respond" element={
+              <FeatureRoute feature="challenges">
+                <ProtectedRoute requiredRole="Wrestler">
+                  <ChallengeResponse />
+                </ProtectedRoute>
+              </FeatureRoute>
+            } />
             <Route path="/challenges/:challengeId" element={
               <FeatureRoute feature="challenges">
                 <ProtectedRoute requiredRole="Wrestler">

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -42,9 +42,16 @@ function sourceTypeLabel(sourceType: AppNotification['sourceType']): string {
 }
 
 function getNavigationPath(notification: AppNotification, playerId: string | null): string {
+  // Route challenge notifications by type rather than only sourceType
+  if (notification.sourceType === 'challenge') {
+    if (notification.type === 'challenge_received') {
+      return `/challenges/${notification.sourceId}/respond`;
+    }
+    // challenge_accepted, challenge_declined, or generic
+    return `/challenges/${notification.sourceId}`;
+  }
   switch (notification.sourceType) {
     case 'promo': return '/promos';
-    case 'challenge': return '/challenges';
     case 'match': {
       const params = new URLSearchParams({ status: 'scheduled' });
       if (playerId) params.set('playerId', playerId);

--- a/frontend/src/components/challenges/ChallengeDetail.tsx
+++ b/frontend/src/components/challenges/ChallengeDetail.tsx
@@ -271,13 +271,13 @@ export default function ChallengeDetail() {
 
       <div className="challenge-detail-messages">
         <h3>{t('challenges.detail.messages')}</h3>
-        {challenge.message && (
+        {(challenge.challengeNote || challenge.message) && (
           <div className="challenge-message-block from-challenger">
             <div className="challenge-message-sender">
               {challenge.challenger.wrestlerName} ({challenge.challenger.playerName})
             </div>
             <div className="challenge-message-text">
-              &ldquo;{challenge.message}&rdquo;
+              &ldquo;{challenge.challengeNote || challenge.message}&rdquo;
             </div>
           </div>
         )}
@@ -292,6 +292,31 @@ export default function ChallengeDetail() {
           </div>
         )}
       </div>
+
+      {challenge.opponents && challenge.opponents.length > 1 && (
+        <div className="challenge-detail-opponent-responses">
+          <h3>{t('challenges.detail.opponentResponses', 'Opponent Responses')}</h3>
+          <ul>
+            {challenge.opponents.map((op) => {
+              const pid = op.playerId;
+              const resp = pid ? challenge.responses?.[pid] : undefined;
+              const status = resp?.status || 'pending';
+              return (
+                <li key={pid || op.wrestlerName}>
+                  <strong>{op.wrestlerName}</strong>
+                  {' — '}
+                  <span className={`challenge-status-badge ${status}`}>
+                    {t(`challenges.status.${status}`)}
+                  </span>
+                  {resp?.declineReason && (
+                    <div className="challenge-decline-reason">&ldquo;{resp.declineReason}&rdquo;</div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
 
       <div className="challenge-detail-info">
         <div className="challenge-info-item">

--- a/frontend/src/components/challenges/ChallengeResponse.css
+++ b/frontend/src/components/challenges/ChallengeResponse.css
@@ -1,0 +1,163 @@
+.challenge-response {
+  max-width: 640px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+}
+
+.challenge-response-back {
+  display: inline-block;
+  color: var(--text-secondary, #888);
+  text-decoration: none;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.challenge-response-back:hover {
+  color: var(--text-primary, #fff);
+}
+
+.challenge-response-loading,
+.challenge-response-error {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-secondary, #888);
+}
+
+.challenge-response-error {
+  color: #e74c3c;
+  background: rgba(231, 76, 60, 0.1);
+  border-radius: 6px;
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+}
+
+.challenge-response-card {
+  background: var(--card-bg, #1f1f1f);
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.challenge-response-label {
+  color: var(--text-secondary, #888);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-right: 0.5rem;
+}
+
+.challenge-response-from {
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.challenge-response-player-name {
+  color: var(--text-secondary, #888);
+  font-weight: 400;
+}
+
+.challenge-response-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.challenge-response-opponents ul {
+  margin: 0.5rem 0 0 0;
+  padding-left: 1.25rem;
+}
+
+.challenge-response-note {
+  background: rgba(255, 255, 255, 0.05);
+  border-left: 3px solid var(--accent, #5c7cfa);
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  font-style: italic;
+  margin-top: 1rem;
+}
+
+.challenge-response-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.challenge-response-decline-form {
+  background: var(--card-bg, #1f1f1f);
+  padding: 1rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.challenge-response-decline-form label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.challenge-response-decline-form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  background: var(--input-bg, #2a2a2a);
+  border: 1px solid var(--border, #333);
+  border-radius: 4px;
+  color: var(--text-primary, #fff);
+  font-family: inherit;
+  resize: vertical;
+}
+
+.challenge-response-char-count {
+  text-align: right;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #888);
+}
+
+.challenge-response-success {
+  background: var(--card-bg, #1f1f1f);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.challenge-response-success h2 {
+  color: #2ecc71;
+  margin-bottom: 1rem;
+}
+
+.challenge-response-date {
+  font-size: 1.1rem;
+  color: var(--text-secondary, #888);
+  margin: 0.5rem 0 1.5rem;
+}
+
+.challenge-response-success-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.btn-view-match,
+.btn-back-challenges {
+  padding: 0.6rem 1.25rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: opacity 0.15s;
+}
+
+.btn-view-match {
+  background: var(--accent, #5c7cfa);
+  color: #fff;
+}
+
+.btn-back-challenges {
+  background: var(--card-bg-light, #2a2a2a);
+  color: var(--text-primary, #fff);
+}
+
+.btn-view-match:hover,
+.btn-back-challenges:hover {
+  opacity: 0.85;
+}

--- a/frontend/src/components/challenges/ChallengeResponse.tsx
+++ b/frontend/src/components/challenges/ChallengeResponse.tsx
@@ -1,0 +1,252 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { challengesApi } from '../../services/api/challenges.api';
+import type { ChallengeWithPlayers } from '../../types/challenge';
+import './ChallengeResponse.css';
+
+const MAX_REASON_LENGTH = 200;
+
+interface ScheduleResult {
+  matchId?: string;
+  scheduledEventId?: string;
+  matchDate?: string;
+  eventName?: string;
+  status?: string;
+}
+
+export default function ChallengeResponse() {
+  const { t } = useTranslation();
+  const { challengeId } = useParams<{ challengeId: string }>();
+  const navigate = useNavigate();
+
+  const [challenge, setChallenge] = useState<ChallengeWithPlayers | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showDeclineForm, setShowDeclineForm] = useState(false);
+  const [declineReason, setDeclineReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [scheduleResult, setScheduleResult] = useState<ScheduleResult | null>(null);
+
+  useEffect(() => {
+    if (!challengeId) return;
+    const controller = new AbortController();
+    challengesApi
+      .getById(challengeId, controller.signal)
+      .then((c) => setChallenge(c))
+      .catch((err) => {
+        if (err.name !== 'AbortError') setError(err.message || 'Failed to load challenge');
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [challengeId]);
+
+  const handleAccept = async () => {
+    if (!challengeId) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await challengesApi.respondV2(challengeId, 'accepted');
+      if (result.status === 'auto_scheduled' && result.matchId) {
+        setScheduleResult({
+          matchId: result.matchId,
+          scheduledEventId: result.scheduledEventId,
+          matchDate: result.matchDate,
+          eventName: result.eventName,
+          status: result.status,
+        });
+      } else {
+        // Not all opponents accepted yet — go back to MyChallenges
+        navigate('/challenges');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to accept challenge');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!challengeId) return;
+    if (!declineReason.trim()) {
+      setError('Please provide a reason for declining');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await challengesApi.respondV2(challengeId, 'declined', declineReason.trim());
+      navigate('/challenges');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to decline challenge');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="challenge-response">
+        <div className="challenge-response-loading">{t('common.loading')}</div>
+      </div>
+    );
+  }
+
+  if (!challenge) {
+    return (
+      <div className="challenge-response">
+        <Link to="/challenges" className="challenge-response-back">
+          &larr; {t('challenges.detail.backToBoard')}
+        </Link>
+        <div className="challenge-response-error">
+          {error || t('challenges.detail.notFound')}
+        </div>
+      </div>
+    );
+  }
+
+  if (scheduleResult) {
+    return (
+      <div className="challenge-response">
+        <div className="challenge-response-success">
+          <h2>{t('challenges.response.scheduledHeading', 'Challenge Accepted!')}</h2>
+          <p>
+            {scheduleResult.eventName
+              ? t('challenges.response.scheduledOnEvent', {
+                  eventName: scheduleResult.eventName,
+                  defaultValue: 'Your match has been scheduled as a Pre-Show match on {{eventName}}.',
+                })
+              : t('challenges.response.scheduledStandalone', 'Your match has been scheduled as a Pre-Show match.')}
+          </p>
+          {scheduleResult.matchDate && (
+            <p className="challenge-response-date">
+              {new Date(scheduleResult.matchDate).toLocaleDateString(undefined, {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </p>
+          )}
+          <div className="challenge-response-success-actions">
+            <Link to="/matches?status=scheduled" className="btn-view-match">
+              {t('challenges.response.viewMatch', 'View Match')}
+            </Link>
+            <Link to="/challenges" className="btn-back-challenges">
+              {t('challenges.detail.backToBoard')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="challenge-response">
+      <Link to="/challenges" className="challenge-response-back">
+        &larr; {t('challenges.detail.backToBoard')}
+      </Link>
+
+      <h2>{t('challenges.response.heading', 'Respond to Challenge')}</h2>
+
+      <div className="challenge-response-card">
+        <div className="challenge-response-from">
+          <span className="challenge-response-label">{t('challenges.detail.challenger')}:</span>
+          <strong>{challenge.challenger.wrestlerName}</strong>{' '}
+          <span className="challenge-response-player-name">({challenge.challenger.playerName})</span>
+        </div>
+
+        <div className="challenge-response-details">
+          <div>
+            <span className="challenge-response-label">{t('challenges.issue.matchType')}:</span>{' '}
+            {challenge.matchType}
+          </div>
+          {challenge.stipulation && (
+            <div>
+              <span className="challenge-response-label">{t('challenges.issue.stipulation')}:</span>{' '}
+              {challenge.stipulation}
+            </div>
+          )}
+        </div>
+
+        {challenge.opponents && challenge.opponents.length > 1 && (
+          <div className="challenge-response-opponents">
+            <span className="challenge-response-label">
+              {t('challenges.response.challengedOpponents', 'All challenged opponents')}:
+            </span>
+            <ul>
+              {challenge.opponents.map((o) => (
+                <li key={o.playerId || o.wrestlerName}>
+                  {o.wrestlerName} ({o.playerName})
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {(challenge.challengeNote || challenge.message) && (
+          <div className="challenge-response-note">
+            &ldquo;{challenge.challengeNote || challenge.message}&rdquo;
+          </div>
+        )}
+      </div>
+
+      {error && <div className="challenge-response-error">{error}</div>}
+
+      {!showDeclineForm ? (
+        <div className="challenge-response-actions">
+          <button
+            className="btn-accept"
+            disabled={submitting}
+            onClick={handleAccept}
+          >
+            {t('challenges.detail.accept')}
+          </button>
+          <button
+            className="btn-decline"
+            disabled={submitting}
+            onClick={() => setShowDeclineForm(true)}
+          >
+            {t('challenges.detail.decline')}
+          </button>
+        </div>
+      ) : (
+        <div className="challenge-response-decline-form">
+          <label>
+            {t('challenges.response.declineReasonLabel', 'Reason for declining')} *
+          </label>
+          <textarea
+            value={declineReason}
+            onChange={(e) =>
+              e.target.value.length <= MAX_REASON_LENGTH && setDeclineReason(e.target.value)
+            }
+            rows={3}
+            placeholder={t('challenges.response.declineReasonPlaceholder', 'Tell them why...')}
+            required
+          />
+          <div className="challenge-response-char-count">
+            {declineReason.length}/{MAX_REASON_LENGTH}
+          </div>
+          <div className="challenge-response-actions">
+            <button
+              className="btn-decline"
+              disabled={submitting || !declineReason.trim()}
+              onClick={handleDecline}
+            >
+              {t('challenges.response.submitDecline', 'Submit Decline')}
+            </button>
+            <button
+              className="btn-cancel-form"
+              disabled={submitting}
+              onClick={() => {
+                setShowDeclineForm(false);
+                setDeclineReason('');
+              }}
+            >
+              {t('common.cancel')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/challenges/IssueChallenge.tsx
+++ b/frontend/src/components/challenges/IssueChallenge.tsx
@@ -7,15 +7,16 @@ import type { TagTeam } from '../../types/tagTeam';
 import { getInitial } from './challengeUtils';
 import './IssueChallenge.css';
 
-const MAX_MESSAGE_LENGTH = 500;
+const MAX_CHALLENGE_NOTE_LENGTH = 200;
+const MAX_OPPONENTS = 5;
 
 export default function IssueChallenge() {
   const { t } = useTranslation();
-  const [opponentId, setOpponentId] = useState('');
+  const [opponentIds, setOpponentIds] = useState<string[]>([]);
   const [matchType, setMatchType] = useState('');
   const [stipulation, setStipulation] = useState('');
   const [isChampionship, setIsChampionship] = useState(false);
-  const [message, setMessage] = useState('');
+  const [challengeNote, setChallengeNote] = useState('');
   const [showPreview, setShowPreview] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -57,20 +58,30 @@ export default function IssueChallenge() {
   }, []);
 
   const currentPlayer = players.find((p) => p.playerId === currentPlayerId);
-  const opponent = players.find((p) => p.playerId === opponentId);
+  const selectedOpponents = players.filter((p) => opponentIds.includes(p.playerId));
   // Only show players with linked accounts (userId) who can actually respond to challenges
   const availableOpponents = players.filter((p) => p.playerId !== currentPlayerId && p.userId);
 
   const selectedTagTeam = tagTeams.find((tt) => tt.tagTeamId === selectedTagTeamId);
 
   const isFormValid = challengeMode === 'tag_team'
-    ? selectedTagTeamId && matchType && message.length <= MAX_MESSAGE_LENGTH
-    : opponentId && matchType && message.length <= MAX_MESSAGE_LENGTH;
+    ? !!selectedTagTeamId && !!matchType && challengeNote.length <= MAX_CHALLENGE_NOTE_LENGTH
+    : opponentIds.length > 0 && opponentIds.length <= MAX_OPPONENTS && !!matchType && challengeNote.length <= MAX_CHALLENGE_NOTE_LENGTH;
 
-  const handleMessageChange = (value: string) => {
-    if (value.length <= MAX_MESSAGE_LENGTH + 50) {
-      setMessage(value);
+  const handleChallengeNoteChange = (value: string) => {
+    if (value.length <= MAX_CHALLENGE_NOTE_LENGTH + 20) {
+      setChallengeNote(value);
     }
+  };
+
+  const toggleOpponent = (playerId: string) => {
+    setOpponentIds((prev) => {
+      if (prev.includes(playerId)) {
+        return prev.filter((id) => id !== playerId);
+      }
+      if (prev.length >= MAX_OPPONENTS) return prev;
+      return [...prev, playerId];
+    });
   };
 
   const handleSubmit = async () => {
@@ -80,20 +91,19 @@ export default function IssueChallenge() {
     try {
       if (challengeMode === 'tag_team') {
         await challengesApi.create({
-          challengedId: '',
           challengeMode: 'tag_team',
           challengedTagTeamId: selectedTagTeamId,
           matchType,
           stipulation: stipulation || undefined,
-          message: message || undefined,
+          challengeNote: challengeNote || undefined,
         });
       } else {
         await challengesApi.create({
-          challengedId: opponentId,
+          opponentIds,
           matchType,
           stipulation: stipulation || undefined,
           championshipId: isChampionship ? 'championship-match' : undefined,
-          message: message || undefined,
+          challengeNote: challengeNote || undefined,
         });
       }
       setSubmitted(true);
@@ -105,11 +115,11 @@ export default function IssueChallenge() {
   };
 
   const handleReset = () => {
-    setOpponentId('');
+    setOpponentIds([]);
     setMatchType('');
     setStipulation('');
     setIsChampionship(false);
-    setMessage('');
+    setChallengeNote('');
     setShowPreview(false);
     setSubmitted(false);
     setError(null);
@@ -152,7 +162,7 @@ export default function IssueChallenge() {
 
   const canShowPreview = challengeMode === 'tag_team'
     ? isFormValid && playerTagTeam && selectedTagTeam
-    : isFormValid && opponent && currentPlayer;
+    : isFormValid && selectedOpponents.length > 0 && currentPlayer;
 
   return (
     <div className="issue-challenge">
@@ -189,7 +199,7 @@ export default function IssueChallenge() {
                   name="challengeMode"
                   value="tag_team"
                   checked={challengeMode === 'tag_team'}
-                  onChange={() => { setChallengeMode('tag_team'); setOpponentId(''); }}
+                  onChange={() => { setChallengeMode('tag_team'); setOpponentIds([]); }}
                 />
                 {t('challenges.issue.tagTeamChallenge')}
               </label>
@@ -218,15 +228,29 @@ export default function IssueChallenge() {
           </div>
         ) : (
           <div className="issue-form-group">
-            <label>{t('challenges.issue.selectOpponent')}</label>
-            <select value={opponentId} onChange={(e) => setOpponentId(e.target.value)}>
-              <option value="">{t('challenges.issue.selectOpponentPlaceholder')}</option>
-              {availableOpponents.map((p) => (
-                <option key={p.playerId} value={p.playerId}>
-                  {p.currentWrestler} ({p.name})
-                </option>
-              ))}
-            </select>
+            <label>
+              {t('challenges.issue.selectOpponent')} ({opponentIds.length}/{MAX_OPPONENTS})
+            </label>
+            <div className="issue-opponent-multiselect" role="group">
+              {availableOpponents.map((p) => {
+                const checked = opponentIds.includes(p.playerId);
+                const disabled = !checked && opponentIds.length >= MAX_OPPONENTS;
+                return (
+                  <label
+                    key={p.playerId}
+                    className={`issue-opponent-option${checked ? ' selected' : ''}${disabled ? ' disabled' : ''}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={disabled}
+                      onChange={() => toggleOpponent(p.playerId)}
+                    />
+                    <span>{p.currentWrestler} ({p.name})</span>
+                  </label>
+                );
+              })}
+            </div>
           </div>
         )}
 
@@ -266,17 +290,17 @@ export default function IssueChallenge() {
         </div>
 
         <div className="issue-form-group">
-          <label>{t('challenges.issue.message')}</label>
+          <label>{t('challenges.issue.challengeNote', 'Optional note')}</label>
           <textarea
-            value={message}
-            onChange={(e) => handleMessageChange(e.target.value)}
-            placeholder={t('challenges.issue.messagePlaceholder')}
-            rows={4}
+            value={challengeNote}
+            onChange={(e) => handleChallengeNoteChange(e.target.value)}
+            placeholder={t('challenges.issue.challengeNotePlaceholder', 'Add a short note (optional)')}
+            rows={3}
           />
           <div
-            className={`issue-char-count ${message.length > MAX_MESSAGE_LENGTH ? 'over-limit' : ''}`}
+            className={`issue-char-count ${challengeNote.length > MAX_CHALLENGE_NOTE_LENGTH ? 'over-limit' : ''}`}
           >
-            {message.length}/{MAX_MESSAGE_LENGTH}
+            {challengeNote.length}/{MAX_CHALLENGE_NOTE_LENGTH}
           </div>
         </div>
 
@@ -330,15 +354,15 @@ export default function IssueChallenge() {
                     </span>
                   )}
                 </div>
-                {message && (
+                {challengeNote && (
                   <div className="issue-preview-message">
-                    &ldquo;{message}&rdquo;
+                    &ldquo;{challengeNote}&rdquo;
                   </div>
                 )}
               </div>
             )}
 
-            {showPreview && challengeMode === 'singles' && currentPlayer && opponent && (
+            {showPreview && challengeMode === 'singles' && currentPlayer && selectedOpponents.length > 0 && (
               <div className="issue-preview">
                 <h3>{t('challenges.issue.preview')}</h3>
                 <div className="issue-preview-versus">
@@ -352,12 +376,16 @@ export default function IssueChallenge() {
                     <div className="issue-preview-name">{currentPlayer.name}</div>
                   </div>
                   <span className="issue-preview-vs">{t('common.vs').toUpperCase()}</span>
-                  <div className="issue-preview-player">
-                    <div className="issue-preview-avatar">
-                      {getInitial(opponent.currentWrestler)}
-                    </div>
-                    <div className="issue-preview-wrestler">{opponent.currentWrestler}</div>
-                    <div className="issue-preview-name">{opponent.name}</div>
+                  <div className="issue-preview-opponents">
+                    {selectedOpponents.map((op) => (
+                      <div key={op.playerId} className="issue-preview-player">
+                        <div className="issue-preview-avatar">
+                          {getInitial(op.currentWrestler)}
+                        </div>
+                        <div className="issue-preview-wrestler">{op.currentWrestler}</div>
+                        <div className="issue-preview-name">{op.name}</div>
+                      </div>
+                    ))}
                   </div>
                 </div>
                 <div className="issue-preview-details">
@@ -371,9 +399,9 @@ export default function IssueChallenge() {
                     </span>
                   )}
                 </div>
-                {message && (
+                {challengeNote && (
                   <div className="issue-preview-message">
-                    &ldquo;{message}&rdquo;
+                    &ldquo;{challengeNote}&rdquo;
                   </div>
                 )}
               </div>

--- a/frontend/src/components/challenges/MyChallenges.tsx
+++ b/frontend/src/components/challenges/MyChallenges.tsx
@@ -173,9 +173,42 @@ export default function MyChallenges() {
           </div>
         </div>
 
-        {challenge.message && (
+        {(challenge.challengeNote || challenge.message) && (
           <div className="my-challenge-message">
-            &ldquo;{challenge.message}&rdquo;
+            &ldquo;{challenge.challengeNote || challenge.message}&rdquo;
+          </div>
+        )}
+
+        {challenge.opponents && challenge.opponents.length > 1 && challenge.responses && (
+          <div className="my-challenge-responses">
+            <strong>{t('challenges.my.opponentResponses', 'Opponent Responses')}:</strong>
+            <ul>
+              {challenge.opponents.map((op) => {
+                const pid = op.playerId;
+                const resp = pid ? challenge.responses?.[pid] : undefined;
+                const status = resp?.status || 'pending';
+                return (
+                  <li key={pid || op.wrestlerName}>
+                    <span>{op.wrestlerName}</span>{' '}
+                    <span className={`challenge-status-badge ${status}`}>{t(`challenges.status.${status}`)}</span>
+                    {resp?.declineReason && (
+                      <div className="my-challenge-decline-reason">&ldquo;{resp.declineReason}&rdquo;</div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        {challenge.status === 'auto_scheduled' && challenge.matchId && (
+          <div className="my-challenge-scheduled">
+            <span className="challenge-status-badge auto_scheduled">
+              {t('challenges.status.auto_scheduled', 'Scheduled ✓')}
+            </span>
+            <Link to={`/matches?status=scheduled`} className="my-challenge-scheduled-link">
+              {t('challenges.my.viewScheduledMatch', 'View match')} &rarr;
+            </Link>
           </div>
         )}
 

--- a/frontend/src/components/challenges/__tests__/IssueChallenge.test.tsx
+++ b/frontend/src/components/challenges/__tests__/IssueChallenge.test.tsx
@@ -36,6 +36,8 @@ vi.mock('react-i18next', () => ({
         'challenges.issue.championshipMatch': 'Championship Match',
         'challenges.issue.message': 'Message',
         'challenges.issue.messagePlaceholder': 'Say something...',
+        'challenges.issue.challengeNote': 'Optional note',
+        'challenges.issue.challengeNotePlaceholder': 'Add a short note (optional)',
         'challenges.issue.showPreview': 'Show Preview',
         'challenges.issue.hidePreview': 'Hide Preview',
         'challenges.issue.preview': 'Preview',
@@ -103,17 +105,17 @@ describe('IssueChallenge', () => {
     ]);
   });
 
-  it('renders the form with opponent, match type, stipulation, and message fields', async () => {
+  it('renders the form with opponent, match type, stipulation, and note fields', async () => {
     renderIssue();
 
     await waitFor(() => {
       expect(screen.getByText('Issue a Challenge')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Select Opponent')).toBeInTheDocument();
+    expect(screen.getByText(/Select Opponent/)).toBeInTheDocument();
     expect(screen.getByText('Match Type')).toBeInTheDocument();
     expect(screen.getByText('Stipulation')).toBeInTheDocument();
-    expect(screen.getByText('Message')).toBeInTheDocument();
+    expect(screen.getByText('Optional note')).toBeInTheDocument();
     expect(screen.getByText('Submit Challenge')).toBeInTheDocument();
   });
 
@@ -124,17 +126,10 @@ describe('IssueChallenge', () => {
       expect(screen.getByText('Issue a Challenge')).toBeInTheDocument();
     });
 
-    // The opponent dropdown should contain "The Rock (Jane)" but NOT self or unlinked
-    const opponentSelect = screen.getAllByRole('combobox')[0]!;
-    const options = Array.from(opponentSelect.querySelectorAll('option'));
-    const optionTexts = options.map((o) => o.textContent);
-
-    // Should have placeholder + Jane (linked, not self)
-    expect(optionTexts).toContain('The Rock (Jane)');
-    // Should NOT have self
-    expect(optionTexts).not.toContain('Stone Cold (John)');
-    // Should NOT have unlinked player
-    expect(optionTexts).not.toContain('Unlinked Guy (NoLink)');
+    // The opponent multi-select should contain "The Rock (Jane)" but NOT self or unlinked
+    expect(screen.getByText('The Rock (Jane)')).toBeInTheDocument();
+    expect(screen.queryByText('Stone Cold (John)')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unlinked Guy (NoLink)')).not.toBeInTheDocument();
   });
 
   it('populates match type and stipulation dropdowns from API', async () => {
@@ -145,9 +140,10 @@ describe('IssueChallenge', () => {
     });
 
     // Wait for API-driven dropdowns to populate
+    // Now selects are [matchType, stipulation] — opponents is a checkbox group
     await waitFor(() => {
       const selects = screen.getAllByRole('combobox');
-      const matchTypeSelect = selects[1]!;
+      const matchTypeSelect = selects[0]!;
       const matchOptions = Array.from(matchTypeSelect.querySelectorAll('option')).map((o) => o.textContent);
       expect(matchOptions).toContain('Singles');
       expect(matchOptions).toContain('Tag Team');
@@ -155,14 +151,14 @@ describe('IssueChallenge', () => {
     });
 
     const selects = screen.getAllByRole('combobox');
-    const stipSelect = selects[2]!;
+    const stipSelect = selects[1]!;
     const stipOptions = Array.from(stipSelect.querySelectorAll('option')).map((o) => o.textContent);
     expect(stipOptions).toContain('None');
     expect(stipOptions).toContain('Steel Cage');
     expect(stipOptions).toContain('Ladder');
   });
 
-  it('enforces 500 character message limit with counter display', async () => {
+  it('enforces 200 character challenge note limit with counter display', async () => {
     const user = userEvent.setup();
     renderIssue();
 
@@ -170,14 +166,14 @@ describe('IssueChallenge', () => {
       expect(screen.getByText('Issue a Challenge')).toBeInTheDocument();
     });
 
-    const textarea = screen.getByPlaceholderText('Say something...');
-    const longText = 'A'.repeat(500);
+    const textarea = screen.getByPlaceholderText('Add a short note (optional)');
+    const longText = 'A'.repeat(200);
     await user.type(textarea, longText);
 
-    expect(screen.getByText('500/500')).toBeInTheDocument();
+    expect(screen.getByText('200/200')).toBeInTheDocument();
   });
 
-  it('shows preview and submits successfully', async () => {
+  it('submits successfully with opponentIds[]', async () => {
     const user = userEvent.setup();
     mockCreateChallenge.mockResolvedValue({});
 
@@ -187,29 +183,24 @@ describe('IssueChallenge', () => {
       expect(screen.getByText('Issue a Challenge')).toBeInTheDocument();
     });
 
-    // Fill form
+    // Check opponent p-2
+    const opponentCheckbox = screen.getByLabelText('The Rock (Jane)');
+    await user.click(opponentCheckbox);
+
+    // Select match type
     const selects = screen.getAllByRole('combobox');
-    await user.selectOptions(selects[0]!, 'p-2');
-    await user.selectOptions(selects[1]!, 'Singles');
-
-    // Preview toggle should appear when form is valid
-    await waitFor(() => {
-      expect(screen.getByText('Show Preview')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText('Show Preview'));
-    expect(screen.getByText('Preview')).toBeInTheDocument();
+    await user.selectOptions(selects[0]!, 'Singles');
 
     // Submit
     await user.click(screen.getByText('Submit Challenge'));
 
     await waitFor(() => {
       expect(mockCreateChallenge).toHaveBeenCalledWith({
-        challengedId: 'p-2',
+        opponentIds: ['p-2'],
         matchType: 'Singles',
         stipulation: undefined,
         championshipId: undefined,
-        message: undefined,
+        challengeNote: undefined,
       });
     });
 

--- a/frontend/src/services/api/challenges.api.ts
+++ b/frontend/src/services/api/challenges.api.ts
@@ -33,6 +33,17 @@ export const challengesApi = {
     });
   },
 
+  respondV2: async (
+    challengeId: string,
+    response: 'accepted' | 'declined',
+    declineReason?: string,
+  ): Promise<ChallengeWithPlayers & { matchId?: string; scheduledEventId?: string; matchDate?: string; eventName?: string }> => {
+    return fetchWithAuth(`${API_BASE_URL}/challenges/${challengeId}/respond`, {
+      method: 'POST',
+      body: JSON.stringify({ response, declineReason }),
+    });
+  },
+
   cancel: async (challengeId: string): Promise<ChallengeWithPlayers> => {
     return fetchWithAuth(`${API_BASE_URL}/challenges/${challengeId}/cancel`, {
       method: 'POST',

--- a/frontend/src/types/challenge.ts
+++ b/frontend/src/types/challenge.ts
@@ -2,23 +2,35 @@ export type ChallengeStatus =
   | 'pending'
   | 'accepted'
   | 'declined'
+  | 'partially_declined'
   | 'countered'
   | 'scheduled'
+  | 'auto_scheduled'
   | 'expired'
   | 'cancelled';
+
+export interface ChallengeResponseRecord {
+  status: 'pending' | 'accepted' | 'declined';
+  declineReason?: string;
+}
 
 export interface Challenge {
   challengeId: string;
   challengerId: string;
-  challengedId: string;
+  challengedId: string; // Primary opponent (for GSI). Prefer `opponentIds` for multi-opponent challenges.
+  opponentIds?: string[];
+  responses?: Record<string, ChallengeResponseRecord>;
   matchType: string;
   stipulation?: string;
   championshipId?: string;
+  challengeNote?: string;
+  /** @deprecated Use `challengeNote` */
   message?: string;
   status: ChallengeStatus;
   responseMessage?: string;
   counteredChallengeId?: string;
   matchId?: string;
+  scheduledEventId?: string;
   challengeMode?: 'singles' | 'tag_team';
   challengerTagTeamId?: string;
   challengedTagTeamId?: string;
@@ -44,15 +56,19 @@ export interface TagTeamChallengeInfo {
 export interface ChallengeWithPlayers extends Challenge {
   challenger: ChallengePlayerInfo;
   challenged: ChallengePlayerInfo;
+  opponents?: ChallengePlayerInfo[];
   challengerTagTeam?: TagTeamChallengeInfo;
   challengedTagTeam?: TagTeamChallengeInfo;
 }
 
 export interface CreateChallengeInput {
-  challengedId: string;
+  challengedId?: string; // Legacy single-opponent field
+  opponentIds?: string[];
   matchType: string;
   stipulation?: string;
   championshipId?: string;
+  challengeNote?: string;
+  /** @deprecated Use `challengeNote` */
   message?: string;
   challengeMode?: 'singles' | 'tag_team';
   challengedTagTeamId?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -324,7 +324,7 @@ export interface Video {
   updatedAt: string;
 }
 
-export type NotificationType = 'promo_mention' | 'challenge_received' | 'match_scheduled' | 'announcement' | 'stable_invitation' | 'tag_team_invitation' | 'transfer_reviewed';
+export type NotificationType = 'promo_mention' | 'challenge_received' | 'challenge_accepted' | 'challenge_declined' | 'challenge_scheduled' | 'match_scheduled' | 'announcement' | 'stable_invitation' | 'tag_team_invitation' | 'transfer_reviewed';
 
 export interface AppNotification {
   notificationId: string;


### PR DESCRIPTION
## Summary
Implements Feature 2 from `plans/plan-storyline-challenges-events-wizard.md` — decouples challenges from promos and adds multi-opponent support with per-opponent accept/decline tracking and automatic match scheduling.

- **Multi-opponent challenges** — `opponentIds[]` (1–5) replaces the single `challengedId`; `message` → `challengeNote`.
- **Per-opponent responses** — new `responses` map on each challenge stores each opponent's status + optional `declineReason`.
- **Required decline reason** — `POST /challenges/:id/respond` now requires `declineReason` when declining.
- **Auto-schedule on full acceptance** — when all opponents accept, a pre-show match is created on the next upcoming event (or next Monday if accepted on Sunday) and all participants get a `challenge_scheduled` notification linking to the match.
- **New notification types** — `challenge_accepted`, `challenge_declined`, `challenge_scheduled`, routed by NotificationBell to the right pages.
- **New `/challenges/:id/respond` page** — players click a `challenge_received` notification to accept (one-tap) or decline with a required reason.
- **MyChallenges / ChallengeDetail** now show per-opponent status, decline reasons, and a "Scheduled ✓" badge once auto-scheduled.
- **IssueChallenge** — single-opponent select replaced with multi-select checkboxes; promo-style preview removed in favor of an optional 200-char note.

Backward compatibility: legacy `challengedId` + `message` request fields are still accepted; `challengedId` is preserved on records for existing GSI queries.

## Test plan
- [x] `cd backend && npx vitest run functions/challenges` — 67 passing
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — no new errors
- [ ] Manual: challenge 2 opponents → one declines with reason → challenger sees decline reason
- [ ] Manual: challenge 1 opponent → opponent accepts → match auto-scheduled on next event, all parties notified

🤖 Generated with [Claude Code](https://claude.com/claude-code)