### PR TITLE
feat(announcements): increase match limit from 5 to 8

### DIFF
--- a/frontend/src/components/admin/AnnouncementWizard.tsx
+++ b/frontend/src/components/admin/AnnouncementWizard.tsx
@@ -450,7 +450,7 @@ export default function AnnouncementWizard({ onClose, onPublished }: Announcemen
   }
 
   function addMatch() {
-    if (matches.length >= 5) return;
+    if (matches.length >= 8) return;
     setMatches((prev) => [...prev, newMatch()]);
   }
 
@@ -688,8 +688,8 @@ export default function AnnouncementWizard({ onClose, onPublished }: Announcemen
             {step === 3 && (
               <div className="wizard-body">
                 <div className="wizard-matches-header">
-                  <h3 className="wizard-section-title">Matches ({matches.length}/5)</h3>
-                  {matches.length < 5 && (
+                  <h3 className="wizard-section-title">Matches ({matches.length}/8)</h3>
+                  {matches.length < 8 && (
                     <button className="wizard-btn-add" onClick={addMatch}>
                       + Add Match
                     </button>


### PR DESCRIPTION
## Summary
- Increases the announcement wizard match limit from 5 to 8 to allow more matches per card

## Test plan
- [ ] Open the Announcement Wizard
- [ ] Verify you can add up to 8 matches
- [ ] Verify the "Add Match" button disappears at 8 matches
- [ ] Verify the counter shows `(n/8)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)