### PR TITLE
fix(promos): require targetPromoId on response promos (#284)

### DIFF
--- a/backend/functions/promos/__tests__/createPromo.test.ts
+++ b/backend/functions/promos/__tests__/createPromo.test.ts
@@ -180,6 +180,40 @@ describe('createPromo', () => {
     expect(body(result).message).toBe('Content must be at least 50 characters');
   });
 
+  it('returns 400 when a response promo is submitted without targetPromoId', async () => {
+    const event = withAuth(
+      makeEvent({ body: JSON.stringify({ promoType: 'response', content: VALID_CONTENT }) }),
+      'Wrestler',
+    );
+    const result = await createPromo(event, ctx, cb);
+    expect(result!.statusCode).toBe(400);
+    expect(body(result).message).toBe(
+      'Response promos must reference an existing promo (targetPromoId)'
+    );
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('accepts a response promo when targetPromoId is provided', async () => {
+    mockQuery.mockResolvedValue({
+      Items: [{ playerId: 'player-1', userId: 'user-sub-1', name: 'Test Player' }],
+    });
+    mockPut.mockResolvedValue({});
+
+    const event = withAuth(
+      makeEvent({
+        body: JSON.stringify({
+          promoType: 'response',
+          content: VALID_CONTENT,
+          targetPromoId: 'parent-promo-id',
+        }),
+      }),
+      'Wrestler',
+    );
+    const result = await createPromo(event, ctx, cb);
+    expect(result!.statusCode).toBe(201);
+    expect(body(result).targetPromoId).toBe('parent-promo-id');
+  });
+
   it('returns 400 when no player profile is linked to the user', async () => {
     mockQuery.mockResolvedValue({ Items: [] });
     const event = withAuth(
@@ -197,8 +231,11 @@ describe('createPromo', () => {
       vi.clearAllMocks();
       mockQuery.mockResolvedValue({ Items: [{ playerId: 'p1', userId: 'user-sub-1' }] });
       mockPut.mockResolvedValue({});
+      const payload: Record<string, string> = { promoType, content: VALID_CONTENT };
+      // Response promos require a target promo reference.
+      if (promoType === 'response') payload.targetPromoId = 'parent-promo-id';
       const event = withAuth(
-        makeEvent({ body: JSON.stringify({ promoType, content: VALID_CONTENT }) }), 'Wrestler',
+        makeEvent({ body: JSON.stringify(payload) }), 'Wrestler',
       );
       const result = await createPromo(event, ctx, cb);
       expect(result!.statusCode).toBe(201);

--- a/backend/functions/promos/__tests__/getPromos.test.ts
+++ b/backend/functions/promos/__tests__/getPromos.test.ts
@@ -195,6 +195,24 @@ describe('getPromos', () => {
     expect(parent.responseCount).toBe(1);
   });
 
+  it('excludes orphan response promos (promoType=response with no targetPromoId) when excludeResponses=true', async () => {
+    mockScanAll.mockResolvedValue([
+      { promoId: 'p1', playerId: 'pl1', promoType: 'open-mic', isHidden: false, createdAt: '2024-01-01T00:00:00Z' },
+      { promoId: 'orphan', playerId: 'pl1', promoType: 'response', isHidden: false, createdAt: '2024-01-03T00:00:00Z' },
+    ]);
+    mockGet.mockResolvedValue({
+      Item: { playerId: 'pl1', name: 'John', currentWrestler: 'The Rock' },
+    });
+
+    const event = makeEvent({ queryStringParameters: { excludeResponses: 'true' } });
+    const result = await getPromos(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const data = body(result);
+    expect(data).toHaveLength(1);
+    expect(data.find((p: any) => p.promoId === 'orphan')).toBeUndefined();
+  });
+
   it('includes response promos by default (no excludeResponses param)', async () => {
     mockScanAll.mockResolvedValue([
       { promoId: 'p1', playerId: 'pl1', promoType: 'open-mic', isHidden: false, createdAt: '2024-01-01T00:00:00Z' },

--- a/backend/functions/promos/createPromo.ts
+++ b/backend/functions/promos/createPromo.ts
@@ -41,6 +41,9 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     if (content.length > 2000) {
       return badRequest('Content must be at most 2000 characters');
     }
+    if (promoType === 'response' && !targetPromoId) {
+      return badRequest('Response promos must reference an existing promo (targetPromoId)');
+    }
 
     // Find the player via user sub
     const playerResult = await dynamoDb.query({

--- a/backend/functions/promos/getPromos.ts
+++ b/backend/functions/promos/getPromos.ts
@@ -63,7 +63,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     // Enrich with player context
     const enriched = promos
-      .filter((p) => (includeHidden === 'true' || !(p.isHidden as boolean)) && !(excludeResponses === 'true' && p.targetPromoId))
+      .filter((p) => (includeHidden === 'true' || !(p.isHidden as boolean)) && !(excludeResponses === 'true' && (p.targetPromoId || p.promoType === 'response')))
       .map((p) => {
         const author = playerMap[p.playerId as string];
         const target = p.targetPlayerId ? playerMap[p.targetPlayerId as string] : undefined;

--- a/frontend/src/components/promos/PromoEditor.css
+++ b/frontend/src/components/promos/PromoEditor.css
@@ -66,6 +66,19 @@
   font-size: 0.8rem;
 }
 
+.form-required {
+  color: #ef4444;
+  font-weight: 700;
+  margin-left: 4px;
+}
+
+.form-hint {
+  color: #aaa;
+  font-size: 0.85rem;
+  margin: 6px 0 0;
+  font-style: italic;
+}
+
 /* Type Selector Grid */
 .promo-type-grid {
   display: grid;

--- a/frontend/src/components/promos/PromoEditor.tsx
+++ b/frontend/src/components/promos/PromoEditor.tsx
@@ -195,7 +195,9 @@ export default function PromoEditor() {
 
   const contentLength = content.length;
   const isContentValid = contentLength >= MIN_CONTENT && contentLength <= MAX_CONTENT;
-  const canSubmit = isContentValid && promoType && !submitting;
+  const needsTargetPromo = promoType === 'response';
+  const hasTargetPromo = !!targetPromoId;
+  const canSubmit = isContentValid && promoType && !submitting && (!needsTargetPromo || hasTargetPromo);
 
   const previewPromo = useMemo((): PromoWithContext => {
     const targetPlayer = players.find((p) => p.playerId === targetPlayerId);
@@ -539,26 +541,38 @@ export default function PromoEditor() {
         )}
 
         {/* Target Promo */}
-        {showTargetPromo && targetPlayerId && (
+        {showTargetPromo && (
           <div className="form-group">
             <label className="form-label" htmlFor="target-promo">
               {t('promos.editor.targetPromo', 'Responding to Promo')}
+              <span className="form-required" aria-label="required"> *</span>
             </label>
-            <select
-              id="target-promo"
-              className="form-select"
-              value={targetPromoId}
-              onChange={(e) => setTargetPromoId(e.target.value)}
-            >
-              <option value="">
-                {t('promos.editor.selectPromo', '-- Select a promo --')}
-              </option>
-              {targetPromos.map((promo) => (
-                <option key={promo.promoId} value={promo.promoId}>
-                  {promo.title || promo.content.slice(0, 60) + '...'}
+            {!targetPlayerId ? (
+              <p className="form-hint">
+                {t('promos.editor.selectPlayerFirst', 'Select a target wrestler above to see their promos.')}
+              </p>
+            ) : targetPromos.length === 0 ? (
+              <p className="form-hint">
+                {t('promos.editor.noTargetPromos', 'This wrestler has no promos yet. Pick a different wrestler or a different promo type.')}
+              </p>
+            ) : (
+              <select
+                id="target-promo"
+                className="form-select"
+                value={targetPromoId}
+                onChange={(e) => setTargetPromoId(e.target.value)}
+                required
+              >
+                <option value="">
+                  {t('promos.editor.selectPromo', '-- Select a promo --')}
                 </option>
-              ))}
-            </select>
+                {targetPromos.map((promo) => (
+                  <option key={promo.promoId} value={promo.promoId}>
+                    {promo.title || promo.content.slice(0, 60) + '...'}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/promos/PromoFeed.tsx
+++ b/frontend/src/components/promos/PromoFeed.tsx
@@ -90,7 +90,10 @@ export default function PromoFeed() {
     } catch { /* silent fail for reactions */ }
   }, []);
 
-  const pinnedPromos = useMemo(() => promos.filter((p) => p.isPinned && !p.targetPromoId), [promos]);
+  const pinnedPromos = useMemo(
+    () => promos.filter((p) => p.isPinned && !p.targetPromoId && p.promoType !== 'response'),
+    [promos]
+  );
 
   const mentionCount = useMemo(() => {
     if (!playerId) return 0;
@@ -98,7 +101,7 @@ export default function PromoFeed() {
   }, [promos, playerId, isRead]);
 
   const filteredPromos = useMemo(() => {
-    let result = promos.filter((p) => !p.isPinned && !p.targetPromoId);
+    let result = promos.filter((p) => !p.isPinned && !p.targetPromoId && p.promoType !== 'response');
     if (activeFilter !== 'all') {
       result = result.filter((p) => matchesFilter(p, activeFilter, playerId));
     }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1354,6 +1354,8 @@
       "selectPlayer": "-- Wrestler auswählen --",
       "targetPromo": "Antwort auf Promo",
       "selectPromo": "-- Promo auswählen --",
+      "selectPlayerFirst": "Wähle oben einen Ziel-Wrestler, um dessen Promos zu sehen.",
+      "noTargetPromos": "Dieser Wrestler hat noch keine Promos. Wähle einen anderen Wrestler oder einen anderen Promo-Typ.",
       "match": "Kampf",
       "selectMatch": "-- Kampf auswählen --",
       "championship": "Meisterschaft",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1355,6 +1355,8 @@
       "selectPlayer": "-- Select a wrestler --",
       "targetPromo": "Responding to Promo",
       "selectPromo": "-- Select a promo --",
+      "selectPlayerFirst": "Select a target wrestler above to see their promos.",
+      "noTargetPromos": "This wrestler has no promos yet. Pick a different wrestler or a different promo type.",
       "match": "Match",
       "selectMatch": "-- Select a match --",
       "championship": "Championship",


### PR DESCRIPTION
Follow-up to #285. After deploying that fix, response promos were still appearing in the feed because users could submit a promo with `promoType: 'response'` but **no** `targetPromoId`. The prior exclusion filter only looked at `targetPromoId`, so these orphans slipped through.

## Root cause

- The promo editor didn't require a target promo to be selected for `response` type — only a target wrestler.
- `createPromo` backend didn't enforce the link either.
- So the DB has rows like `{ promoType: 'response', targetPromoId: undefined }` that are unreachable from any thread but show up in the main feed.

## Changes

**Backend — validation at the source**
- `createPromo.ts`: reject `promoType === 'response'` when `targetPromoId` is missing (400).

**Backend — broaden the exclusion filter (for existing orphans already in prod)**
- `getPromos.ts`: when `?excludeResponses=true`, drop any promo where `targetPromoId` is set **or** `promoType === 'response'`. This cleans up the feed without a data migration.

**Frontend — form guards**
- `PromoEditor.tsx`: submit is disabled until a `targetPromoId` is picked for response promos. Target-promo selector is marked required; inline hints explain "select a wrestler first" and "this wrestler has no promos yet" states.
- `PromoEditor.css`: new `.form-required` and `.form-hint` styles.
- i18n (EN + DE): new `promos.editor.selectPlayerFirst` and `promos.editor.noTargetPromos` keys.

**Frontend — defensive filter parity**
- `PromoFeed.tsx`: client-side guards also reject `promoType === 'response'`, matching the backend.

## Tests

- Backend: new tests for `createPromo` (400 when response lacks target; 201 when target is supplied) and `getPromos` (orphan response with no `targetPromoId` is still excluded). Fixed an existing test that created a response with no target.
- Full backend run: 931/948 — the 17 pre-existing failures on `main` (unrelated `getStandings-season` suite) are untouched.
- Full frontend run: 465/465 passing.
- Backend + frontend lint and typecheck: clean.

## Post-merge verification

Once deployed to prod, the orphan responses currently visible will disappear from `/promos` (the broader backend filter catches them). No data migration is required. New submissions cannot create orphans going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)