### PR TITLE
fix(dashboard): correct champion reign day count on hero banner

### DIFF
--- a/backend/functions/dashboard/__tests__/getDashboard.test.ts
+++ b/backend/functions/dashboard/__tests__/getDashboard.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../../lib/dynamodb', () => ({
   },
   TableNames: {
     CHAMPIONSHIPS: 'Championships',
+    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
     PLAYERS: 'Players',
     SEASONS: 'Seasons',
     MATCHES: 'Matches',
@@ -102,6 +103,87 @@ describe('getDashboard', () => {
     expect(body.currentChampions).toHaveLength(1);
     expect(body.currentChampions[0].championshipName).toBe('World Title');
     expect(body.currentChampions[0].championName).toBe('Stone Cold');
+  });
+
+  it('reads champion wonDate from ChampionshipHistory (open reign), not from Championships.updatedAt', async () => {
+    // Championship.updatedAt was bumped by a recent image upload and is NOT
+    // the real won date. The real won date lives on the open reign row in
+    // ChampionshipHistory (the row with no lostDate).
+    const realWonDate = '2025-11-01T12:00:00Z';
+    const bogusUpdatedAt = '2026-04-10T09:00:00Z';
+
+    mockScanAll
+      .mockReset()
+      .mockResolvedValueOnce([
+        {
+          championshipId: 'c1',
+          name: 'World Title',
+          isActive: true,
+          currentChampion: 'p1',
+          updatedAt: bogusUpdatedAt,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
+      ])
+      .mockResolvedValueOnce([]) // seasons
+      .mockResolvedValueOnce([]) // matches
+      .mockResolvedValueOnce([]); // stipulations
+
+    mockQuery.mockReset().mockImplementation((params: { TableName: string }) => {
+      if (params.TableName === 'ChampionshipHistory') {
+        return Promise.resolve({
+          Items: [
+            {
+              championshipId: 'c1',
+              wonDate: realWonDate,
+              champion: 'p1',
+              defenses: 3,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ Items: [] });
+    });
+    mockQueryAll.mockReset().mockResolvedValue([]);
+
+    const result = await getDashboard({} as never, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.currentChampions).toHaveLength(1);
+    expect(body.currentChampions[0].wonDate).toBe(realWonDate);
+    expect(body.currentChampions[0].wonDate).not.toBe(bogusUpdatedAt);
+    expect(body.currentChampions[0].defenses).toBe(3);
+  });
+
+  it('falls back to undefined wonDate when ChampionshipHistory has no open reign row', async () => {
+    mockScanAll
+      .mockReset()
+      .mockResolvedValueOnce([
+        {
+          championshipId: 'c1',
+          name: 'World Title',
+          isActive: true,
+          currentChampion: 'p1',
+          updatedAt: '2026-04-10T09:00:00Z',
+        },
+      ])
+      .mockResolvedValueOnce([
+        { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockQuery.mockReset().mockResolvedValue({ Items: [] });
+    mockQueryAll.mockReset().mockResolvedValue([]);
+
+    const result = await getDashboard({} as never, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.currentChampions).toHaveLength(1);
+    expect(body.currentChampions[0].wonDate).toBeUndefined();
   });
 
   it('limits upcoming events to 3', async () => {

--- a/backend/functions/dashboard/getDashboard.ts
+++ b/backend/functions/dashboard/getDashboard.ts
@@ -121,8 +121,18 @@ export const handler: APIGatewayProxyHandler = async () => {
       if (id && s.name) stipulationMap.set(id, s.name as string);
     }
 
-    // Current champions: active championships with currentChampion
-    const currentChampions: DashboardChampion[] = [];
+    // Current champions: active championships with currentChampion.
+    // wonDate is read from the open reign in ChampionshipHistory (the row
+    // where lostDate is absent), NOT from Championships.updatedAt — that
+    // field bumps on any championship edit (e.g. image upload) and is not
+    // a reliable source of reign length.
+    interface ChampionCandidate {
+      championship: Record<string, unknown>;
+      playerIds: string[];
+      names: string[];
+      imageUrl?: string;
+    }
+    const championCandidates: ChampionCandidate[] = [];
     for (const c of championships as Record<string, unknown>[]) {
       if (c.isActive === false) continue;
       const champ = c.currentChampion;
@@ -138,17 +148,43 @@ export const handler: APIGatewayProxyHandler = async () => {
         }
       }
       if (names.length > 0) {
-        currentChampions.push({
-          championshipId: c.championshipId as string,
-          championshipName: c.name as string,
-          championName: names.join(' & '),
-          championImageUrl: imageUrl,
-          playerId: (playerIds[0] as string) ?? '',
-          wonDate: c.updatedAt as string,
-          defenses: c.defenses as number | undefined,
-        });
+        championCandidates.push({ championship: c, playerIds, names, imageUrl });
       }
     }
+
+    const currentReigns = await Promise.all(
+      championCandidates.map((cand) =>
+        dynamoDb.query({
+          TableName: TableNames.CHAMPIONSHIP_HISTORY,
+          KeyConditionExpression: 'championshipId = :cid',
+          FilterExpression: 'attribute_not_exists(lostDate)',
+          ExpressionAttributeValues: {
+            ':cid': cand.championship.championshipId as string,
+          },
+          ScanIndexForward: false,
+          Limit: 1,
+        })
+      )
+    );
+
+    const currentChampions: DashboardChampion[] = championCandidates.map(
+      (cand, i) => {
+        const reign = currentReigns[i]?.Items?.[0] as
+          | Record<string, unknown>
+          | undefined;
+        return {
+          championshipId: cand.championship.championshipId as string,
+          championshipName: cand.championship.name as string,
+          championName: cand.names.join(' & '),
+          championImageUrl: cand.imageUrl,
+          playerId: (cand.playerIds[0] as string) ?? '',
+          wonDate: (reign?.wonDate as string | undefined) ?? undefined,
+          defenses:
+            (reign?.defenses as number | undefined) ??
+            (cand.championship.defenses as number | undefined),
+        };
+      }
+    );
 
     // Upcoming events (already limited to 3 by query)
     const upcomingEvents: DashboardEvent[] = ((upcomingEventsResult.Items || []) as Record<


### PR DESCRIPTION
## Summary
- The dashboard hero banner's day-reign counter was wrong because the backend was returning `Championships.updatedAt` as `wonDate`. That field gets bumped on any championship edit (image upload, rename, etc.), so the reign length shown on the hero would reset to 0 whenever an admin touched the championship record.
- Fixed by querying `ChampionshipHistory` for the open reign row (the row with `attribute_not_exists(lostDate)`) per active championship and using its real `wonDate`. Defenses are also pulled from the history row for consistency with how `recordResult.ts` tracks them.
- The frontend already computes `reignDays = floor((now - wonDate) / 86400000)` client-side, so no frontend change is needed.

## Test plan
- [x] `npx tsc --project tsconfig.json --noEmit` clean
- [x] `vitest run functions/dashboard/__tests__/getDashboard.test.ts` — 9/9 passing (added: `wonDate` comes from history not `updatedAt`, defenses pulled from history row, graceful fallback when no open reign row exists)
- [ ] Manual: confirm the hero banner day count on the deployed dashboard matches the value on the Championships page history table

🤖 Generated with [Claude Code](https://claude.com/claude-code)