### PR TITLE
feat(db): migrate cross-aggregate read handlers to repository layer (Wave 5)

### DIFF
--- a/backend/functions/activity/__tests__/getActivity.test.ts
+++ b/backend/functions/activity/__tests__/getActivity.test.ts
@@ -1,32 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
-const { mockScanAll, mockGet } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
-  mockGet: vi.fn(),
+const {
+  mockMatchesListCompleted,
+  mockChampionshipsListAllHistory,
+  mockChampionshipsList,
+  mockSeasonsList,
+  mockTournamentsList,
+  mockChallengesList,
+  mockPromosList,
+  mockPlayersList,
+} = vi.hoisted(() => ({
+  mockMatchesListCompleted: vi.fn(),
+  mockChampionshipsListAllHistory: vi.fn(),
+  mockChampionshipsList: vi.fn(),
+  mockSeasonsList: vi.fn(),
+  mockTournamentsList: vi.fn(),
+  mockChallengesList: vi.fn(),
+  mockPromosList: vi.fn(),
+  mockPlayersList: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: mockGet,
-    put: vi.fn(),
-    scan: vi.fn(),
-    query: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    scanAll: mockScanAll,
-    queryAll: vi.fn(),
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    MATCHES: 'Matches',
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-    TOURNAMENTS: 'Tournaments',
-    SEASONS: 'Seasons',
-    CHALLENGES: 'Challenges',
-    PROMOS: 'Promos',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    matches: { listCompleted: mockMatchesListCompleted },
+    championships: { listAllHistory: mockChampionshipsListAllHistory, list: mockChampionshipsList },
+    seasons: { list: mockSeasonsList },
+    tournaments: { list: mockTournamentsList },
+    challenges: { list: mockChallengesList },
+    promos: { list: mockPromosList },
+    players: { list: mockPlayersList },
+  }),
 }));
 
 import { handler as getActivity } from '../getActivity';
@@ -52,11 +56,21 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
   };
 }
 
+function mockAllEmpty() {
+  mockMatchesListCompleted.mockResolvedValue([]);
+  mockChampionshipsListAllHistory.mockResolvedValue([]);
+  mockChampionshipsList.mockResolvedValue([]);
+  mockSeasonsList.mockResolvedValue([]);
+  mockTournamentsList.mockResolvedValue([]);
+  mockChallengesList.mockResolvedValue([]);
+  mockPromosList.mockResolvedValue([]);
+  mockPlayersList.mockResolvedValue([]);
+}
+
 describe('getActivity', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockScanAll.mockResolvedValue([]);
-    mockGet.mockResolvedValue({ Item: { name: 'Test Player', currentWrestler: 'Wrestler' } });
+    mockAllEmpty();
   });
 
   it('returns empty items and null nextCursor when no data', async () => {
@@ -69,24 +83,22 @@ describe('getActivity', () => {
   });
 
   it('returns merged and sorted activity items', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([
-        {
-          matchId: 'm1',
-          date: '2024-02-01T12:00:00.000Z',
-          updatedAt: '2024-02-01T14:00:00.000Z',
-          status: 'completed',
-          participants: ['p1', 'p2'],
-          winners: ['p1'],
-          losers: ['p2'],
-          matchFormat: 'singles',
-        },
-      ])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([
+      {
+        matchId: 'm1',
+        date: '2024-02-01T12:00:00.000Z',
+        updatedAt: '2024-02-01T14:00:00.000Z',
+        status: 'completed',
+        participants: ['p1', 'p2'],
+        winners: ['p1'],
+        losers: ['p2'],
+        matchFormat: 'singles',
+      },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Test Player', currentWrestler: 'Wrestler' },
+      { playerId: 'p2', name: 'Test Player', currentWrestler: 'Wrestler2' },
+    ]);
 
     const result = await getActivity(makeEvent(), ctx, cb);
 
@@ -101,33 +113,31 @@ describe('getActivity', () => {
   });
 
   it('excludes matches without updatedAt from activity', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([
-        {
-          matchId: 'm1',
-          date: '2024-02-01T12:00:00.000Z',
-          updatedAt: '2024-02-01T14:00:00.000Z',
-          status: 'completed',
-          participants: ['p1', 'p2'],
-          winners: ['p1'],
-          losers: ['p2'],
-          matchFormat: 'singles',
-        },
-        {
-          matchId: 'm2',
-          date: '2024-02-02T12:00:00.000Z',
-          status: 'completed',
-          participants: ['p1', 'p2'],
-          winners: ['p2'],
-          losers: ['p1'],
-          matchFormat: 'singles',
-        },
-      ])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([
+      {
+        matchId: 'm1',
+        date: '2024-02-01T12:00:00.000Z',
+        updatedAt: '2024-02-01T14:00:00.000Z',
+        status: 'completed',
+        participants: ['p1', 'p2'],
+        winners: ['p1'],
+        losers: ['p2'],
+        matchFormat: 'singles',
+      },
+      {
+        matchId: 'm2',
+        date: '2024-02-02T12:00:00.000Z',
+        status: 'completed',
+        participants: ['p1', 'p2'],
+        winners: ['p2'],
+        losers: ['p1'],
+        matchFormat: 'singles',
+      },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Test Player', currentWrestler: 'Wrestler' },
+      { playerId: 'p2', name: 'Test Player', currentWrestler: 'Wrestler2' },
+    ]);
 
     const result = await getActivity(makeEvent(), ctx, cb);
 
@@ -148,17 +158,15 @@ describe('getActivity', () => {
       losers: ['p2'],
       matchFormat: 'singles',
     };
-    mockScanAll
-      .mockResolvedValueOnce([
-        match,
-        { ...match, matchId: 'm2', date: '2024-01-02T00:00:00.000Z', updatedAt: '2024-01-02T00:00:00.000Z' },
-        { ...match, matchId: 'm3', date: '2024-01-03T00:00:00.000Z', updatedAt: '2024-01-03T00:00:00.000Z' },
-      ])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([
+      match,
+      { ...match, matchId: 'm2', date: '2024-01-02T00:00:00.000Z', updatedAt: '2024-01-02T00:00:00.000Z' },
+      { ...match, matchId: 'm3', date: '2024-01-03T00:00:00.000Z', updatedAt: '2024-01-03T00:00:00.000Z' },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Test Player', currentWrestler: 'Wrestler' },
+      { playerId: 'p2', name: 'Test Player', currentWrestler: 'Wrestler2' },
+    ]);
 
     const result = await getActivity(
       makeEvent({ queryStringParameters: { limit: '2' } }),
@@ -182,17 +190,15 @@ describe('getActivity', () => {
       losers: ['p2'],
       matchFormat: 'singles',
     };
-    mockScanAll
-      .mockResolvedValueOnce([
-        { ...match, matchId: 'm3', date: '2024-01-03T00:00:00.000Z', updatedAt: '2024-01-03T00:00:00.000Z' },
-        { ...match, matchId: 'm2', date: '2024-01-02T00:00:00.000Z', updatedAt: '2024-01-02T00:00:00.000Z' },
-        { ...match, matchId: 'm1', date: '2024-01-01T00:00:00.000Z', updatedAt: '2024-01-01T00:00:00.000Z' },
-      ])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([])
-      .mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([
+      { ...match, matchId: 'm3', date: '2024-01-03T00:00:00.000Z', updatedAt: '2024-01-03T00:00:00.000Z' },
+      { ...match, matchId: 'm2', date: '2024-01-02T00:00:00.000Z', updatedAt: '2024-01-02T00:00:00.000Z' },
+      { ...match, matchId: 'm1', date: '2024-01-01T00:00:00.000Z', updatedAt: '2024-01-01T00:00:00.000Z' },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Test Player', currentWrestler: 'Wrestler' },
+      { playerId: 'p2', name: 'Test Player', currentWrestler: 'Wrestler2' },
+    ]);
 
     const result = await getActivity(
       makeEvent({ queryStringParameters: { limit: '2', cursor: '2024-01-02T12:00:00.000Z' } }),
@@ -207,26 +213,23 @@ describe('getActivity', () => {
     expect(body.items[1].metadata.matchId).toBe('m1');
   });
 
-  it('when type=match only scans Matches table', async () => {
-    mockScanAll.mockResolvedValue([]);
-
+  it('when type=match only calls match-related repos', async () => {
     await getActivity(
       makeEvent({ queryStringParameters: { type: 'match' } }),
       ctx,
       cb
     );
 
-    expect(mockScanAll).toHaveBeenCalledTimes(1);
-    expect(mockScanAll).toHaveBeenCalledWith(
-      expect.objectContaining({
-        TableName: 'Matches',
-        FilterExpression: '#s = :status',
-      })
-    );
+    expect(mockMatchesListCompleted).toHaveBeenCalledTimes(1);
+    expect(mockChampionshipsListAllHistory).not.toHaveBeenCalled();
+    expect(mockSeasonsList).not.toHaveBeenCalled();
+    expect(mockTournamentsList).not.toHaveBeenCalled();
+    expect(mockChallengesList).not.toHaveBeenCalled();
+    expect(mockPromosList).not.toHaveBeenCalled();
   });
 
-  it('returns 500 when DynamoDB scanAll throws', async () => {
-    mockScanAll.mockRejectedValue(new Error('DynamoDB failure'));
+  it('returns 500 when a repository method throws', async () => {
+    mockMatchesListCompleted.mockRejectedValue(new Error('DynamoDB failure'));
 
     const result = await getActivity(makeEvent(), ctx, cb);
 

--- a/backend/functions/activity/getActivity.ts
+++ b/backend/functions/activity/getActivity.ts
@@ -1,5 +1,15 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getRepositories } from '../../lib/repositories';
+import type {
+  Match,
+  ChampionshipHistoryEntry,
+  Season,
+  Tournament,
+  Challenge,
+  Promo,
+  Player,
+  Championship,
+} from '../../lib/repositories';
 import { success, serverError } from '../../lib/response';
 
 const ACTIVITY_TYPES = ['match', 'championship', 'challenge', 'promo', 'tournament', 'season'] as const;
@@ -41,30 +51,18 @@ function parseQuery(event: { queryStringParameters?: Record<string, string | und
   return { limit, cursor, typeFilter };
 }
 
-async function fetchPlayerNames(playerIds: Set<string>): Promise<Record<string, string>> {
+function buildPlayerNameMap(allPlayers: Player[]): Record<string, string> {
   const names: Record<string, string> = {};
-  for (const playerId of playerIds) {
-    const result = await dynamoDb.get({
-      TableName: TableNames.PLAYERS,
-      Key: { playerId },
-    });
-    if (result.Item) {
-      names[playerId] = (result.Item.name as string) || (result.Item.currentWrestler as string) || playerId;
-    }
+  for (const player of allPlayers) {
+    names[player.playerId] = player.name || player.currentWrestler || player.playerId;
   }
   return names;
 }
 
-async function fetchChampionshipNames(championshipIds: Set<string>): Promise<Record<string, string>> {
+function buildChampionshipNameMap(allChampionships: Championship[]): Record<string, string> {
   const names: Record<string, string> = {};
-  for (const championshipId of championshipIds) {
-    const result = await dynamoDb.get({
-      TableName: TableNames.CHAMPIONSHIPS,
-      Key: { championshipId },
-    });
-    if (result.Item) {
-      names[championshipId] = (result.Item.name as string) || championshipId;
-    }
+  for (const championship of allChampionships) {
+    names[championship.championshipId] = championship.name || championship.championshipId;
   }
   return names;
 }
@@ -72,6 +70,7 @@ async function fetchChampionshipNames(championshipIds: Set<string>): Promise<Rec
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
     const { limit, cursor, typeFilter } = parseQuery(event);
+    const { matches, championships, seasons, tournaments, challenges, promos, players } = getRepositories();
 
     const includeMatch = !typeFilter || typeFilter === 'match';
     const includeChampionship = !typeFilter || typeFilter === 'championship';
@@ -85,28 +84,21 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const championshipIds = new Set<string>();
 
     if (includeMatch) {
-      const matches = await dynamoDb.scanAll({
-        TableName: TableNames.MATCHES,
-        FilterExpression: '#s = :status',
-        ExpressionAttributeNames: { '#s': 'status' },
-        ExpressionAttributeValues: { ':status': 'completed' },
-      });
-      for (const m of matches) {
-        const updatedAt = m.updatedAt as string | undefined;
-        if (!updatedAt) continue; // only show matches that have been recorded/updated with updatedAt
-        const date = m.date as string;
-        const participants = (m.participants as string[]) || [];
-        const winners = (m.winners as string[]) || [];
-        const losers = (m.losers as string[]) || [];
-        participants.forEach((p: string) => playerIds.add(p));
+      const completedMatches: Match[] = await matches.listCompleted();
+      for (const m of completedMatches) {
+        if (!m.updatedAt) continue; // only show matches that have been recorded/updated with updatedAt
+        const participants = m.participants || [];
+        const winners = m.winners || [];
+        const losers = m.losers || [];
+        participants.forEach((p) => playerIds.add(p));
         rawItems.push({
           type: 'match_result',
-          timestamp: updatedAt,
-          id: `match-${m.matchId as string}`,
+          timestamp: m.updatedAt,
+          id: `match-${m.matchId}`,
           summary: '', // filled after we have names
           metadata: {
             matchId: m.matchId,
-            date,
+            date: m.date,
             matchFormat: m.matchFormat,
             stipulationId: m.stipulationId,
             participants,
@@ -122,25 +114,21 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     if (includeChampionship) {
-      const history = await dynamoDb.scanAll({
-        TableName: TableNames.CHAMPIONSHIP_HISTORY,
-      });
+      const history: ChampionshipHistoryEntry[] = await championships.listAllHistory();
       for (const h of history) {
-        const updatedAt = h.updatedAt as string | undefined;
-        if (!updatedAt) continue; // only show championship history with updatedAt
-        const wonDate = h.wonDate as string;
-        championshipIds.add(h.championshipId as string);
+        if (!h.updatedAt) continue; // only show championship history with updatedAt
+        championshipIds.add(h.championshipId);
         const champion = h.champion;
         if (typeof champion === 'string') playerIds.add(champion);
-        else if (Array.isArray(champion)) champion.forEach((c: string) => playerIds.add(c));
+        else if (Array.isArray(champion)) champion.forEach((c) => playerIds.add(c));
         rawItems.push({
           type: 'championship_change',
-          timestamp: updatedAt,
-          id: `championship-${h.championshipId as string}-${wonDate}`,
+          timestamp: h.updatedAt,
+          id: `championship-${h.championshipId}-${h.wonDate}`,
           summary: '',
           metadata: {
             championshipId: h.championshipId,
-            wonDate,
+            wonDate: h.wonDate,
             champion,
             matchId: h.matchId,
             lostDate: h.lostDate,
@@ -151,40 +139,35 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     if (includeSeason) {
-      const seasons = await dynamoDb.scanAll({
-        TableName: TableNames.SEASONS,
-      });
-      for (const s of seasons) {
-        const updatedAt = s.updatedAt as string | undefined;
-        if (!updatedAt) continue; // only show seasons with updatedAt
-        const startDate = s.startDate as string;
-        const status = s.status as string;
+      const allSeasons: Season[] = await seasons.list();
+      for (const s of allSeasons) {
+        if (!s.updatedAt) continue; // only show seasons with updatedAt
         rawItems.push({
           type: 'season_event',
-          timestamp: updatedAt,
-          id: `season-start-${s.seasonId as string}`,
+          timestamp: s.updatedAt,
+          id: `season-start-${s.seasonId}`,
           summary: '',
           metadata: {
             seasonId: s.seasonId,
             name: s.name,
-            startDate,
+            startDate: s.startDate,
             endDate: s.endDate,
-            status,
+            status: s.status,
             event: 'started',
           },
         });
-        if (status === 'completed' && s.endDate) {
+        if (s.status === 'completed' && s.endDate) {
           rawItems.push({
             type: 'season_event',
-            timestamp: updatedAt,
-            id: `season-end-${s.seasonId as string}`,
+            timestamp: s.updatedAt,
+            id: `season-end-${s.seasonId}`,
             summary: '',
             metadata: {
               seasonId: s.seasonId,
               name: s.name,
               startDate: s.startDate,
               endDate: s.endDate,
-              status,
+              status: s.status,
               event: 'ended',
             },
           });
@@ -193,26 +176,22 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     if (includeTournament) {
-      const tournaments = await dynamoDb.scanAll({
-        TableName: TableNames.TOURNAMENTS,
-      });
-      for (const t of tournaments) {
-        const updatedAt = (t.updatedAt as string | undefined) || (t.createdAt as string | undefined);
+      const allTournaments: Tournament[] = await tournaments.list();
+      for (const t of allTournaments) {
+        const updatedAt = t.updatedAt || t.createdAt;
         if (!updatedAt) continue; // only show tournaments with updatedAt or createdAt
-        const status = t.status as string;
-        const winner = t.winner as string | undefined;
-        if (winner) playerIds.add(winner);
+        if (t.winner) playerIds.add(t.winner);
         rawItems.push({
           type: 'tournament_result',
           timestamp: updatedAt,
-          id: `tournament-${t.tournamentId as string}`,
+          id: `tournament-${t.tournamentId}`,
           summary: '',
           metadata: {
             tournamentId: t.tournamentId,
             name: t.name,
             type: t.type,
-            status,
-            winner,
+            status: t.status,
+            winner: t.winner,
             createdAt: t.createdAt,
           },
         });
@@ -220,18 +199,16 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     if (includeChallenge) {
-      const challenges = await dynamoDb.scanAll({
-        TableName: TableNames.CHALLENGES,
-      });
-      for (const c of challenges) {
-        const updatedAt = (c.updatedAt as string | undefined) || (c.createdAt as string | undefined);
+      const allChallenges: Challenge[] = await challenges.list();
+      for (const c of allChallenges) {
+        const updatedAt = c.updatedAt || c.createdAt;
         if (!updatedAt) continue; // only show challenges with updatedAt or createdAt
-        playerIds.add(c.challengerId as string);
-        playerIds.add(c.challengedId as string);
+        playerIds.add(c.challengerId);
+        playerIds.add(c.challengedId);
         rawItems.push({
           type: 'challenge_event',
           timestamp: updatedAt,
-          id: `challenge-${c.challengeId as string}`,
+          id: `challenge-${c.challengeId}`,
           summary: '',
           metadata: {
             challengeId: c.challengeId,
@@ -246,17 +223,15 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     if (includePromo) {
-      const promos = await dynamoDb.scanAll({
-        TableName: TableNames.PROMOS,
-      });
-      for (const p of promos) {
-        const updatedAt = (p.updatedAt as string | undefined) || (p.createdAt as string | undefined);
+      const allPromos: Promo[] = await promos.list();
+      for (const p of allPromos) {
+        const updatedAt = p.updatedAt || p.createdAt;
         if (!updatedAt) continue; // only show promos with updatedAt or createdAt
-        playerIds.add(p.playerId as string);
+        playerIds.add(p.playerId);
         rawItems.push({
           type: 'promo_posted',
           timestamp: updatedAt,
-          id: `promo-${p.promoId as string}`,
+          id: `promo-${p.promoId}`,
           summary: '',
           metadata: {
             promoId: p.promoId,
@@ -269,16 +244,22 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       }
     }
 
-    const playerNames = await fetchPlayerNames(playerIds);
-    const championshipNames = await fetchChampionshipNames(championshipIds);
+    // Batch-fetch all players and championships to build name maps (eliminates N+1 lookups)
+    const [allPlayers, allChampionships] = await Promise.all([
+      players.list(),
+      championshipIds.size > 0 ? championships.list() : Promise.resolve([]),
+    ]);
+
+    const playerNames = buildPlayerNameMap(allPlayers);
+    const championshipNames = buildChampionshipNameMap(allChampionships);
 
     for (const item of rawItems) {
       if (item.type === 'match_result') {
         const meta = item.metadata;
         const winners = (meta.winners as string[]) || [];
         const losers = (meta.losers as string[]) || [];
-        const winnerNames = winners.map((id: string) => playerNames[id] || id);
-        const loserNames = losers.map((id: string) => playerNames[id] || id);
+        const winnerNames = winners.map((id) => playerNames[id] || id);
+        const loserNames = losers.map((id) => playerNames[id] || id);
         meta.winnerNames = winnerNames;
         meta.loserNames = loserNames;
         item.summary = winnerNames.length && loserNames.length
@@ -288,7 +269,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         const meta = item.metadata;
         const champ = meta.champion;
         const champNames = Array.isArray(champ)
-          ? (champ as string[]).map((id: string) => playerNames[id] || id)
+          ? (champ as string[]).map((id) => playerNames[id] || id)
           : [playerNames[champ as string] || (champ as string)];
         meta.championNames = champNames;
         meta.championshipName = championshipNames[meta.championshipId as string] || meta.championshipId;

--- a/backend/functions/dashboard/__tests__/getDashboard.test.ts
+++ b/backend/functions/dashboard/__tests__/getDashboard.test.ts
@@ -1,29 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Context, Callback } from 'aws-lambda';
 
-const { mockScanAll, mockQuery, mockQueryAll } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
-  mockQuery: vi.fn(),
-  mockQueryAll: vi.fn(),
+const {
+  mockChampionshipsList,
+  mockPlayersList,
+  mockSeasonsList,
+  mockMatchesList,
+  mockStipulationsList,
+  mockEventsListByStatus,
+  mockChallengesListByStatus,
+  mockChampionshipsFindCurrentReign,
+  mockSeasonStandingsListBySeason,
+} = vi.hoisted(() => ({
+  mockChampionshipsList: vi.fn(),
+  mockPlayersList: vi.fn(),
+  mockSeasonsList: vi.fn(),
+  mockMatchesList: vi.fn(),
+  mockStipulationsList: vi.fn(),
+  mockEventsListByStatus: vi.fn(),
+  mockChallengesListByStatus: vi.fn(),
+  mockChampionshipsFindCurrentReign: vi.fn(),
+  mockSeasonStandingsListBySeason: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    scanAll: mockScanAll,
-    query: mockQuery,
-    queryAll: mockQueryAll,
-  },
-  TableNames: {
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-    PLAYERS: 'Players',
-    SEASONS: 'Seasons',
-    MATCHES: 'Matches',
-    STIPULATIONS: 'Stipulations',
-    EVENTS: 'Events',
-    CHALLENGES: 'Challenges',
-    SEASON_STANDINGS: 'SeasonStandings',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    championships: { list: mockChampionshipsList, findCurrentReign: mockChampionshipsFindCurrentReign },
+    players: { list: mockPlayersList },
+    seasons: { list: mockSeasonsList },
+    matches: { list: mockMatchesList },
+    stipulations: { list: mockStipulationsList },
+    events: { listByStatus: mockEventsListByStatus },
+    challenges: { listByStatus: mockChallengesListByStatus },
+    seasonStandings: { listBySeason: mockSeasonStandingsListBySeason },
+  }),
 }));
 
 import { handler as getDashboard } from '../getDashboard';
@@ -34,14 +44,15 @@ const cb: Callback = () => {};
 describe('getDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockScanAll
-      .mockResolvedValueOnce([]) // championships
-      .mockResolvedValueOnce([]) // players
-      .mockResolvedValueOnce([]) // seasons
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([]); // stipulations
-    mockQuery.mockResolvedValue({ Items: [] });
-    mockQueryAll.mockResolvedValue([]);
+    mockChampionshipsList.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
+    mockSeasonsList.mockResolvedValue([]);
+    mockMatchesList.mockResolvedValue([]);
+    mockStipulationsList.mockResolvedValue([]);
+    mockEventsListByStatus.mockResolvedValue([]);
+    mockChallengesListByStatus.mockResolvedValue([]);
+    mockChampionshipsFindCurrentReign.mockResolvedValue(null);
+    mockSeasonStandingsListBySeason.mockResolvedValue([]);
   });
 
   it('returns 200 with all dashboard sections', async () => {
@@ -80,21 +91,15 @@ describe('getDashboard', () => {
   });
 
   it('returns correct current champions (only active with champion)', async () => {
-    mockScanAll
-      .mockReset()
-      .mockResolvedValueOnce([
-        { championshipId: 'c1', name: 'World Title', isActive: true, currentChampion: 'p1' },
-        { championshipId: 'c2', name: 'Tag Titles', isActive: false, currentChampion: 'p2' },
-        { championshipId: 'c3', name: 'Midcard', isActive: true },
-      ])
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
-      ])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]); // stipulations
-    mockQuery.mockReset().mockResolvedValue({ Items: [] });
-    mockQueryAll.mockReset().mockResolvedValue([]);
+    mockChampionshipsList.mockResolvedValue([
+      { championshipId: 'c1', name: 'World Title', isActive: true, currentChampion: 'p1' },
+      { championshipId: 'c2', name: 'Tag Titles', isActive: false, currentChampion: 'p2' },
+      { championshipId: 'c3', name: 'Midcard', isActive: true },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
+    ]);
+    mockChampionshipsFindCurrentReign.mockResolvedValue(null);
 
     const result = await getDashboard({} as never, ctx, cb);
 
@@ -106,46 +111,27 @@ describe('getDashboard', () => {
   });
 
   it('reads champion wonDate from ChampionshipHistory (open reign), not from Championships.updatedAt', async () => {
-    // Championship.updatedAt was bumped by a recent image upload and is NOT
-    // the real won date. The real won date lives on the open reign row in
-    // ChampionshipHistory (the row with no lostDate).
     const realWonDate = '2025-11-01T12:00:00Z';
     const bogusUpdatedAt = '2026-04-10T09:00:00Z';
 
-    mockScanAll
-      .mockReset()
-      .mockResolvedValueOnce([
-        {
-          championshipId: 'c1',
-          name: 'World Title',
-          isActive: true,
-          currentChampion: 'p1',
-          updatedAt: bogusUpdatedAt,
-        },
-      ])
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
-      ])
-      .mockResolvedValueOnce([]) // seasons
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([]); // stipulations
-
-    mockQuery.mockReset().mockImplementation((params: { TableName: string }) => {
-      if (params.TableName === 'ChampionshipHistory') {
-        return Promise.resolve({
-          Items: [
-            {
-              championshipId: 'c1',
-              wonDate: realWonDate,
-              champion: 'p1',
-              defenses: 3,
-            },
-          ],
-        });
-      }
-      return Promise.resolve({ Items: [] });
+    mockChampionshipsList.mockResolvedValue([
+      {
+        championshipId: 'c1',
+        name: 'World Title',
+        isActive: true,
+        currentChampion: 'p1',
+        updatedAt: bogusUpdatedAt,
+      },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
+    ]);
+    mockChampionshipsFindCurrentReign.mockResolvedValue({
+      championshipId: 'c1',
+      wonDate: realWonDate,
+      champion: 'p1',
+      defenses: 3,
     });
-    mockQueryAll.mockReset().mockResolvedValue([]);
 
     const result = await getDashboard({} as never, ctx, cb);
 
@@ -158,25 +144,19 @@ describe('getDashboard', () => {
   });
 
   it('falls back to undefined wonDate when ChampionshipHistory has no open reign row', async () => {
-    mockScanAll
-      .mockReset()
-      .mockResolvedValueOnce([
-        {
-          championshipId: 'c1',
-          name: 'World Title',
-          isActive: true,
-          currentChampion: 'p1',
-          updatedAt: '2026-04-10T09:00:00Z',
-        },
-      ])
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
-      ])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
-    mockQuery.mockReset().mockResolvedValue({ Items: [] });
-    mockQueryAll.mockReset().mockResolvedValue([]);
+    mockChampionshipsList.mockResolvedValue([
+      {
+        championshipId: 'c1',
+        name: 'World Title',
+        isActive: true,
+        currentChampion: 'p1',
+        updatedAt: '2026-04-10T09:00:00Z',
+      },
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'Stone Cold' },
+    ]);
+    mockChampionshipsFindCurrentReign.mockResolvedValue(null);
 
     const result = await getDashboard({} as never, ctx, cb);
 
@@ -187,21 +167,16 @@ describe('getDashboard', () => {
   });
 
   it('limits upcoming events to 3', async () => {
-    vi.clearAllMocks();
-    mockScanAll
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]); // stipulations
-    mockQuery.mockResolvedValue({
-      Items: [
-        { eventId: 'e1', name: 'Event 1', date: '2025-03-01', eventType: 'ppv' },
-        { eventId: 'e2', name: 'Event 2', date: '2025-03-02', eventType: 'ppv' },
-        { eventId: 'e3', name: 'Event 3', date: '2025-03-03', eventType: 'ppv' },
-      ],
+    mockEventsListByStatus.mockImplementation((status: string) => {
+      if (status === 'upcoming') {
+        return Promise.resolve([
+          { eventId: 'e1', name: 'Event 1', date: '2025-03-01', eventType: 'ppv' },
+          { eventId: 'e2', name: 'Event 2', date: '2025-03-02', eventType: 'ppv' },
+          { eventId: 'e3', name: 'Event 3', date: '2025-03-03', eventType: 'ppv' },
+        ]);
+      }
+      return Promise.resolve([]);
     });
-    mockQueryAll.mockResolvedValue([]);
 
     const result = await getDashboard({} as never, ctx, cb);
 
@@ -211,7 +186,7 @@ describe('getDashboard', () => {
   });
 
   it('excludes completed matches without updatedAt from recent results', async () => {
-    const completedNoUpdatedAt = [
+    mockMatchesList.mockResolvedValue([
       {
         matchId: 'm1',
         date: '2025-01-10T00:00:00Z',
@@ -220,16 +195,11 @@ describe('getDashboard', () => {
         losers: ['p2'],
         matchFormat: 'singles',
       },
-    ];
-    mockScanAll
-      .mockReset()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ playerId: 'p1', currentWrestler: 'A' }, { playerId: 'p2', currentWrestler: 'B' }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(completedNoUpdatedAt)
-      .mockResolvedValueOnce([]);
-    mockQuery.mockReset().mockResolvedValue({ Items: [] });
-    mockQueryAll.mockReset().mockResolvedValue([]);
+    ]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', currentWrestler: 'A' },
+      { playerId: 'p2', currentWrestler: 'B' },
+    ]);
 
     const result = await getDashboard({} as never, ctx, cb);
 
@@ -262,15 +232,11 @@ describe('getDashboard', () => {
         matchFormat: 'singles',
       })),
     ];
-    mockScanAll
-      .mockReset()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ playerId: 'p1', currentWrestler: 'A' }, { playerId: 'p2', currentWrestler: 'B' }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(manyMatches)
-      .mockResolvedValueOnce([]); // stipulations
-    mockQuery.mockReset().mockResolvedValue({ Items: [] });
-    mockQueryAll.mockReset().mockResolvedValue([]);
+    mockMatchesList.mockResolvedValue(manyMatches);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', currentWrestler: 'A' },
+      { playerId: 'p2', currentWrestler: 'B' },
+    ]);
 
     const result = await getDashboard({} as never, ctx, cb);
 
@@ -280,10 +246,8 @@ describe('getDashboard', () => {
     expect(body.recentResults.every((m: { matchId: string }) => m.matchId.startsWith('recent'))).toBe(true);
   });
 
-  it('returns 500 on DynamoDB error', async () => {
-    mockScanAll.mockReset().mockRejectedValue(new Error('DynamoDB connection failed'));
-    mockQuery.mockReset().mockResolvedValue({ Items: [] });
-    mockQueryAll.mockReset().mockResolvedValue([]);
+  it('returns 500 on repository error', async () => {
+    mockChampionshipsList.mockRejectedValue(new Error('DynamoDB connection failed'));
 
     const result = await getDashboard({} as never, ctx, cb);
 

--- a/backend/functions/dashboard/getDashboard.ts
+++ b/backend/functions/dashboard/getDashboard.ts
@@ -1,5 +1,6 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getRepositories } from '../../lib/repositories';
+import type { Player, Championship, ChampionshipHistoryEntry } from '../../lib/repositories';
 import { success, serverError } from '../../lib/response';
 
 interface DashboardChampion {
@@ -66,59 +67,37 @@ interface DashboardResponse {
 
 export const handler: APIGatewayProxyHandler = async () => {
   try {
+    const { championships, players, seasons, matches, stipulations, events, challenges, seasonStandings } = getRepositories();
+
     // Fetch data: championships, players, seasons, matches, stipulations; events and challenges via query
-    const [championships, players, seasons, matches, stipulations, upcomingEventsResult, inProgressEventsResult, pendingChallenges] =
+    const [championshipList, playerList, seasonList, matchList, stipulationList, upcomingEventsList, inProgressEventsList, pendingChallengeList] =
       await Promise.all([
-        dynamoDb.scanAll({ TableName: TableNames.CHAMPIONSHIPS }),
-        dynamoDb.scanAll({ TableName: TableNames.PLAYERS }),
-        dynamoDb.scanAll({ TableName: TableNames.SEASONS }),
-        dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
-        dynamoDb.scanAll({ TableName: TableNames.STIPULATIONS }),
-        dynamoDb.query({
-          TableName: TableNames.EVENTS,
-          IndexName: 'StatusIndex',
-          KeyConditionExpression: '#s = :status',
-          ExpressionAttributeNames: { '#s': 'status' },
-          ExpressionAttributeValues: { ':status': 'upcoming' },
-          ScanIndexForward: true,
-          Limit: 3,
-        }),
-        dynamoDb.query({
-          TableName: TableNames.EVENTS,
-          IndexName: 'StatusIndex',
-          KeyConditionExpression: '#s = :status',
-          ExpressionAttributeNames: { '#s': 'status' },
-          ExpressionAttributeValues: { ':status': 'in-progress' },
-          ScanIndexForward: true,
-        }),
-        dynamoDb.queryAll({
-          TableName: TableNames.CHALLENGES,
-          IndexName: 'StatusIndex',
-          KeyConditionExpression: '#s = :status',
-          ExpressionAttributeNames: { '#s': 'status' },
-          ExpressionAttributeValues: { ':status': 'pending' },
-        }),
+        championships.list(),
+        players.list(),
+        seasons.list(),
+        matches.list(),
+        stipulations.list(),
+        events.listByStatus('upcoming'),
+        events.listByStatus('in-progress'),
+        challenges.listByStatus('pending'),
       ]);
 
     // Only include players who have a wrestler assigned (exclude Fantasy-only users)
-    const wrestlerPlayers = (players as Record<string, unknown>[]).filter((p) => p.currentWrestler);
+    const wrestlerPlayers = playerList.filter((p) => p.currentWrestler);
 
-    const playerMap = new Map<string, Record<string, unknown>>();
+    const playerMap = new Map<string, Player>();
     for (const p of wrestlerPlayers) {
-      const id = p.playerId as string;
-      if (id) playerMap.set(id, p);
+      if (p.playerId) playerMap.set(p.playerId, p);
     }
 
-    const championshipMap = new Map<string, Record<string, unknown>>();
-    for (const c of championships as Record<string, unknown>[]) {
-      const id = c.championshipId as string;
-      if (id) championshipMap.set(id, c);
+    const championshipMap = new Map<string, Championship>();
+    for (const c of championshipList) {
+      if (c.championshipId) championshipMap.set(c.championshipId, c);
     }
 
     const stipulationMap = new Map<string, string>();
-    for (const s of (stipulations as Record<string, unknown>[]) ?? []) {
-      const id = s.stipulationId as string;
-      if (id && s.name) stipulationMap.set(id, s.name as string);
+    for (const s of stipulationList ?? []) {
+      if (s.stipulationId && s.name) stipulationMap.set(s.stipulationId, s.name);
     }
 
     // Current champions: active championships with currentChampion.
@@ -127,13 +106,13 @@ export const handler: APIGatewayProxyHandler = async () => {
     // field bumps on any championship edit (e.g. image upload) and is not
     // a reliable source of reign length.
     interface ChampionCandidate {
-      championship: Record<string, unknown>;
+      championship: Championship;
       playerIds: string[];
       names: string[];
       imageUrl?: string;
     }
     const championCandidates: ChampionCandidate[] = [];
-    for (const c of championships as Record<string, unknown>[]) {
+    for (const c of championshipList) {
       if (c.isActive === false) continue;
       const champ = c.currentChampion;
       if (!champ) continue;
@@ -141,10 +120,10 @@ export const handler: APIGatewayProxyHandler = async () => {
       const names: string[] = [];
       let imageUrl: string | undefined;
       for (const pid of playerIds) {
-        const player = playerMap.get(pid as string);
+        const player = playerMap.get(pid);
         if (player) {
-          names.push((player.currentWrestler as string) || (player.name as string));
-          if (player.imageUrl) imageUrl = player.imageUrl as string;
+          names.push(player.currentWrestler || player.name);
+          if (player.imageUrl) imageUrl = player.imageUrl;
         }
       }
       if (names.length > 0) {
@@ -152,103 +131,84 @@ export const handler: APIGatewayProxyHandler = async () => {
       }
     }
 
-    const currentReigns = await Promise.all(
+    const currentReigns: (ChampionshipHistoryEntry | null)[] = await Promise.all(
       championCandidates.map((cand) =>
-        dynamoDb.query({
-          TableName: TableNames.CHAMPIONSHIP_HISTORY,
-          KeyConditionExpression: 'championshipId = :cid',
-          FilterExpression: 'attribute_not_exists(lostDate)',
-          ExpressionAttributeValues: {
-            ':cid': cand.championship.championshipId as string,
-          },
-          ScanIndexForward: false,
-          Limit: 1,
-        })
+        championships.findCurrentReign(cand.championship.championshipId)
       )
     );
 
     const currentChampions: DashboardChampion[] = championCandidates.map(
       (cand, i) => {
-        const reign = currentReigns[i]?.Items?.[0] as
-          | Record<string, unknown>
-          | undefined;
+        const reign = currentReigns[i];
         return {
-          championshipId: cand.championship.championshipId as string,
-          championshipName: cand.championship.name as string,
+          championshipId: cand.championship.championshipId,
+          championshipName: cand.championship.name,
           championName: cand.names.join(' & '),
           championImageUrl: cand.imageUrl,
-          playerId: (cand.playerIds[0] as string) ?? '',
-          wonDate: (reign?.wonDate as string | undefined) ?? undefined,
-          defenses:
-            (reign?.defenses as number | undefined) ??
-            (cand.championship.defenses as number | undefined),
+          playerId: cand.playerIds[0] ?? '',
+          wonDate: reign?.wonDate ?? undefined,
+          defenses: reign?.defenses ?? cand.championship.defenses,
         };
       }
     );
 
-    // Upcoming events (already limited to 3 by query)
-    const upcomingEvents: DashboardEvent[] = ((upcomingEventsResult.Items || []) as Record<
-      string,
-      unknown
-   >[])
+    // Upcoming events (slice to 3 client-side)
+    const upcomingEvents: DashboardEvent[] = upcomingEventsList
       .sort(
         (a, b) =>
-          new Date(a.date as string).getTime() - new Date(b.date as string).getTime()
+          new Date(a.date).getTime() - new Date(b.date).getTime()
       )
       .slice(0, 3)
       .map((e) => ({
-        eventId: e.eventId as string,
-        name: (e.name as string) ?? 'Event',
-        date: e.date as string,
-        eventType: (e.eventType as string) ?? 'event',
-        venue: e.venue as string | undefined,
-        matchCount: e.matchCount as number | undefined,
+        eventId: e.eventId,
+        name: e.name ?? 'Event',
+        date: e.date,
+        eventType: e.eventType ?? 'event',
+        venue: e.venue,
+        matchCount: e.matchCards?.length,
       }));
 
     // In-progress events
-    const inProgressEvents: DashboardEvent[] = ((inProgressEventsResult.Items || []) as Record<
-      string,
-      unknown
-    >[])
+    const inProgressEvents: DashboardEvent[] = inProgressEventsList
       .sort(
         (a, b) =>
-          new Date(a.date as string).getTime() - new Date(b.date as string).getTime()
+          new Date(a.date).getTime() - new Date(b.date).getTime()
       )
       .map((e) => ({
-        eventId: e.eventId as string,
-        name: (e.name as string) ?? 'Event',
-        date: e.date as string,
-        eventType: (e.eventType as string) ?? 'event',
-        venue: e.venue as string | undefined,
-        matchCount: e.matchCount as number | undefined,
+        eventId: e.eventId,
+        name: e.name ?? 'Event',
+        date: e.date,
+        eventType: e.eventType ?? 'event',
+        venue: e.venue,
+        matchCount: e.matchCards?.length,
       }));
 
     // Recent results: only matches with updatedAt (recorded after we added it), sort by updatedAt desc, limit 20 for date grouping
-    const completedMatches = (matches as Record<string, unknown>[]).filter(
+    const completedMatches = matchList.filter(
       (m) =>
         m.status === 'completed' &&
         m.winners &&
         m.losers &&
-        (m.updatedAt as string)
+        m.updatedAt
     );
     completedMatches.sort(
       (a, b) =>
-        new Date(b.updatedAt as string).getTime() -
-        new Date(a.updatedAt as string).getTime()
+        new Date(b.updatedAt!).getTime() -
+        new Date(a.updatedAt!).getTime()
     );
     // Limit recent results to matches updated within the last 3 days
     const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
     const recentCompletedMatches = completedMatches.filter(
-      (m) => ((m.updatedAt as string) || (m.date as string)) >= threeDaysAgo
+      (m) => (m.updatedAt || m.date) >= threeDaysAgo
     );
     // Safety cap to avoid unbounded responses
     const recentResults: DashboardMatch[] = recentCompletedMatches.slice(0, 50).map((m) => {
-      const winnerIds = m.winners as string[];
-      const loserIds = m.losers as string[];
+      const winnerIds = m.winners!;
+      const loserIds = m.losers!;
       const winnerName = (winnerIds || [])
         .map((id) => {
           const p = playerMap.get(id);
-          return p ? (p.currentWrestler as string) || (p.name as string) : '';
+          return p ? p.currentWrestler || p.name : '';
         })
         .filter(Boolean)
         .join(' & ');
@@ -256,78 +216,74 @@ export const handler: APIGatewayProxyHandler = async () => {
       const loserName = (loserIds || [])
         .map((id) => {
           const p = playerMap.get(id);
-          return p ? (p.currentWrestler as string) || (p.name as string) : '';
+          return p ? p.currentWrestler || p.name : '';
         })
         .filter(Boolean)
         .join(' vs ');
       const firstWinner = winnerIds?.[0];
       const firstLoser = loserIds?.[0];
-      const champId = m.championshipId as string | undefined;
+      const champId = m.championshipId;
       const champ = champId ? championshipMap.get(champId) : undefined;
-      const stipulationId = m.stipulationId as string | undefined;
+      const stipulationId = m.stipulationId;
       const stipulationName = stipulationId ? stipulationMap.get(stipulationId) : undefined;
-      const matchType = (m.matchFormat as string) ?? (m.matchType as string) ?? 'singles';
+      const matchType = m.matchFormat ?? m.matchType ?? 'singles';
       const isChampionship = Boolean(m.isChampionship && champId);
       return {
-        matchId: m.matchId as string,
-        date: m.date as string,
+        matchId: m.matchId,
+        date: m.date,
         matchType,
         stipulation: stipulationName,
         isChampionship,
-        championshipName: champ ? (champ.name as string) : undefined,
-        championshipImageUrl: champ?.imageUrl as string | undefined,
-        starRating: m.starRating as number | undefined,
+        championshipName: champ ? champ.name : undefined,
+        championshipImageUrl: champ?.imageUrl,
+        starRating: m.starRating,
         matchOfTheNight: Boolean(m.matchOfTheNight),
-        winnerName: winnerName || '—',
+        winnerName: winnerName || '\u2014',
         winnerImageUrl: firstWinner
-          ? (playerMap.get(firstWinner)?.imageUrl as string | undefined)
+          ? playerMap.get(firstWinner)?.imageUrl
           : undefined,
-        loserName: loserName || '—',
+        loserName: loserName || '\u2014',
         loserImageUrl: firstLoser
-          ? (playerMap.get(firstLoser)?.imageUrl as string | undefined)
+          ? playerMap.get(firstLoser)?.imageUrl
           : undefined,
-        eventId: m.eventId as string | undefined,
+        eventId: m.eventId,
       };
     });
 
     // Active season
-    const activeSeason = (seasons as Record<string, unknown>[]).find(
+    const activeSeason = seasonList.find(
       (s) => s.status === 'active'
     );
     let seasonInfo: DashboardSeason | null = null;
     if (activeSeason) {
-      const seasonMatches = (matches as Record<string, unknown>[]).filter(
+      const seasonMatches = matchList.filter(
         (m) => m.seasonId === activeSeason.seasonId && m.status === 'completed'
       );
       seasonInfo = {
-        seasonId: activeSeason.seasonId as string,
-        name: activeSeason.name as string,
-        startDate: activeSeason.startDate as string | undefined,
-        endDate: activeSeason.endDate as string | undefined,
-        status: activeSeason.status as string,
+        seasonId: activeSeason.seasonId,
+        name: activeSeason.name,
+        startDate: activeSeason.startDate,
+        endDate: activeSeason.endDate,
+        status: activeSeason.status,
         matchesPlayed: seasonMatches.length,
       };
     }
 
     // Quick stats
-    const totalMatches = (matches as Record<string, unknown>[]).filter(
+    const totalMatches = matchList.filter(
       (m) => m.status === 'completed'
     ).length;
     let mostWinsPlayer: { name: string; wins: number } | undefined;
     if (activeSeason) {
-      const seasonStandings = await dynamoDb.queryAll({
-        TableName: TableNames.SEASON_STANDINGS,
-        KeyConditionExpression: 'seasonId = :sid',
-        ExpressionAttributeValues: { ':sid': activeSeason.seasonId },
-      });
+      const standings = await seasonStandings.listBySeason(activeSeason.seasonId);
       let maxWins = 0;
-      for (const s of seasonStandings as Record<string, unknown>[]) {
-        const w = (s.wins as number) ?? 0;
+      for (const s of standings) {
+        const w = s.wins ?? 0;
         if (w > maxWins) {
           maxWins = w;
-          const p = playerMap.get(s.playerId as string);
+          const p = playerMap.get(s.playerId);
           mostWinsPlayer = {
-            name: (p?.currentWrestler as string) || (p?.name as string) || '—',
+            name: p?.currentWrestler || p?.name || '\u2014',
             wins: w,
           };
         }
@@ -335,11 +291,11 @@ export const handler: APIGatewayProxyHandler = async () => {
     } else {
       let maxWins = 0;
       for (const p of wrestlerPlayers) {
-        const w = (p.wins as number) ?? 0;
+        const w = p.wins ?? 0;
         if (w > maxWins) {
           maxWins = w;
           mostWinsPlayer = {
-            name: (p.currentWrestler as string) || (p.name as string) || '—',
+            name: p.currentWrestler || p.name || '\u2014',
             wins: w,
           };
         }
@@ -349,7 +305,7 @@ export const handler: APIGatewayProxyHandler = async () => {
     const quickStats: DashboardQuickStats = {
       totalPlayers: wrestlerPlayers.length,
       totalMatches,
-      activeChampionships: (championships as Record<string, unknown>[]).filter(
+      activeChampionships: championshipList.filter(
         (c) => c.isActive !== false
       ).length,
       mostWinsPlayer,
@@ -362,7 +318,7 @@ export const handler: APIGatewayProxyHandler = async () => {
       recentResults,
       seasonInfo,
       quickStats,
-      activeChallengesCount: pendingChallenges.length,
+      activeChallengesCount: pendingChallengeList.length,
     };
 
     return success(response);

--- a/backend/functions/rivalries/getRivalries.ts
+++ b/backend/functions/rivalries/getRivalries.ts
@@ -1,27 +1,10 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getRepositories } from '../../lib/repositories';
+import type { Match, Player } from '../../lib/repositories';
 import { success, serverError } from '../../lib/response';
 
 const MIN_MATCHES_FOR_RIVALRY = 3;
 const MAX_RIVALRIES_RETURNED = 20;
-
-interface MatchRecord {
-  matchId: string;
-  date: string;
-  participants: string[];
-  winners?: string[];
-  losers?: string[];
-  isChampionship?: boolean;
-  status: string;
-  seasonId?: string;
-}
-
-interface PlayerRecord {
-  playerId: string;
-  name: string;
-  currentWrestler: string;
-  imageUrl?: string;
-}
 
 interface RivalryAgg {
   player1Id: string;
@@ -47,22 +30,22 @@ function intensityBadge(matchCount: number): 'heatingUp' | 'intense' | 'historic
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
+    const { matches, players } = getRepositories();
     const seasonId = event.queryStringParameters?.seasonId;
 
-    const [playersResult, matchesResult] = await Promise.all([
-      dynamoDb.scanAll({ TableName: TableNames.PLAYERS }),
-      dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
+    const [allPlayers, allMatches] = await Promise.all([
+      players.list(),
+      matches.list(),
     ]);
 
     // Only include players who have a wrestler assigned (exclude Fantasy-only users)
-    const players = (playersResult as unknown as PlayerRecord[]).filter((p) => p.currentWrestler);
-    const allMatches = matchesResult as unknown as MatchRecord[];
-    let completed = allMatches.filter((m) => m.status === 'completed');
+    const filteredPlayers = allPlayers.filter((p: Player) => p.currentWrestler);
+    let completed = allMatches.filter((m: Match) => m.status === 'completed');
     if (seasonId) {
-      completed = completed.filter((m) => m.seasonId === seasonId);
+      completed = completed.filter((m: Match) => m.seasonId === seasonId);
     }
 
-    const playerMap = new Map(players.map((p) => [p.playerId, p]));
+    const playerMap = new Map(filteredPlayers.map((p: Player) => [p.playerId, p]));
 
     const aggMap = new Map<string, RivalryAgg>();
 

--- a/backend/functions/standings/__tests__/getStandings-allTime.test.ts
+++ b/backend/functions/standings/__tests__/getStandings-allTime.test.ts
@@ -3,37 +3,20 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockGet, mockPut, mockScan, mockQuery, mockUpdate, mockDelete, mockScanAll, mockQueryAll } = vi.hoisted(() => ({
-  mockGet: vi.fn(),
-  mockPut: vi.fn(),
-  mockScan: vi.fn(),
-  mockQuery: vi.fn(),
-  mockUpdate: vi.fn(),
-  mockDelete: vi.fn(),
-  mockScanAll: vi.fn(),
-  mockQueryAll: vi.fn(),
+const { mockOverallsListAll, mockMatchesListCompleted, mockPlayersList, mockSeasonStandingsListBySeason } = vi.hoisted(() => ({
+  mockOverallsListAll: vi.fn(),
+  mockMatchesListCompleted: vi.fn(),
+  mockPlayersList: vi.fn(),
+  mockSeasonStandingsListBySeason: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: mockGet,
-    put: mockPut,
-    scan: mockScan,
-    query: mockQuery,
-    update: mockUpdate,
-    delete: mockDelete,
-    scanAll: mockScanAll,
-    queryAll: mockQueryAll,
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    SEASON_STANDINGS: 'SeasonStandings',
-    MATCHES: 'Matches',
-    WRESTLER_OVERALLS: 'WrestlerOveralls',
-    STABLES: 'Stables',
-    TAG_TEAMS: 'TagTeams',
-    STABLE_INVITATIONS: 'StableInvitations',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    overalls: { listAll: mockOverallsListAll },
+    matches: { listCompleted: mockMatchesListCompleted },
+    players: { list: mockPlayersList },
+    seasonStandings: { listBySeason: mockSeasonStandingsListBySeason },
+  }),
 }));
 
 import { handler as getStandings } from '../getStandings';
@@ -56,7 +39,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: { authorizer: {} } as any,
+    requestContext: { authorizer: {} } as unknown as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -67,14 +50,13 @@ describe('getStandings — all-time (no seasonId)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns all players sorted by wins descending', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // completed matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 10, losses: 2, draws: 1 },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 15, losses: 5, draws: 0 },
-        { playerId: 'p3', name: 'Carol', currentWrestler: 'W3', wins: 8, losses: 3, draws: 2 },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 10, losses: 2, draws: 1 },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 15, losses: 5, draws: 0 },
+      { playerId: 'p3', name: 'Carol', currentWrestler: 'W3', wins: 8, losses: 3, draws: 2 },
+    ]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -89,14 +71,13 @@ describe('getStandings — all-time (no seasonId)', () => {
   });
 
   it('breaks ties by losses ascending (fewer losses ranks higher)', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 10, losses: 5, draws: 0 },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 10, losses: 2, draws: 0 },
-        { playerId: 'p3', name: 'Carol', currentWrestler: 'W3', wins: 10, losses: 8, draws: 0 },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 10, losses: 5, draws: 0 },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 10, losses: 2, draws: 0 },
+      { playerId: 'p3', name: 'Carol', currentWrestler: 'W3', wins: 10, losses: 8, draws: 0 },
+    ]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -109,13 +90,12 @@ describe('getStandings — all-time (no seasonId)', () => {
   });
 
   it('defaults missing wins/losses to 0 for sorting', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'NoStats', currentWrestler: 'W1' },
-        { playerId: 'p2', name: 'HasWins', currentWrestler: 'W2', wins: 3, losses: 1 },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'NoStats', currentWrestler: 'W1' },
+      { playerId: 'p2', name: 'HasWins', currentWrestler: 'W2', wins: 3, losses: 1 },
+    ]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -127,7 +107,9 @@ describe('getStandings — all-time (no seasonId)', () => {
   });
 
   it('returns empty array when no players exist', async () => {
-    mockScanAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -138,7 +120,9 @@ describe('getStandings — all-time (no seasonId)', () => {
   });
 
   it('does not include seasonId in response for all-time standings', async () => {
-    mockScanAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -146,25 +130,16 @@ describe('getStandings — all-time (no seasonId)', () => {
     expect(body.seasonId).toBeUndefined();
   });
 
-  it('calls scanAll for Overalls, Matches, then Players', async () => {
-    mockScanAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  it('calls repository methods for overalls, matches, and players', async () => {
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
 
     await getStandings(makeEvent(), ctx, cb);
 
-    expect(mockScanAll).toHaveBeenCalledTimes(3);
-    // First two calls are in Promise.all: overalls + matches
-    expect(mockScanAll).toHaveBeenNthCalledWith(1, {
-      TableName: 'WrestlerOveralls',
-    });
-    expect(mockScanAll).toHaveBeenNthCalledWith(2, {
-      TableName: 'Matches',
-      FilterExpression: '#status = :completed',
-      ExpressionAttributeNames: { '#status': 'status' },
-      ExpressionAttributeValues: { ':completed': 'completed' },
-    });
-    expect(mockScanAll).toHaveBeenNthCalledWith(3, {
-      TableName: 'Players',
-    });
+    expect(mockOverallsListAll).toHaveBeenCalledTimes(1);
+    expect(mockMatchesListCompleted).toHaveBeenCalledTimes(1);
+    expect(mockPlayersList).toHaveBeenCalledTimes(1);
   });
 
   it('includes recentForm and currentStreak on each player (ordered by updatedAt desc)', async () => {
@@ -173,13 +148,12 @@ describe('getStandings — all-time (no seasonId)', () => {
       { date: '2024-01-04', updatedAt: '2024-01-04T12:00:00Z', participants: ['p1', 'p3'], winners: ['p1'], losers: ['p3'], status: 'completed' },
       { date: '2024-01-03', updatedAt: '2024-01-03T12:00:00Z', participants: ['p1', 'p2'], winners: ['p2'], losers: ['p1'], status: 'completed' },
     ];
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce(completedMatches)
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 10, losses: 2, draws: 1 },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 8, losses: 5, draws: 0 },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue(completedMatches);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 10, losses: 2, draws: 1 },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 8, losses: 5, draws: 0 },
+    ]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -198,13 +172,12 @@ describe('getStandings — all-time (no seasonId)', () => {
       { date: '2024-01-06', updatedAt: '2024-01-06T12:00:00Z', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'], status: 'completed' },
       { date: '2024-01-05', participants: ['p1', 'p2'], winners: ['p2'], losers: ['p1'], status: 'completed' }, // no updatedAt
     ];
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce(completedMatches)
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 1, losses: 1, draws: 0 },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 1, losses: 1, draws: 0 },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue(completedMatches);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 1, losses: 1, draws: 0 },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2', wins: 1, losses: 1, draws: 0 },
+    ]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -217,10 +190,9 @@ describe('getStandings — all-time (no seasonId)', () => {
   });
 
   it('returns empty recentForm and zero streak when no completed matches', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([{ playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 0, losses: 0, draws: 0 }]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([{ playerId: 'p1', name: 'Alice', currentWrestler: 'W1', wins: 0, losses: 0, draws: 0 }]);
 
     const result = await getStandings(makeEvent(), ctx, cb);
 
@@ -236,8 +208,9 @@ describe('getStandings — all-time (no seasonId)', () => {
 describe('getStandings — error handling (all-time)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns 500 when scanAll throws', async () => {
-    mockScanAll.mockRejectedValue(new Error('DynamoDB connection failed'));
+  it('returns 500 when a repository method throws', async () => {
+    mockOverallsListAll.mockRejectedValue(new Error('DynamoDB connection failed'));
+    mockMatchesListCompleted.mockRejectedValue(new Error('DynamoDB connection failed'));
 
     const result = await getStandings(makeEvent(), ctx, cb);
 

--- a/backend/functions/standings/__tests__/getStandings-season.test.ts
+++ b/backend/functions/standings/__tests__/getStandings-season.test.ts
@@ -3,37 +3,20 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockGet, mockPut, mockScan, mockQuery, mockUpdate, mockDelete, mockScanAll, mockQueryAll } = vi.hoisted(() => ({
-  mockGet: vi.fn(),
-  mockPut: vi.fn(),
-  mockScan: vi.fn(),
-  mockQuery: vi.fn(),
-  mockUpdate: vi.fn(),
-  mockDelete: vi.fn(),
-  mockScanAll: vi.fn(),
-  mockQueryAll: vi.fn(),
+const { mockOverallsListAll, mockMatchesListCompleted, mockPlayersList, mockSeasonStandingsListBySeason } = vi.hoisted(() => ({
+  mockOverallsListAll: vi.fn(),
+  mockMatchesListCompleted: vi.fn(),
+  mockPlayersList: vi.fn(),
+  mockSeasonStandingsListBySeason: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: mockGet,
-    put: mockPut,
-    scan: mockScan,
-    query: mockQuery,
-    update: mockUpdate,
-    delete: mockDelete,
-    scanAll: mockScanAll,
-    queryAll: mockQueryAll,
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    SEASON_STANDINGS: 'SeasonStandings',
-    MATCHES: 'Matches',
-    WRESTLER_OVERALLS: 'WrestlerOveralls',
-    STABLES: 'Stables',
-    TAG_TEAMS: 'TagTeams',
-    STABLE_INVITATIONS: 'StableInvitations',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    overalls: { listAll: mockOverallsListAll },
+    matches: { listCompleted: mockMatchesListCompleted },
+    players: { list: mockPlayersList },
+    seasonStandings: { listBySeason: mockSeasonStandingsListBySeason },
+  }),
 }));
 
 import { handler as getStandings } from '../getStandings';
@@ -56,7 +39,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: { authorizer: {} } as any,
+    requestContext: { authorizer: {} } as unknown as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -73,18 +56,17 @@ describe('getStandings — season-specific (with seasonId)', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns season standings merged with all players', async () => {
-    mockQueryAll.mockResolvedValue([
+    mockSeasonStandingsListBySeason.mockResolvedValue([
       { seasonId: 's1', playerId: 'p1', wins: 5, losses: 2, draws: 1 },
       { seasonId: 's1', playerId: 'p2', wins: 8, losses: 3, draws: 0 },
     ]);
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // completed matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'Wrestler A' },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'Wrestler B' },
-        { playerId: 'p3', name: 'Carol', currentWrestler: 'Wrestler C' },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'Wrestler A' },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'Wrestler B' },
+      { playerId: 'p3', name: 'Carol', currentWrestler: 'Wrestler C' },
+    ]);
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -113,14 +95,13 @@ describe('getStandings — season-specific (with seasonId)', () => {
   });
 
   it('gives 0-0-0 to players without season standings', async () => {
-    mockQueryAll.mockResolvedValue([]); // no standings at all
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1' },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2' },
-      ]);
+    mockSeasonStandingsListBySeason.mockResolvedValue([]); // no standings at all
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1' },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2' },
+    ]);
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -136,19 +117,18 @@ describe('getStandings — season-specific (with seasonId)', () => {
   });
 
   it('sorts season standings by wins desc then losses asc', async () => {
-    mockQueryAll.mockResolvedValue([
+    mockSeasonStandingsListBySeason.mockResolvedValue([
       { seasonId: 's1', playerId: 'p1', wins: 5, losses: 4, draws: 0 },
       { seasonId: 's1', playerId: 'p2', wins: 5, losses: 1, draws: 0 },
       { seasonId: 's1', playerId: 'p3', wins: 7, losses: 3, draws: 0 },
     ]);
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1' },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2' },
-        { playerId: 'p3', name: 'Carol', currentWrestler: 'W3' },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1' },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2' },
+      { playerId: 'p3', name: 'Carol', currentWrestler: 'W3' },
+    ]);
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -160,8 +140,10 @@ describe('getStandings — season-specific (with seasonId)', () => {
   });
 
   it('returns empty players when no players exist for a season', async () => {
-    mockQueryAll.mockResolvedValue([]);
-    mockScanAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockSeasonStandingsListBySeason.mockResolvedValue([]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -171,44 +153,43 @@ describe('getStandings — season-specific (with seasonId)', () => {
     expect(body.seasonId).toBe('s1');
   });
 
-  it('queries SeasonStandings table with correct seasonId', async () => {
-    mockQueryAll.mockResolvedValue([]);
-    mockScanAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  it('calls seasonStandings.listBySeason with correct seasonId', async () => {
+    mockSeasonStandingsListBySeason.mockResolvedValue([]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
 
     await getStandings(makeSeasonEvent('season-42'), ctx, cb);
 
-    expect(mockQueryAll).toHaveBeenCalledTimes(1);
-    expect(mockQueryAll).toHaveBeenCalledWith({
-      TableName: 'SeasonStandings',
-      KeyConditionExpression: 'seasonId = :seasonId',
-      ExpressionAttributeValues: { ':seasonId': 'season-42' },
-    });
+    expect(mockSeasonStandingsListBySeason).toHaveBeenCalledTimes(1);
+    expect(mockSeasonStandingsListBySeason).toHaveBeenCalledWith('season-42');
   });
 
-  it('scans Overalls, Matches, then Players when fetching season standings', async () => {
-    mockQueryAll.mockResolvedValue([]);
-    mockScanAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  it('calls repository methods for overalls, matches, players, and seasonStandings', async () => {
+    mockSeasonStandingsListBySeason.mockResolvedValue([]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([]);
 
     await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
-    expect(mockScanAll).toHaveBeenCalledTimes(3);
-    expect(mockScanAll).toHaveBeenNthCalledWith(1, { TableName: 'WrestlerOveralls' });
-    expect(mockScanAll).toHaveBeenNthCalledWith(2, expect.objectContaining({ TableName: 'Matches' }));
-    expect(mockScanAll).toHaveBeenNthCalledWith(3, { TableName: 'Players' });
+    expect(mockOverallsListAll).toHaveBeenCalledTimes(1);
+    expect(mockMatchesListCompleted).toHaveBeenCalledTimes(1);
+    expect(mockPlayersList).toHaveBeenCalledTimes(1);
+    expect(mockSeasonStandingsListBySeason).toHaveBeenCalledTimes(1);
   });
 
   it('handles standings with falsy wins/losses/draws (defaults to 0)', async () => {
-    mockQueryAll.mockResolvedValue([
+    mockSeasonStandingsListBySeason.mockResolvedValue([
       { seasonId: 's1', playerId: 'p1', wins: 0, losses: 0, draws: 0 },
       { seasonId: 's1', playerId: 'p2', wins: undefined, losses: undefined, draws: undefined },
     ]);
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'W1' },
-        { playerId: 'p2', name: 'Bob', currentWrestler: 'W2' },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'W1' },
+      { playerId: 'p2', name: 'Bob', currentWrestler: 'W2' },
+    ]);
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -223,15 +204,14 @@ describe('getStandings — season-specific (with seasonId)', () => {
   });
 
   it('preserves original player fields in season standings response', async () => {
-    mockQueryAll.mockResolvedValue([
+    mockSeasonStandingsListBySeason.mockResolvedValue([
       { seasonId: 's1', playerId: 'p1', wins: 3, losses: 1, draws: 0 },
     ]);
-    mockScanAll
-      .mockResolvedValueOnce([]) // overalls
-      .mockResolvedValueOnce([]) // matches
-      .mockResolvedValueOnce([
-        { playerId: 'p1', name: 'Alice', currentWrestler: 'The Rock', divisionId: 'div-1' },
-      ]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockResolvedValue([
+      { playerId: 'p1', name: 'Alice', currentWrestler: 'The Rock', divisionId: 'div-1' },
+    ]);
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -248,8 +228,10 @@ describe('getStandings — season-specific (with seasonId)', () => {
 describe('getStandings — error handling (season)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns 500 when queryAll throws', async () => {
-    mockQueryAll.mockRejectedValue(new Error('DynamoDB query failed'));
+  it('returns 500 when seasonStandings.listBySeason throws', async () => {
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockSeasonStandingsListBySeason.mockRejectedValue(new Error('DynamoDB query failed'));
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 
@@ -257,12 +239,11 @@ describe('getStandings — error handling (season)', () => {
     expect(JSON.parse(result!.body).message).toBe('Failed to fetch standings');
   });
 
-  it('returns 500 when scanAll (players) throws during season query', async () => {
-    mockQueryAll.mockResolvedValue([]);
-    mockScanAll
-      .mockResolvedValueOnce([]) // Overalls scan succeeds
-      .mockResolvedValueOnce([]) // Matches scan succeeds
-      .mockRejectedValueOnce(new Error('DynamoDB scan failed')); // Players scan fails
+  it('returns 500 when players.list throws during season query', async () => {
+    mockSeasonStandingsListBySeason.mockResolvedValue([]);
+    mockOverallsListAll.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersList.mockRejectedValue(new Error('DynamoDB scan failed'));
 
     const result = await getStandings(makeSeasonEvent('s1'), ctx, cb);
 

--- a/backend/functions/standings/getStandings.ts
+++ b/backend/functions/standings/getStandings.ts
@@ -1,41 +1,35 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getRepositories } from '../../lib/repositories';
+import type { Match } from '../../lib/repositories';
 import { success, serverError } from '../../lib/response';
 
 type FormResult = 'W' | 'L' | 'D';
 
 function getResultForPlayer(
   playerId: string,
-  match: { participants?: string[]; winners?: string[]; losers?: string[]; isDraw?: boolean }
+  match: { participants: string[]; winners?: string[]; losers?: string[]; isDraw?: boolean }
 ): FormResult {
-  const participants = (match.participants || []) as string[];
+  const participants = match.participants || [];
   if (!participants.includes(playerId)) return 'D';
   if (match.isDraw) return 'D';
-  const winners = (match.winners || []) as string[];
-  const losers = (match.losers || []) as string[];
+  const winners = match.winners || [];
+  const losers = match.losers || [];
   if (winners.includes(playerId)) return 'W';
   if (losers.includes(playerId)) return 'L';
   return 'D';
 }
 
-type CompletedMatchForForm = {
-  date?: string;
-  updatedAt?: string;
-  participants?: string[];
-  winners?: string[];
-  losers?: string[];
-  isDraw?: boolean;
-};
+type CompletedMatchForForm = Pick<Match, 'participants' | 'winners' | 'losers' | 'isDraw' | 'updatedAt'>;
 
 function computeRecentFormAndStreak(
   playerId: string,
   completedMatches: CompletedMatchForForm[]
 ): { recentForm: FormResult[]; currentStreak: { type: FormResult; count: number } } {
   const playerMatches = completedMatches
-    .filter((m) => ((m.participants || []) as string[]).includes(playerId))
+    .filter((m) => (m.participants || []).includes(playerId))
     .sort((a, b) => {
-      const aTime = new Date((a.updatedAt ?? 0) as string | number).getTime();
-      const bTime = new Date((b.updatedAt ?? 0) as string | number).getTime();
+      const aTime = new Date(a.updatedAt ?? 0).getTime();
+      const bTime = new Date(b.updatedAt ?? 0).getTime();
       return bTime - aTime;
     })
     .slice(0, 5);
@@ -54,64 +48,52 @@ function computeRecentFormAndStreak(
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
+    const { matches, players, overalls, seasonStandings } = getRepositories();
     const seasonId = event.queryStringParameters?.seasonId;
 
     // Fetch overalls and matches in parallel
     const [overallItems, rawMatches] = await Promise.all([
-      dynamoDb.scanAll({ TableName: TableNames.WRESTLER_OVERALLS }),
-      dynamoDb.scanAll({
-        TableName: TableNames.MATCHES,
-        FilterExpression: '#status = :completed',
-        ExpressionAttributeNames: { '#status': 'status' },
-        ExpressionAttributeValues: { ':completed': 'completed' },
-      }),
+      overalls.listAll(),
+      matches.listCompleted(),
     ]);
 
     const overallsByPlayerId = new Map<string, number>(
       overallItems
         .filter(o => o.mainOverall !== undefined)
-        .map(o => [o.playerId as string, o.mainOverall as number])
+        .map(o => [o.playerId, o.mainOverall])
     );
 
-    let completedMatches = rawMatches;
-
     // Last 5 and streak: only matches with updatedAt (same as dashboard recent results), sort by updatedAt desc
-    completedMatches = completedMatches.filter((m) => m.updatedAt) as typeof completedMatches;
+    const completedMatches = rawMatches.filter((m) => m.updatedAt);
 
     if (seasonId) {
       // Get season-specific standings with pagination support
-      const seasonStandings = await dynamoDb.queryAll({
-        TableName: TableNames.SEASON_STANDINGS,
-        KeyConditionExpression: 'seasonId = :seasonId',
-        ExpressionAttributeValues: { ':seasonId': seasonId },
-      });
+      const seasonStandingsList = await seasonStandings.listBySeason(seasonId);
 
       // Get all player details with pagination support
-      const allPlayers = await dynamoDb.scanAll({
-        TableName: TableNames.PLAYERS,
-      });
+      const allPlayers = await players.list();
 
       // Only include players who have a wrestler assigned (exclude Fantasy-only users)
-      const players = allPlayers.filter((p) => p.currentWrestler);
+      const filteredPlayers = allPlayers.filter((p) => p.currentWrestler);
 
       // Build a map of season standings by playerId
       const standingsMap = new Map(
-        seasonStandings.map((s) => [s.playerId as string, s])
+        seasonStandingsList.map((s) => [s.playerId, s])
       );
 
       // Show ALL players - those with standings get season W-L-D, others get 0-0-0
-      const standings = players.map((player) => {
-        const standing = standingsMap.get(player.playerId as string);
+      const standings = filteredPlayers.map((player) => {
+        const standing = standingsMap.get(player.playerId);
         const { recentForm, currentStreak } = computeRecentFormAndStreak(
-          player.playerId as string,
+          player.playerId,
           completedMatches
         );
-        const mainOverall = overallsByPlayerId.get(player.playerId as string);
+        const mainOverall = overallsByPlayerId.get(player.playerId);
         return {
           ...player,
-          wins: standing ? ((standing.wins as number) || 0) : 0,
-          losses: standing ? ((standing.losses as number) || 0) : 0,
-          draws: standing ? ((standing.draws as number) || 0) : 0,
+          wins: standing ? (standing.wins || 0) : 0,
+          losses: standing ? (standing.losses || 0) : 0,
+          draws: standing ? (standing.draws || 0) : 0,
           recentForm,
           currentStreak,
           ...(mainOverall !== undefined ? { mainOverall } : {}),
@@ -134,19 +116,17 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     // Default: get all-time standings from Players table with pagination support
-    const allPlayers = await dynamoDb.scanAll({
-      TableName: TableNames.PLAYERS,
-    });
+    const allPlayers = await players.list();
 
     // Only include players who have a wrestler assigned (exclude Fantasy-only users)
     const wrestlers = allPlayers.filter((p) => p.currentWrestler);
 
     // Sort players by wins descending, then by losses ascending
-    const players = wrestlers.sort((a, b) => {
-      const aWins = (a.wins as number) || 0;
-      const bWins = (b.wins as number) || 0;
-      const aLosses = (a.losses as number) || 0;
-      const bLosses = (b.losses as number) || 0;
+    const sortedPlayers = wrestlers.sort((a, b) => {
+      const aWins = a.wins || 0;
+      const bWins = b.wins || 0;
+      const aLosses = a.losses || 0;
+      const bLosses = b.losses || 0;
 
       if (bWins !== aWins) {
         return bWins - aWins;
@@ -154,12 +134,12 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return aLosses - bLosses;
     });
 
-    const playersWithForm = players.map((player) => {
+    const playersWithForm = sortedPlayers.map((player) => {
       const { recentForm, currentStreak } = computeRecentFormAndStreak(
-        player.playerId as string,
+        player.playerId,
         completedMatches
       );
-      const mainOverall = overallsByPlayerId.get(player.playerId as string);
+      const mainOverall = overallsByPlayerId.get(player.playerId);
       return { ...player, recentForm, currentStreak, ...(mainOverall !== undefined ? { mainOverall } : {}) };
     });
 

--- a/backend/functions/statistics/__tests__/getStatistics-achievements.test.ts
+++ b/backend/functions/statistics/__tests__/getStatistics-achievements.test.ts
@@ -3,27 +3,23 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockScanAll } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
+const { mockPlayersList, mockMatchesList, mockChampionshipsListAllHistory, mockChampionshipsList, mockMatchTypesList, mockStipulationsList } = vi.hoisted(() => ({
+  mockPlayersList: vi.fn(),
+  mockMatchesList: vi.fn(),
+  mockChampionshipsListAllHistory: vi.fn(),
+  mockChampionshipsList: vi.fn(),
+  mockMatchTypesList: vi.fn(),
+  mockStipulationsList: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: vi.fn(),
-    put: vi.fn(),
-    scan: vi.fn(),
-    query: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    scanAll: mockScanAll,
-    queryAll: vi.fn(),
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    MATCHES: 'Matches',
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    players: { list: mockPlayersList },
+    matches: { list: mockMatchesList },
+    championships: { listAllHistory: mockChampionshipsListAllHistory, list: mockChampionshipsList },
+    matchTypes: { list: mockMatchTypesList },
+    stipulations: { list: mockStipulationsList },
+  }),
 }));
 
 import { handler } from '../getStatistics';
@@ -46,7 +42,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: {} as any,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -81,15 +77,22 @@ function makeMatch(overrides: Record<string, unknown> = {}) {
 const player1 = makePlayer('p1', 'Player One', 'Wrestler A');
 const player2 = makePlayer('p2', 'Player Two', 'Wrestler B');
 
+function setupDefaultMocks(players: unknown[] = [], matches: unknown[] = [], champHistory: unknown[] = [], championships: unknown[] = []) {
+  mockPlayersList.mockResolvedValue(players);
+  mockMatchesList.mockResolvedValue(matches);
+  mockChampionshipsListAllHistory.mockResolvedValue(champHistory);
+  mockChampionshipsList.mockResolvedValue(championships);
+  mockMatchTypesList.mockResolvedValue([]);
+  mockStipulationsList.mockResolvedValue([]);
+}
+
 // ─── Achievements Section ────────────────────────────────────────────
 
 describe('getStatistics - achievements', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns all 18 achievement definitions and player list when no playerId specified', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce([]);                  // MATCHES
+    setupDefaultMocks([player1, player2], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements' },
@@ -104,7 +107,7 @@ describe('getStatistics - achievements', () => {
     expect(body.achievements).toBeUndefined();
 
     // Verify achievement types are correct
-    const types = new Set(body.allAchievements.map((a: any) => a.achievementType));
+    const types = new Set(body.allAchievements.map((a: Record<string, unknown>) => a.achievementType));
     expect(types).toContain('milestone');
     expect(types).toContain('record');
     expect(types).toContain('special');
@@ -122,11 +125,7 @@ describe('getStatistics - achievements', () => {
       })
     );
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -136,7 +135,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a1'); // First Victory (1+ wins)
     expect(ids).toContain('a2'); // Double Digits (10+ wins)
@@ -164,11 +163,7 @@ describe('getStatistics - achievements', () => {
       })
     );
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])            // PLAYERS
-      .mockResolvedValueOnce([...winMatches, ...lossMatches]) // MATCHES
-      .mockResolvedValueOnce([])                             // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                            // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], [...winMatches, ...lossMatches], [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -178,7 +173,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a4'); // Century Mark
     expect(ids).toContain('a5'); // Iron Man
@@ -196,11 +191,7 @@ describe('getStatistics - achievements', () => {
       })
     );
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -210,14 +201,14 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a18'); // Best in the World (10+ streak)
     expect(ids).toContain('a6');  // Unstoppable Force (15+ streak)
 
     // Verify metadata on a18
-    const bestInWorld = body.achievements.find((a: any) => a.achievementId === 'a18');
-    expect(bestInWorld.metadata.streakLength).toBe(15);
+    const bestInWorld = body.achievements.find((a: Record<string, unknown>) => a.achievementId === 'a18');
+    expect((bestInWorld.metadata as Record<string, unknown>).streakLength).toBe(15);
   });
 
   it('awards Dominant Champion (a7) for 180+ day reign', async () => {
@@ -233,11 +224,7 @@ describe('getStatistics - achievements', () => {
       { championshipId: 'c1', name: 'World Title', type: 'singles' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)         // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);       // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -247,7 +234,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a7'); // Dominant Champion
   });
@@ -264,11 +251,7 @@ describe('getStatistics - achievements', () => {
       })
     );
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -278,7 +261,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a8'); // Title Collector
   });
@@ -298,11 +281,7 @@ describe('getStatistics - achievements', () => {
       { championshipId: 'c2', name: 'IC Title', type: 'singles' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)         // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);       // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -312,7 +291,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a9'); // Grand Slam
   });
@@ -332,11 +311,7 @@ describe('getStatistics - achievements', () => {
       { championshipId: 'c2', name: 'IC Title', type: 'singles' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)         // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);       // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -346,7 +321,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).not.toContain('a9');
   });
@@ -365,11 +340,7 @@ describe('getStatistics - achievements', () => {
       })
     );
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -379,7 +350,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     // Cage Master cannot be earned since no matches categorize as 'cage' anymore
     expect(ids).not.toContain('a12');
@@ -395,11 +366,7 @@ describe('getStatistics - achievements', () => {
       makeMatch({ matchId: 'w1', date: '2024-05-01', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -409,7 +376,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a13'); // Deadman Walking
   });
@@ -423,11 +390,7 @@ describe('getStatistics - achievements', () => {
       makeMatch({ matchId: 'w1', date: '2024-04-01', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -437,7 +400,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).not.toContain('a13');
   });
@@ -459,11 +422,7 @@ describe('getStatistics - achievements', () => {
       { championshipId: 'c3', name: 'US Title', type: 'singles' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)         // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);       // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'achievements', playerId: 'p1' },
@@ -473,7 +432,7 @@ describe('getStatistics - achievements', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const ids = body.achievements.map((a: any) => a.achievementId);
+    const ids = body.achievements.map((a: Record<string, unknown>) => a.achievementId);
 
     expect(ids).toContain('a15'); // Peoples Champion
   });
@@ -491,11 +450,7 @@ describe('getStatistics - helper functions', () => {
       makeMatch({ matchId: 'm1', matchFormat: 'Singles', stipulationId: 'stip-ladder-1', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1])   // PLAYERS
-      .mockResolvedValueOnce(matches)     // MATCHES
-      .mockResolvedValueOnce([])          // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);         // CHAMPIONSHIPS
+    setupDefaultMocks([player1], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -506,10 +461,10 @@ describe('getStatistics - helper functions', () => {
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
     // Should count in singles, not ladder
-    const singlesStats = body.statistics.find((s: any) => s.statType === 'singles');
+    const singlesStats = body.statistics.find((s: Record<string, unknown>) => s.statType === 'singles');
     expect(singlesStats.wins).toBe(1);
     expect(singlesStats.matchesPlayed).toBe(1);
-    const ladderStats = body.statistics.find((s: any) => s.statType === 'ladder');
+    const ladderStats = body.statistics.find((s: Record<string, unknown>) => s.statType === 'ladder');
     expect(ladderStats.wins).toBe(0);
     expect(ladderStats.matchesPlayed).toBe(0);
   });
@@ -523,11 +478,7 @@ describe('getStatistics - helper functions', () => {
       makeMatch({ matchId: 'm3', matchFormat: 'Singles', stipulationId: 'stip-hiac-2', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -538,10 +489,10 @@ describe('getStatistics - helper functions', () => {
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
     // Should count in singles, not cage
-    const singlesStats = body.statistics.find((s: any) => s.statType === 'singles');
+    const singlesStats = body.statistics.find((s: Record<string, unknown>) => s.statType === 'singles');
     expect(singlesStats.wins).toBe(3);
     expect(singlesStats.matchesPlayed).toBe(3);
-    const cageStats = body.statistics.find((s: any) => s.statType === 'cage');
+    const cageStats = body.statistics.find((s: Record<string, unknown>) => s.statType === 'cage');
     expect(cageStats.wins).toBe(0);
     expect(cageStats.matchesPlayed).toBe(0);
   });
@@ -552,11 +503,7 @@ describe('getStatistics - helper functions', () => {
       makeMatch({ matchId: 'm2', matchFormat: '6-Man Tag', participants: ['p1', 'p2', 'p3'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -566,7 +513,7 @@ describe('getStatistics - helper functions', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const tagStats = body.statistics.find((s: any) => s.statType === 'tag');
+    const tagStats = body.statistics.find((s: Record<string, unknown>) => s.statType === 'tag');
     expect(tagStats.wins).toBe(2);
     expect(tagStats.matchesPlayed).toBe(2);
   });
@@ -582,11 +529,7 @@ describe('getStatistics - helper functions', () => {
       makeMatch({ matchId: 'm6', date: '2024-06-01', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -596,7 +539,7 @@ describe('getStatistics - helper functions', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const overall = body.statistics.find((s: any) => s.statType === 'overall');
+    const overall = body.statistics.find((s: Record<string, unknown>) => s.statType === 'overall');
 
     expect(overall.longestWinStreak).toBe(3);
     expect(overall.currentWinStreak).toBe(2);
@@ -616,11 +559,7 @@ describe('getStatistics - helper functions', () => {
       makeMatch({ matchId: 'm6', date: '2024-10-15', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'], status: 'pending' }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -630,7 +569,7 @@ describe('getStatistics - helper functions', () => {
 
     expect(result!.statusCode).toBe(200);
     const body = JSON.parse(result!.body);
-    const overall = body.statistics.find((s: any) => s.statType === 'overall');
+    const overall = body.statistics.find((s: Record<string, unknown>) => s.statType === 'overall');
 
     expect(overall.wins).toBe(3);
     expect(overall.losses).toBe(1);

--- a/backend/functions/statistics/__tests__/getStatistics-leaderboards.test.ts
+++ b/backend/functions/statistics/__tests__/getStatistics-leaderboards.test.ts
@@ -3,27 +3,23 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockScanAll } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
+const { mockPlayersList, mockMatchesList, mockChampionshipsListAllHistory, mockChampionshipsList, mockMatchTypesList, mockStipulationsList } = vi.hoisted(() => ({
+  mockPlayersList: vi.fn(),
+  mockMatchesList: vi.fn(),
+  mockChampionshipsListAllHistory: vi.fn(),
+  mockChampionshipsList: vi.fn(),
+  mockMatchTypesList: vi.fn(),
+  mockStipulationsList: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: vi.fn(),
-    put: vi.fn(),
-    scan: vi.fn(),
-    query: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    scanAll: mockScanAll,
-    queryAll: vi.fn(),
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    MATCHES: 'Matches',
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    players: { list: mockPlayersList },
+    matches: { list: mockMatchesList },
+    championships: { listAllHistory: mockChampionshipsListAllHistory, list: mockChampionshipsList },
+    matchTypes: { list: mockMatchTypesList },
+    stipulations: { list: mockStipulationsList },
+  }),
 }));
 
 import { handler } from '../getStatistics';
@@ -46,7 +42,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: {} as any,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -82,6 +78,15 @@ const player1 = makePlayer('p1', 'Alpha', 'Wrestler A');
 const player2 = makePlayer('p2', 'Beta', 'Wrestler B');
 const player3 = makePlayer('p3', 'Gamma', 'Wrestler C');
 
+function setupDefaultMocks(players: unknown[] = [], matches: unknown[] = [], champHistory: unknown[] = []) {
+  mockPlayersList.mockResolvedValue(players);
+  mockMatchesList.mockResolvedValue(matches);
+  mockChampionshipsListAllHistory.mockResolvedValue(champHistory);
+  mockChampionshipsList.mockResolvedValue([]);
+  mockMatchTypesList.mockResolvedValue([]);
+  mockStipulationsList.mockResolvedValue([]);
+}
+
 // ─── Leaderboards Section ────────────────────────────────────────────
 
 describe('getStatistics - leaderboards', () => {
@@ -96,10 +101,7 @@ describe('getStatistics - leaderboards', () => {
       makeMatch({ matchId: 'm4', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'leaderboards' },
@@ -129,10 +131,7 @@ describe('getStatistics - leaderboards', () => {
       makeMatch({ matchId: 'm3', participants: ['p1', 'p2'], winners: ['p2'], losers: ['p1'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'leaderboards' },
@@ -144,11 +143,7 @@ describe('getStatistics - leaderboards', () => {
     const body = JSON.parse(result!.body);
     const bestWinPct = body.leaderboards.bestWinPercentage;
 
-    // p3 has 0 matches and 1 loss, so p3 has 1 match actually (loss in m2)
     // p2: 1W 1L = 50%, p1: 2W 1L = 66.7%, p3: 0W 1L = 0%
-    // Wait, let me reconsider: p2 participates in m1 (loss) and m3 (win) = 1W 1L = 50%
-    // p3 participates in m2 (loss) = 0W 1L = 0%
-    // p1: 2W 1L = 66.7%
     // Sorted: p1 (66.7%), p2 (50%), p3 (0%)
     expect(bestWinPct[0].playerName).toBe('Alpha');
     expect(bestWinPct[0].value).toBe(66.7);
@@ -165,10 +160,7 @@ describe('getStatistics - leaderboards', () => {
       makeMatch({ matchId: 'm4', date: '2024-04-01', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'leaderboards' },
@@ -193,10 +185,7 @@ describe('getStatistics - leaderboards', () => {
       makeMatch({ matchId: 'm3', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'], isChampionship: true }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'leaderboards' },
@@ -221,10 +210,7 @@ describe('getStatistics - leaderboards', () => {
       { championshipId: 'c2', champion: 'p3', wonDate: '2024-01-01', lostDate: '2024-02-01', daysHeld: 31 },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce([])                            // MATCHES
-      .mockResolvedValueOnce(champHistory);                 // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], [], champHistory);
 
     const event = makeEvent({
       queryStringParameters: { section: 'leaderboards' },
@@ -272,10 +258,7 @@ describe('getStatistics - records', () => {
       matches.push(makeMatch({ matchId: `d${i}`, date: `2024-04-${String(i + 1).padStart(2, '0')}`, participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }));
     }
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'records' },
@@ -321,10 +304,7 @@ describe('getStatistics - records', () => {
       { championshipId: 'c1', champion: 'p2', wonDate: '2024-07-01', lostDate: '2024-08-01', daysHeld: 31, defenses: 1 },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce(champHistory);                 // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, champHistory);
 
     const event = makeEvent({
       queryStringParameters: { section: 'records' },
@@ -339,17 +319,17 @@ describe('getStatistics - records', () => {
     expect(champRecords).toHaveLength(4);
 
     // Longest Single Reign: p1 with 182 days
-    const longestReign = champRecords.find((r: any) => r.recordName === 'Longest Single Reign');
+    const longestReign = champRecords.find((r: Record<string, unknown>) => r.recordName === 'Longest Single Reign');
     expect(longestReign.holderName).toBe('Alpha');
     expect(longestReign.value).toBe('182 days');
 
     // Most Title Defenses: p1 with 5
-    const mostDefenses = champRecords.find((r: any) => r.recordName === 'Most Title Defenses');
+    const mostDefenses = champRecords.find((r: Record<string, unknown>) => r.recordName === 'Most Title Defenses');
     expect(mostDefenses.holderName).toBe('Alpha');
     expect(mostDefenses.value).toBe(5);
 
     // Most Defenses in Single Reign: p1 with 5
-    const mostDefSingleReign = champRecords.find((r: any) => r.recordName === 'Most Defenses in Single Reign');
+    const mostDefSingleReign = champRecords.find((r: Record<string, unknown>) => r.recordName === 'Most Defenses in Single Reign');
     expect(mostDefSingleReign.value).toBe(5);
   });
 
@@ -365,10 +345,7 @@ describe('getStatistics - records', () => {
       makeMatch({ matchId: 'm6', date: '2024-06-01', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'records' },
@@ -383,13 +360,12 @@ describe('getStatistics - records', () => {
     expect(streakRecords).toHaveLength(4);
 
     // Longest Win Streak: p1 with 4
-    const longestWin = streakRecords.find((r: any) => r.recordName === 'Longest Win Streak');
+    const longestWin = streakRecords.find((r: Record<string, unknown>) => r.recordName === 'Longest Win Streak');
     expect(longestWin.holderName).toBe('Alpha');
     expect(longestWin.value).toBe(4);
 
-    // Longest Loss Streak: p2 with 3 (lost m1, m3, m4 - but m1 and m3 are not consecutive for p2)
-    // Actually p2: m1 loss, m3 loss, m4 loss, m5 win, m6 win => streak of 3
-    const longestLoss = streakRecords.find((r: any) => r.recordName === 'Longest Loss Streak');
+    // Longest Loss Streak: p2 with 3
+    const longestLoss = streakRecords.find((r: Record<string, unknown>) => r.recordName === 'Longest Loss Streak');
     expect(longestLoss.value).toBe(3);
   });
 
@@ -412,10 +388,7 @@ describe('getStatistics - records', () => {
       makeMatch({ matchId: 'l2', matchFormat: 'Singles', stipulationId: 'stip-ladder-1', participants: ['p2', 'p3'], winners: ['p3'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'records' },
@@ -430,24 +403,21 @@ describe('getStatistics - records', () => {
     expect(matchTypeRecords).toHaveLength(4);
 
     // All Singles-format matches (including those with cage/ladder stipulationId) are now singles
-    // p1: s1(W), s2(W), c1(W), c2(W), c3(W), l1(L) = 5 wins, 1 loss in singles
-    // p2: s3(W), c1(L), c2(L), c3(L), l2(L) = 1 win, 4 losses in singles
-    // p3: s2(L), s3(L), l1(W), l2(W) = 2 wins, 2 losses in singles
-    const singlesRecord = matchTypeRecords.find((r: any) => r.recordName === 'Most Singles Wins');
+    const singlesRecord = matchTypeRecords.find((r: Record<string, unknown>) => r.recordName === 'Most Singles Wins');
     expect(singlesRecord.holderName).toBe('Alpha');
     expect(singlesRecord.value).toBe(5);
 
-    const tagRecord = matchTypeRecords.find((r: any) => r.recordName === 'Most Tag Team Wins');
+    const tagRecord = matchTypeRecords.find((r: Record<string, unknown>) => r.recordName === 'Most Tag Team Wins');
     expect(tagRecord.holderName).toBe('Beta');
     expect(tagRecord.value).toBe(2);
 
     // No matches categorize as cage or ladder anymore (format-only categorization)
-    const cageRecord = matchTypeRecords.find((r: any) => r.recordName === 'Best Cage Match Record');
+    const cageRecord = matchTypeRecords.find((r: Record<string, unknown>) => r.recordName === 'Best Cage Match Record');
     expect(cageRecord.holderName).toBe('N/A');
     expect(cageRecord.value).toBe('0%');
 
     // mostLadderWins returns first player with 0 wins (all tied at 0)
-    const ladderRecord = matchTypeRecords.find((r: any) => r.recordName === 'Most Ladder Match Wins');
+    const ladderRecord = matchTypeRecords.find((r: Record<string, unknown>) => r.recordName === 'Most Ladder Match Wins');
     expect(ladderRecord.value).toBe(0);
   });
 
@@ -465,10 +435,7 @@ describe('getStatistics - records', () => {
       makeMatch({ matchId: 'm9', date: '2024-09-01', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches)                       // MATCHES
-      .mockResolvedValueOnce([]);                           // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2, player3], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'records' },
@@ -483,14 +450,14 @@ describe('getStatistics - records', () => {
     expect(Array.isArray(body.activeThreats)).toBe(true);
 
     // Should have at least "Most Career Wins" threat
-    const winsThread = body.activeThreats.find((t: any) => t.recordName === 'Most Career Wins');
+    const winsThread = body.activeThreats.find((t: Record<string, unknown>) => t.recordName === 'Most Career Wins');
     expect(winsThread).toBeDefined();
     expect(winsThread.currentValue).toBe(5);
     expect(winsThread.threatValue).toBe(4);
     expect(winsThread.gapDescription).toBe('1 wins behind');
 
     // Should have "Longest Win Streak" threat since p2 has active streak of 4
-    const streakThreat = body.activeThreats.find((t: any) => t.recordName === 'Longest Win Streak');
+    const streakThreat = body.activeThreats.find((t: Record<string, unknown>) => t.recordName === 'Longest Win Streak');
     expect(streakThreat).toBeDefined();
     expect(streakThreat.threatValue).toBe('5 active');
   });

--- a/backend/functions/statistics/__tests__/getStatistics-match-types.test.ts
+++ b/backend/functions/statistics/__tests__/getStatistics-match-types.test.ts
@@ -1,29 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
-const { mockScanAll } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
+const { mockPlayersList, mockMatchesList, mockChampionshipsListAllHistory, mockChampionshipsList, mockMatchTypesList, mockStipulationsList } = vi.hoisted(() => ({
+  mockPlayersList: vi.fn(),
+  mockMatchesList: vi.fn(),
+  mockChampionshipsListAllHistory: vi.fn(),
+  mockChampionshipsList: vi.fn(),
+  mockMatchTypesList: vi.fn(),
+  mockStipulationsList: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: vi.fn(),
-    put: vi.fn(),
-    scan: vi.fn(),
-    query: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    scanAll: mockScanAll,
-    queryAll: vi.fn(),
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    MATCHES: 'Matches',
-    MATCH_TYPES: 'MatchTypes',
-    STIPULATIONS: 'Stipulations',
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    players: { list: mockPlayersList },
+    matches: { list: mockMatchesList },
+    championships: { listAllHistory: mockChampionshipsListAllHistory, list: mockChampionshipsList },
+    matchTypes: { list: mockMatchTypesList },
+    stipulations: { list: mockStipulationsList },
+  }),
 }));
 
 import { handler } from '../getStatistics';
@@ -44,7 +38,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: {} as any,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -76,6 +70,15 @@ function makeMatch(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function setupDefaultMocks(players: unknown[] = [], matches: unknown[] = [], matchTypes: unknown[] = [], stipulations: unknown[] = []) {
+  mockPlayersList.mockResolvedValue(players);
+  mockMatchesList.mockResolvedValue(matches);
+  mockChampionshipsListAllHistory.mockResolvedValue([]);
+  mockChampionshipsList.mockResolvedValue([]);
+  mockMatchTypesList.mockResolvedValue(matchTypes);
+  mockStipulationsList.mockResolvedValue(stipulations);
+}
+
 describe('getStatistics - match-types section', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -94,16 +97,17 @@ describe('getStatistics - match-types section', () => {
       makeMatch({ participants: ['p3', 'p1'], winners: ['p3'], losers: ['p1'], matchFormat: 'Triple Threat' }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce(players)
-      .mockResolvedValueOnce(matches)
-      .mockResolvedValueOnce([
+    setupDefaultMocks(
+      players,
+      matches,
+      [
         { matchTypeId: 'mt-single', name: 'Single' },
         { matchTypeId: 'mt-tag', name: 'Tag Team' },
-      ])
-      .mockResolvedValueOnce([
+      ],
+      [
         { stipulationId: 'stip-none', name: 'No DQ' },
-      ]);
+      ],
+    );
 
     const result = await handler(makeEvent({
       queryStringParameters: { section: 'match-types' },
@@ -130,14 +134,15 @@ describe('getStatistics - match-types section', () => {
       makeMatch({ participants: ['p3', 'p1'], winners: ['p3'], losers: ['p1'], matchFormat: 'Triple Threat' }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce(players)
-      .mockResolvedValueOnce(matches)
-      .mockResolvedValueOnce([
+    setupDefaultMocks(
+      players,
+      matches,
+      [
         { matchTypeId: 'mt-single', name: 'Single' },
         { matchTypeId: 'mt-tag', name: 'Tag Team' },
-      ])
-      .mockResolvedValueOnce([]);
+      ],
+      [],
+    );
 
     const result = await handler(makeEvent({
       queryStringParameters: { section: 'match-types', matchTypeId: 'mt-tag' },
@@ -174,14 +179,15 @@ describe('getStatistics - match-types section', () => {
       }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce(players)
-      .mockResolvedValueOnce(matches)
-      .mockResolvedValueOnce([{ matchTypeId: 'mt-single', name: 'Single' }])
-      .mockResolvedValueOnce([
+    setupDefaultMocks(
+      players,
+      matches,
+      [{ matchTypeId: 'mt-single', name: 'Single' }],
+      [
         { stipulationId: 'stip-cage', name: 'Steel Cage' },
         { stipulationId: 'stip-ladder', name: 'Ladder Match' },
-      ]);
+      ],
+    );
 
     const result = await handler(makeEvent({
       queryStringParameters: { section: 'match-types', stipulationId: 'stip-cage' },

--- a/backend/functions/statistics/__tests__/getStatistics-matchTypes.test.ts
+++ b/backend/functions/statistics/__tests__/getStatistics-matchTypes.test.ts
@@ -3,32 +3,23 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockScanAll } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
+const { mockPlayersList, mockMatchesList, mockChampionshipsListAllHistory, mockChampionshipsList, mockMatchTypesList, mockStipulationsList } = vi.hoisted(() => ({
+  mockPlayersList: vi.fn(),
+  mockMatchesList: vi.fn(),
+  mockChampionshipsListAllHistory: vi.fn(),
+  mockChampionshipsList: vi.fn(),
+  mockMatchTypesList: vi.fn(),
+  mockStipulationsList: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: vi.fn(),
-    put: vi.fn(),
-    scan: vi.fn(),
-    query: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    scanAll: mockScanAll,
-    queryAll: vi.fn(),
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    MATCHES: 'Matches',
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-    MATCH_TYPES: 'MatchTypes',
-    STIPULATIONS: 'Stipulations',
-    STABLES: 'Stables',
-    TAG_TEAMS: 'TagTeams',
-    STABLE_INVITATIONS: 'StableInvitations',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    players: { list: mockPlayersList },
+    matches: { list: mockMatchesList },
+    championships: { listAllHistory: mockChampionshipsListAllHistory, list: mockChampionshipsList },
+    matchTypes: { list: mockMatchTypesList },
+    stipulations: { list: mockStipulationsList },
+  }),
 }));
 
 import { handler } from '../getStatistics';
@@ -86,6 +77,15 @@ function makeMatch(overrides: Record<string, unknown> = {}) {
 const player1 = makePlayer('p1', 'Player One', 'Wrestler A');
 const player2 = makePlayer('p2', 'Player Two', 'Wrestler B');
 
+function setupDefaultMocks(players: unknown[] = [], matches: unknown[] = [], matchTypes: unknown[] = [], stipulations: unknown[] = []) {
+  mockPlayersList.mockResolvedValue(players);
+  mockMatchesList.mockResolvedValue(matches);
+  mockChampionshipsListAllHistory.mockResolvedValue([]);
+  mockChampionshipsList.mockResolvedValue([]);
+  mockMatchTypesList.mockResolvedValue(matchTypes);
+  mockStipulationsList.mockResolvedValue(stipulations);
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────
 
 describe('getStatistics - match-types section', () => {
@@ -94,19 +94,16 @@ describe('getStatistics - match-types section', () => {
   });
 
   it('returns leaderboard for all matches when no filter applied', async () => {
-    mockScanAll.mockImplementation(({ TableName }: { TableName: string }) => {
-      if (TableName === 'Players') return Promise.resolve([player1, player2]);
-      if (TableName === 'Matches') {
-        return Promise.resolve([
-          makeMatch({ matchFormat: 'Singles', winners: ['p1'], losers: ['p2'] }),
-          makeMatch({ matchFormat: 'Singles', winners: ['p1'], losers: ['p2'] }),
-          makeMatch({ matchFormat: 'Singles', winners: ['p2'], losers: ['p1'] }),
-        ]);
-      }
-      if (TableName === 'MatchTypes') return Promise.resolve([]);
-      if (TableName === 'Stipulations') return Promise.resolve([]);
-      return Promise.resolve([]);
-    });
+    setupDefaultMocks(
+      [player1, player2],
+      [
+        makeMatch({ matchFormat: 'Singles', winners: ['p1'], losers: ['p2'] }),
+        makeMatch({ matchFormat: 'Singles', winners: ['p1'], losers: ['p2'] }),
+        makeMatch({ matchFormat: 'Singles', winners: ['p2'], losers: ['p1'] }),
+      ],
+      [],
+      [],
+    );
 
     const event = makeEvent();
     const result = await handler(event, ctx, cb);
@@ -127,17 +124,14 @@ describe('getStatistics - match-types section', () => {
 
   it('only includes players with matches played', async () => {
     const player3 = makePlayer('p3', 'Player Three', 'Wrestler C');
-    mockScanAll.mockImplementation(({ TableName }: { TableName: string }) => {
-      if (TableName === 'Players') return Promise.resolve([player1, player2, player3]);
-      if (TableName === 'Matches') {
-        return Promise.resolve([
-          makeMatch({ matchFormat: 'Singles', winners: ['p1'], losers: ['p2'] }),
-        ]);
-      }
-      if (TableName === 'MatchTypes') return Promise.resolve([]);
-      if (TableName === 'Stipulations') return Promise.resolve([]);
-      return Promise.resolve([]);
-    });
+    setupDefaultMocks(
+      [player1, player2, player3],
+      [
+        makeMatch({ matchFormat: 'Singles', winners: ['p1'], losers: ['p2'] }),
+      ],
+      [],
+      [],
+    );
 
     const event = makeEvent();
     const result = await handler(event, ctx, cb);
@@ -149,18 +143,15 @@ describe('getStatistics - match-types section', () => {
   });
 
   it('filters by seasonId when provided', async () => {
-    mockScanAll.mockImplementation(({ TableName }: { TableName: string }) => {
-      if (TableName === 'Players') return Promise.resolve([player1, player2]);
-      if (TableName === 'Matches') {
-        return Promise.resolve([
-          makeMatch({ matchFormat: 'Singles', seasonId: 's1', winners: ['p1'], losers: ['p2'] }),
-          makeMatch({ matchFormat: 'Singles', seasonId: 's2', winners: ['p2'], losers: ['p1'] }),
-        ]);
-      }
-      if (TableName === 'MatchTypes') return Promise.resolve([]);
-      if (TableName === 'Stipulations') return Promise.resolve([]);
-      return Promise.resolve([]);
-    });
+    setupDefaultMocks(
+      [player1, player2],
+      [
+        makeMatch({ matchFormat: 'Singles', seasonId: 's1', winners: ['p1'], losers: ['p2'] }),
+        makeMatch({ matchFormat: 'Singles', seasonId: 's2', winners: ['p2'], losers: ['p1'] }),
+      ],
+      [],
+      [],
+    );
 
     const event = makeEvent({
       queryStringParameters: { section: 'match-types', seasonId: 's1' },
@@ -175,7 +166,8 @@ describe('getStatistics - match-types section', () => {
   });
 
   it('returns 500 on error', async () => {
-    mockScanAll.mockRejectedValue(new Error('DynamoDB error'));
+    mockPlayersList.mockRejectedValue(new Error('DynamoDB error'));
+    mockMatchesList.mockResolvedValue([]);
 
     const event = makeEvent();
     const result = await handler(event, ctx, cb);

--- a/backend/functions/statistics/__tests__/getStatistics.test.ts
+++ b/backend/functions/statistics/__tests__/getStatistics.test.ts
@@ -3,27 +3,23 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 // ─── Mocks ───────────────────────────────────────────────────────────
 
-const { mockScanAll } = vi.hoisted(() => ({
-  mockScanAll: vi.fn(),
+const { mockPlayersList, mockMatchesList, mockChampionshipsListAllHistory, mockChampionshipsList, mockMatchTypesList, mockStipulationsList } = vi.hoisted(() => ({
+  mockPlayersList: vi.fn(),
+  mockMatchesList: vi.fn(),
+  mockChampionshipsListAllHistory: vi.fn(),
+  mockChampionshipsList: vi.fn(),
+  mockMatchTypesList: vi.fn(),
+  mockStipulationsList: vi.fn(),
 }));
 
-vi.mock('../../../lib/dynamodb', () => ({
-  dynamoDb: {
-    get: vi.fn(),
-    put: vi.fn(),
-    scan: vi.fn(),
-    query: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    scanAll: mockScanAll,
-    queryAll: vi.fn(),
-  },
-  TableNames: {
-    PLAYERS: 'Players',
-    MATCHES: 'Matches',
-    CHAMPIONSHIPS: 'Championships',
-    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
-  },
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    players: { list: mockPlayersList },
+    matches: { list: mockMatchesList },
+    championships: { listAllHistory: mockChampionshipsListAllHistory, list: mockChampionshipsList },
+    matchTypes: { list: mockMatchTypesList },
+    stipulations: { list: mockStipulationsList },
+  }),
 }));
 
 import { handler } from '../getStatistics';
@@ -46,7 +42,7 @@ function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayPro
     multiValueQueryStringParameters: null,
     stageVariables: null,
     resource: '',
-    requestContext: {} as any,
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
     ...overrides,
   };
 }
@@ -83,6 +79,15 @@ const player1 = makePlayer('p1', 'Player One', 'Wrestler A');
 const player2 = makePlayer('p2', 'Player Two', 'Wrestler B');
 const player3 = makePlayer('p3', 'Player Three', 'Wrestler C');
 
+function setupDefaultMocks(players: unknown[] = [], matches: unknown[] = [], champHistory: unknown[] = [], championships: unknown[] = []) {
+  mockPlayersList.mockResolvedValue(players);
+  mockMatchesList.mockResolvedValue(matches);
+  mockChampionshipsListAllHistory.mockResolvedValue(champHistory);
+  mockChampionshipsList.mockResolvedValue(championships);
+  mockMatchTypesList.mockResolvedValue([]);
+  mockStipulationsList.mockResolvedValue([]);
+}
+
 // ─── Validation Tests ────────────────────────────────────────────────
 
 describe('getStatistics - Validation', () => {
@@ -98,9 +103,7 @@ describe('getStatistics - Validation', () => {
   });
 
   it('returns 400 for an unknown section value', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([player1])  // PLAYERS
-      .mockResolvedValueOnce([]);         // MATCHES
+    setupDefaultMocks([player1], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'invalid-section' },
@@ -113,9 +116,7 @@ describe('getStatistics - Validation', () => {
   });
 
   it('returns player list without stats when head-to-head is missing player IDs', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce([]);                  // MATCHES
+    setupDefaultMocks([player1, player2], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'head-to-head' },
@@ -136,9 +137,7 @@ describe('getStatistics - player-stats', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns only player list when no playerId is specified', async () => {
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce([]);                  // MATCHES
+    setupDefaultMocks([player1, player2], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats' },
@@ -166,11 +165,7 @@ describe('getStatistics - player-stats', () => {
       makeMatch({ matchId: 'm5', matchFormat: 'Singles', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -182,32 +177,32 @@ describe('getStatistics - player-stats', () => {
     const body = JSON.parse(result!.body);
     expect(body.statistics).toHaveLength(5);
 
-    const statTypes = body.statistics.map((s: any) => s.statType);
+    const statTypes = body.statistics.map((s: Record<string, unknown>) => s.statType);
     expect(statTypes).toEqual(['overall', 'singles', 'tag', 'ladder', 'cage']);
 
     // overall: 4 wins, 1 loss
-    const overall = body.statistics.find((s: any) => s.statType === 'overall');
+    const overall = body.statistics.find((s: Record<string, unknown>) => s.statType === 'overall');
     expect(overall.wins).toBe(4);
     expect(overall.losses).toBe(1);
     expect(overall.matchesPlayed).toBe(5);
 
     // singles: m1, m3, m4, m5 (all Singles format, stipulationId no longer affects categorization)
-    const singles = body.statistics.find((s: any) => s.statType === 'singles');
+    const singles = body.statistics.find((s: Record<string, unknown>) => s.statType === 'singles');
     expect(singles.wins).toBe(3);
     expect(singles.losses).toBe(1);
 
     // tag: m2 = 1 win
-    const tag = body.statistics.find((s: any) => s.statType === 'tag');
+    const tag = body.statistics.find((s: Record<string, unknown>) => s.statType === 'tag');
     expect(tag.wins).toBe(1);
     expect(tag.matchesPlayed).toBe(1);
 
     // ladder: categorization is now format-only, so no matches map to ladder
-    const ladder = body.statistics.find((s: any) => s.statType === 'ladder');
+    const ladder = body.statistics.find((s: Record<string, unknown>) => s.statType === 'ladder');
     expect(ladder.wins).toBe(0);
     expect(ladder.matchesPlayed).toBe(0);
 
     // cage: categorization is now format-only, so no matches map to cage
-    const cage = body.statistics.find((s: any) => s.statType === 'cage');
+    const cage = body.statistics.find((s: Record<string, unknown>) => s.statType === 'cage');
     expect(cage.losses).toBe(0);
     expect(cage.wins).toBe(0);
   });
@@ -240,11 +235,7 @@ describe('getStatistics - player-stats', () => {
       { championshipId: 'c1', name: 'World Title', type: 'singles', currentChampion: 'p2' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)         // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);       // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -286,11 +277,7 @@ describe('getStatistics - player-stats', () => {
       { championshipId: 'c-tag', name: 'Tag Titles', type: 'tag', currentChampion: ['p1', 'p2'] },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)         // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);       // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -313,11 +300,7 @@ describe('getStatistics - player-stats', () => {
       makeMatch({ matchId: 'm3', date: '2024-03-01', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -330,7 +313,7 @@ describe('getStatistics - player-stats', () => {
     expect(body.achievements).toBeDefined();
     expect(Array.isArray(body.achievements)).toBe(true);
     // Should at least have "First Victory" (a1)
-    const firstVictory = body.achievements.find((a: any) => a.achievementId === 'a1');
+    const firstVictory = body.achievements.find((a: Record<string, unknown>) => a.achievementId === 'a1');
     expect(firstVictory).toBeDefined();
     expect(firstVictory.achievementName).toBe('First Victory');
   });
@@ -353,11 +336,7 @@ describe('getStatistics - player-stats', () => {
       { championshipId: 'c1', name: 'World Title', type: 'singles', currentChampion: 'p1' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1])        // PLAYERS
-      .mockResolvedValueOnce(matches)           // MATCHES
-      .mockResolvedValueOnce(champHistory)      // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);    // CHAMPIONSHIPS
+    setupDefaultMocks([player1], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1' },
@@ -388,9 +367,7 @@ describe('getStatistics - head-to-head', () => {
       makeMatch({ matchId: 'm4', date: '2024-04-01', participants: ['p1', 'p3'], winners: ['p1'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches);                      // MATCHES
+    setupDefaultMocks([player1, player2, player3], matches);
 
     const event = makeEvent({
       queryStringParameters: { section: 'head-to-head', player1Id: 'p1', player2Id: 'p2' },
@@ -419,9 +396,7 @@ describe('getStatistics - head-to-head', () => {
       })
     );
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches);             // MATCHES
+    setupDefaultMocks([player1, player2], matches);
 
     const event = makeEvent({
       queryStringParameters: { section: 'head-to-head', player1Id: 'p1', player2Id: 'p2' },
@@ -444,9 +419,7 @@ describe('getStatistics - head-to-head', () => {
       makeMatch({ matchId: 'm3', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches);                      // MATCHES
+    setupDefaultMocks([player1, player2, player3], matches);
 
     const event = makeEvent({
       queryStringParameters: { section: 'head-to-head', player1Id: 'p1', player2Id: 'p2' },
@@ -470,9 +443,7 @@ describe('getStatistics - head-to-head', () => {
       makeMatch({ matchId: 'm2', participants: ['p2', 'p3'], winners: ['p2'], losers: ['p3'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2, player3])  // PLAYERS
-      .mockResolvedValueOnce(matches);                      // MATCHES
+    setupDefaultMocks([player1, player2, player3], matches);
 
     const event = makeEvent({
       queryStringParameters: { section: 'head-to-head', player1Id: 'p1', player2Id: 'p2' },
@@ -502,11 +473,7 @@ describe('getStatistics - seasonId filtering', () => {
       makeMatch({ matchId: 'm4', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }), // no seasonId
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1', seasonId: 's1' },
@@ -530,9 +497,7 @@ describe('getStatistics - seasonId filtering', () => {
       makeMatch({ matchId: 'm3', date: '2024-03-01', seasonId: 's2', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches);             // MATCHES
+    setupDefaultMocks([player1, player2], matches);
 
     const event = makeEvent({
       queryStringParameters: { section: 'head-to-head', player1Id: 'p1', player2Id: 'p2', seasonId: 's1' },
@@ -554,10 +519,7 @@ describe('getStatistics - seasonId filtering', () => {
       makeMatch({ matchId: 'm3', seasonId: 's2', participants: ['p1', 'p2'], winners: ['p2'], losers: ['p1'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIP_HISTORY
+    setupDefaultMocks([player1, player2], matches, []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'leaderboards', seasonId: 's1' },
@@ -590,11 +552,7 @@ describe('getStatistics - seasonId filtering', () => {
       { championshipId: 'c1', name: 'World Title', type: 'singles', currentChampion: 'p2' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)          // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);        // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1', seasonId: 's1' },
@@ -617,10 +575,6 @@ describe('getStatistics - seasonId filtering', () => {
   });
 
   it('keeps achievements all-time when seasonId is set', async () => {
-    // Season s1 has only 1 match for p1, but all-time p1 has 3 wins
-    // The season filter applies to stats computation, but achievements
-    // use the filtered completedMatches. However championship-based
-    // achievements use all-time championship history.
     const matches = [
       makeMatch({ matchId: 'm1', seasonId: 's1', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'], isChampionship: true }),
     ];
@@ -637,11 +591,7 @@ describe('getStatistics - seasonId filtering', () => {
       { championshipId: 'c3', name: 'US Title', type: 'singles', currentChampion: 'p2' },
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce(champHistory)          // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce(championships);        // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, champHistory, championships);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1', seasonId: 's1' },
@@ -667,11 +617,7 @@ describe('getStatistics - seasonId filtering', () => {
       makeMatch({ matchId: 'm1', seasonId: 's1', participants: ['p1', 'p2'], winners: ['p1'], losers: ['p2'] }),
     ];
 
-    mockScanAll
-      .mockResolvedValueOnce([player1, player2])  // PLAYERS
-      .mockResolvedValueOnce(matches)              // MATCHES
-      .mockResolvedValueOnce([])                   // CHAMPIONSHIP_HISTORY
-      .mockResolvedValueOnce([]);                  // CHAMPIONSHIPS
+    setupDefaultMocks([player1, player2], matches, [], []);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats', playerId: 'p1', seasonId: 'nonexistent' },
@@ -694,7 +640,8 @@ describe('getStatistics - error handling', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 500 when database call throws an error', async () => {
-    mockScanAll.mockRejectedValueOnce(new Error('DynamoDB connection failed'));
+    mockPlayersList.mockRejectedValue(new Error('DynamoDB connection failed'));
+    mockMatchesList.mockResolvedValue([]);
 
     const event = makeEvent({
       queryStringParameters: { section: 'player-stats' },

--- a/backend/functions/statistics/getStatistics.ts
+++ b/backend/functions/statistics/getStatistics.ts
@@ -1,62 +1,7 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import { dynamoDb, TableNames } from '../../lib/dynamodb';
+import { getRepositories } from '../../lib/repositories';
+import type { Match, Player, Championship, ChampionshipHistoryEntry } from '../../lib/repositories';
 import { success, badRequest, serverError } from '../../lib/response';
-
-interface MatchRecord {
-  matchId: string;
-  date: string;
-  matchFormat?: string;
-  matchType?: string; // legacy field name in existing DB records
-  stipulationId?: string;
-  participants: string[];
-  teams?: string[][];
-  winners?: string[];
-  losers?: string[];
-  isChampionship: boolean;
-  championshipId?: string;
-  status: string;
-  seasonId?: string;
-  starRating?: number;
-  matchOfTheNight?: boolean;
-}
-
-interface PlayerRecord {
-  playerId: string;
-  name: string;
-  currentWrestler: string;
-  wins: number;
-  losses: number;
-  draws: number;
-  imageUrl?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ChampionshipHistoryRecord {
-  championshipId: string;
-  champion: string | string[];
-  wonDate: string;
-  lostDate?: string;
-  daysHeld?: number;
-  defenses?: number;
-}
-
-interface ChampionshipRecord {
-  championshipId: string;
-  name: string;
-  type: string;
-  currentChampion?: string | string[];
-}
-
-interface MatchTypeRecord {
-  matchTypeId: string;
-  name: string;
-}
-
-interface StipulationRecord {
-  stipulationId: string;
-  name: string;
-}
 
 function normalizeMatchType(value?: string): string {
   const normalized = (value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
@@ -70,7 +15,7 @@ function normalizeMatchType(value?: string): string {
   }
 }
 
-function categorizeMatch(match: MatchRecord): string {
+function categorizeMatch(match: Match): string {
   // Map match formats to stat types — handle legacy matchType field
   const mt = (match.matchFormat || match.matchType || 'singles').toLowerCase();
   if (mt.includes('tag')) return 'tag';
@@ -78,7 +23,7 @@ function categorizeMatch(match: MatchRecord): string {
 }
 
 function computeStreaks(
-  matches: MatchRecord[],
+  matches: Match[],
   playerId: string
 ): { currentWinStreak: number; longestWinStreak: number; longestLossStreak: number } {
   // Sort by date ascending
@@ -117,7 +62,7 @@ function computeStreaks(
 }
 
 function computePlayerStatistics(
-  matches: MatchRecord[],
+  matches: Match[],
   playerId: string,
   statType: string
 ): {
@@ -134,7 +79,7 @@ function computePlayerStatistics(
   championshipWins: number;
   championshipLosses: number;
 } {
-  let filtered: MatchRecord[];
+  let filtered: Match[];
 
   if (statType === 'overall') {
     filtered = matches.filter((m) => m.participants.includes(playerId));
@@ -192,6 +137,8 @@ function computePlayerStatistics(
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
+    const { matches: matchesRepo, players: playersRepo, championships: championshipsRepo, matchTypes: matchTypesRepo, stipulations: stipulationsRepo } = getRepositories();
+
     const section = event.queryStringParameters?.section;
     const seasonId = event.queryStringParameters?.seasonId;
 
@@ -200,14 +147,13 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     // Load common data
-    const [playersResult, matchesResult] = await Promise.all([
-      dynamoDb.scanAll({ TableName: TableNames.PLAYERS }),
-      dynamoDb.scanAll({ TableName: TableNames.MATCHES }),
+    const [allPlayers, allMatches] = await Promise.all([
+      playersRepo.list(),
+      matchesRepo.list(),
     ]);
 
     // Only include players who have a wrestler assigned (exclude Fantasy-only users)
-    const players = (playersResult as unknown as PlayerRecord[]).filter((p) => p.currentWrestler);
-    const allMatches = matchesResult as unknown as MatchRecord[];
+    const players = allPlayers.filter((p) => p.currentWrestler);
     const allCompletedMatches = allMatches.filter((m) => m.status === 'completed');
     const completedMatches = seasonId ? allCompletedMatches.filter((m) => m.seasonId === seasonId) : allCompletedMatches;
 
@@ -235,10 +181,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         }));
 
         // Championship stats for this player
-        const champHistoryItems = await dynamoDb.scanAll({
-          TableName: TableNames.CHAMPIONSHIP_HISTORY,
-        });
-        const champHistory = champHistoryItems as unknown as ChampionshipHistoryRecord[];
+        const champHistory = await championshipsRepo.listAllHistory();
 
         const playerChampHistory = champHistory.filter((h) => {
           const champ = h.champion;
@@ -247,16 +190,13 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         });
 
         // Group by championship
-        const champGroups: Record<string, ChampionshipHistoryRecord[]> = {};
+        const champGroups: Record<string, ChampionshipHistoryEntry[]> = {};
         for (const h of playerChampHistory) {
           if (!champGroups[h.championshipId]) champGroups[h.championshipId] = [];
           champGroups[h.championshipId].push(h);
         }
 
-        const championshipsResult = await dynamoDb.scanAll({
-          TableName: TableNames.CHAMPIONSHIPS,
-        });
-        const championships = championshipsResult as unknown as ChampionshipRecord[];
+        const championships = await championshipsRepo.list();
 
         const championshipStats = Object.entries(champGroups).map(([champId, reigns]) => {
           const now = new Date();
@@ -412,10 +352,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         }));
 
         // Championship history for longest reign
-        const champHistoryItems = await dynamoDb.scanAll({
-          TableName: TableNames.CHAMPIONSHIP_HISTORY,
-        });
-        const champHistory = champHistoryItems as unknown as ChampionshipHistoryRecord[];
+        const champHistory = await championshipsRepo.listAllHistory();
 
         // Most wins
         const mostWins = [...allPlayerStats]
@@ -515,10 +452,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           ...computePlayerStatistics(completedMatches, p.playerId, 'overall'),
         }));
 
-        const champHistoryItems = await dynamoDb.scanAll({
-          TableName: TableNames.CHAMPIONSHIP_HISTORY,
-        });
-        const champHistory = champHistoryItems as unknown as ChampionshipHistoryRecord[];
+        const champHistory = await championshipsRepo.listAllHistory();
 
         const now = new Date();
 
@@ -588,7 +522,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         const bestCageRecord = [...allMatchTypeStats].filter((s) => s.matchType === 'cage' && s.matchesPlayed >= 3).sort((a, b) => b.winPercentage - a.winPercentage)[0];
         const mostLadderWins = [...allMatchTypeStats].filter((s) => s.matchType === 'ladder').sort((a, b) => b.wins - a.wins)[0];
 
-        function makeRecord(name: string, player: PlayerRecord | undefined, value: number | string, desc: string) {
+        function makeRecord(name: string, player: Player | undefined, value: number | string, desc: string) {
           return {
             recordName: name,
             holderName: player?.name || 'N/A',
@@ -688,15 +622,10 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           updatedAt: new Date().toISOString(),
         }));
 
-        const champHistoryItems = await dynamoDb.scanAll({
-          TableName: TableNames.CHAMPIONSHIP_HISTORY,
-        });
-        const champHistory = champHistoryItems as unknown as ChampionshipHistoryRecord[];
-
-        const championshipsResult = await dynamoDb.scanAll({
-          TableName: TableNames.CHAMPIONSHIPS,
-        });
-        const championships = championshipsResult as unknown as ChampionshipRecord[];
+        const [champHistory, championships] = await Promise.all([
+          championshipsRepo.listAllHistory(),
+          championshipsRepo.list(),
+        ]);
 
         const playerChampHistory = champHistory.filter((h) => {
           const champ = h.champion;
@@ -704,7 +633,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           return champ === playerId;
         });
 
-        const champGroups: Record<string, ChampionshipHistoryRecord[]> = {};
+        const champGroups: Record<string, ChampionshipHistoryEntry[]> = {};
         for (const h of playerChampHistory) {
           if (!champGroups[h.championshipId]) champGroups[h.championshipId] = [];
           champGroups[h.championshipId].push(h);
@@ -757,7 +686,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
       case 'match-ratings': {
         const ratedMatches = allCompletedMatches.filter(
-          (m): m is MatchRecord & { starRating: number } => typeof (m as MatchRecord).starRating === 'number'
+          (m): m is Match & { starRating: number } => typeof m.starRating === 'number'
         );
         const sorted = [...ratedMatches].sort(
           (a, b) => (b.starRating ?? 0) - (a.starRating ?? 0)
@@ -796,23 +725,20 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         const selectedMatchTypeId = event.queryStringParameters?.matchTypeId;
         const selectedStipulationId = event.queryStringParameters?.stipulationId;
 
-        const [matchTypesResult, stipulationsResult] = await Promise.all([
-          dynamoDb.scanAll({ TableName: TableNames.MATCH_TYPES }),
-          dynamoDb.scanAll({ TableName: TableNames.STIPULATIONS }),
+        const [matchTypesList, stipulationsList] = await Promise.all([
+          matchTypesRepo.list(),
+          stipulationsRepo.list(),
         ]);
 
-        const matchTypes = matchTypesResult as unknown as MatchTypeRecord[];
-        const stipulations = stipulationsResult as unknown as StipulationRecord[];
-
         const selectedMatchType = selectedMatchTypeId
-          ? matchTypes.find((mt) => mt.matchTypeId === selectedMatchTypeId)
+          ? matchTypesList.find((mt) => mt.matchTypeId === selectedMatchTypeId)
           : undefined;
         if (selectedMatchTypeId && !selectedMatchType) {
           return badRequest(`Unknown matchTypeId: ${selectedMatchTypeId}`);
         }
 
         const selectedStipulation = selectedStipulationId
-          ? stipulations.find((s) => s.stipulationId === selectedStipulationId)
+          ? stipulationsList.find((s) => s.stipulationId === selectedStipulationId)
           : undefined;
         if (selectedStipulationId && !selectedStipulation) {
           return badRequest(`Unknown stipulationId: ${selectedStipulationId}`);
@@ -903,10 +829,10 @@ function computeAchievements(
   playerId: string,
   stats: { statType: string; wins: number; matchesPlayed: number; longestWinStreak: number; longestLossStreak: number; championshipWins: number }[],
   championshipStats: { championshipId: string; totalReigns: number; longestReign: number; totalDaysHeld: number }[],
-  completedMatches: MatchRecord[],
-  allChampHistory: ChampionshipHistoryRecord[],
-  allChampionships: ChampionshipRecord[],
-  _players: PlayerRecord[]
+  completedMatches: Match[],
+  allChampHistory: ChampionshipHistoryEntry[],
+  allChampionships: Championship[],
+  _players: Player[]
 ) {
   const earned: { playerId: string; achievementId: string; achievementName: string; achievementType: string; description: string; earnedAt: string; icon: string; metadata?: Record<string, unknown> }[] = [];
   const overall = stats.find((s) => s.statType === 'overall');
@@ -958,10 +884,7 @@ function computeAchievements(
   }
 
   // a9: Grand Slam - hold every championship at least once
-  const activeChampionships = allChampionships.filter((c) => {
-    const ch = c as ChampionshipRecord & { isActive?: boolean };
-    return ch.isActive !== false;
-  });
+  const activeChampionships = allChampionships.filter((c) => c.isActive !== false);
   if (activeChampionships.length > 0) {
     const heldChampionships = new Set(championshipStats.filter((cs) => cs.totalReigns > 0).map((cs) => cs.championshipId));
     const hasAll = activeChampionships.every((c) => heldChampionships.has(c.championshipId));

--- a/backend/lib/repositories/ChampionshipsRepository.ts
+++ b/backend/lib/repositories/ChampionshipsRepository.ts
@@ -1,0 +1,12 @@
+import type { Championship, ChampionshipHistoryEntry } from './types';
+
+export interface ChampionshipsRepository {
+  findById(championshipId: string): Promise<Championship | null>;
+  list(): Promise<Championship[]>;
+  listActive(): Promise<Championship[]>;
+
+  // Championship history
+  listHistory(championshipId: string): Promise<ChampionshipHistoryEntry[]>;
+  listAllHistory(): Promise<ChampionshipHistoryEntry[]>;
+  findCurrentReign(championshipId: string): Promise<ChampionshipHistoryEntry | null>;
+}

--- a/backend/lib/repositories/MatchesRepository.ts
+++ b/backend/lib/repositories/MatchesRepository.ts
@@ -1,0 +1,10 @@
+import type { Match } from './types';
+
+export interface MatchesRepository {
+  findById(matchId: string): Promise<Match | null>;
+  list(): Promise<Match[]>;
+  listCompleted(): Promise<Match[]>;
+  listByStatus(status: string): Promise<Match[]>;
+  listByTournament(tournamentId: string): Promise<Match[]>;
+  listBySeason(seasonId: string): Promise<Match[]>;
+}

--- a/backend/lib/repositories/SeasonStandingsRepository.ts
+++ b/backend/lib/repositories/SeasonStandingsRepository.ts
@@ -1,0 +1,5 @@
+import type { SeasonStanding } from './types';
+
+export interface SeasonStandingsRepository {
+  listBySeason(seasonId: string): Promise<SeasonStanding[]>;
+}

--- a/backend/lib/repositories/TournamentsRepository.ts
+++ b/backend/lib/repositories/TournamentsRepository.ts
@@ -1,0 +1,6 @@
+import type { Tournament } from './types';
+
+export interface TournamentsRepository {
+  findById(tournamentId: string): Promise<Tournament | null>;
+  list(): Promise<Tournament[]>;
+}

--- a/backend/lib/repositories/dynamo/ChampionshipsRepository.ts
+++ b/backend/lib/repositories/dynamo/ChampionshipsRepository.ts
@@ -1,0 +1,48 @@
+import { dynamoDb, TableNames } from '../../dynamodb';
+import type { ChampionshipsRepository } from '../ChampionshipsRepository';
+import type { Championship, ChampionshipHistoryEntry } from '../types';
+
+export class DynamoChampionshipsRepository implements ChampionshipsRepository {
+  async findById(championshipId: string): Promise<Championship | null> {
+    const result = await dynamoDb.get({
+      TableName: TableNames.CHAMPIONSHIPS,
+      Key: { championshipId },
+    });
+    return (result.Item as Championship | undefined) ?? null;
+  }
+
+  async list(): Promise<Championship[]> {
+    return await dynamoDb.scanAll({ TableName: TableNames.CHAMPIONSHIPS }) as unknown as Championship[];
+  }
+
+  async listActive(): Promise<Championship[]> {
+    const all = await this.list();
+    return all.filter((c) => c.isActive !== false);
+  }
+
+  async listHistory(championshipId: string): Promise<ChampionshipHistoryEntry[]> {
+    return await dynamoDb.queryAll({
+      TableName: TableNames.CHAMPIONSHIP_HISTORY,
+      KeyConditionExpression: 'championshipId = :cid',
+      ExpressionAttributeValues: { ':cid': championshipId },
+    }) as unknown as ChampionshipHistoryEntry[];
+  }
+
+  async listAllHistory(): Promise<ChampionshipHistoryEntry[]> {
+    return await dynamoDb.scanAll({
+      TableName: TableNames.CHAMPIONSHIP_HISTORY,
+    }) as unknown as ChampionshipHistoryEntry[];
+  }
+
+  async findCurrentReign(championshipId: string): Promise<ChampionshipHistoryEntry | null> {
+    const result = await dynamoDb.query({
+      TableName: TableNames.CHAMPIONSHIP_HISTORY,
+      KeyConditionExpression: 'championshipId = :cid',
+      FilterExpression: 'attribute_not_exists(lostDate)',
+      ExpressionAttributeValues: { ':cid': championshipId },
+      ScanIndexForward: false,
+      Limit: 1,
+    });
+    return ((result.Items?.[0]) as ChampionshipHistoryEntry | undefined) ?? null;
+  }
+}

--- a/backend/lib/repositories/dynamo/MatchesRepository.ts
+++ b/backend/lib/repositories/dynamo/MatchesRepository.ts
@@ -1,0 +1,52 @@
+import { dynamoDb, TableNames } from '../../dynamodb';
+import type { MatchesRepository } from '../MatchesRepository';
+import type { Match } from '../types';
+
+export class DynamoMatchesRepository implements MatchesRepository {
+  async findById(matchId: string): Promise<Match | null> {
+    const result = await dynamoDb.get({
+      TableName: TableNames.MATCHES,
+      Key: { matchId },
+    });
+    return (result.Item as Match | undefined) ?? null;
+  }
+
+  async list(): Promise<Match[]> {
+    return await dynamoDb.scanAll({ TableName: TableNames.MATCHES }) as unknown as Match[];
+  }
+
+  async listCompleted(): Promise<Match[]> {
+    return await dynamoDb.scanAll({
+      TableName: TableNames.MATCHES,
+      FilterExpression: '#status = :completed',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':completed': 'completed' },
+    }) as unknown as Match[];
+  }
+
+  async listByStatus(status: string): Promise<Match[]> {
+    return await dynamoDb.scanAll({
+      TableName: TableNames.MATCHES,
+      FilterExpression: '#status = :status',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': status },
+    }) as unknown as Match[];
+  }
+
+  async listByTournament(tournamentId: string): Promise<Match[]> {
+    return await dynamoDb.queryAll({
+      TableName: TableNames.MATCHES,
+      IndexName: 'TournamentIndex',
+      KeyConditionExpression: 'tournamentId = :tournamentId',
+      ExpressionAttributeValues: { ':tournamentId': tournamentId },
+    }) as unknown as Match[];
+  }
+
+  async listBySeason(seasonId: string): Promise<Match[]> {
+    return await dynamoDb.scanAll({
+      TableName: TableNames.MATCHES,
+      FilterExpression: 'seasonId = :seasonId',
+      ExpressionAttributeValues: { ':seasonId': seasonId },
+    }) as unknown as Match[];
+  }
+}

--- a/backend/lib/repositories/dynamo/SeasonStandingsRepository.ts
+++ b/backend/lib/repositories/dynamo/SeasonStandingsRepository.ts
@@ -1,0 +1,13 @@
+import { dynamoDb, TableNames } from '../../dynamodb';
+import type { SeasonStandingsRepository } from '../SeasonStandingsRepository';
+import type { SeasonStanding } from '../types';
+
+export class DynamoSeasonStandingsRepository implements SeasonStandingsRepository {
+  async listBySeason(seasonId: string): Promise<SeasonStanding[]> {
+    return await dynamoDb.queryAll({
+      TableName: TableNames.SEASON_STANDINGS,
+      KeyConditionExpression: 'seasonId = :seasonId',
+      ExpressionAttributeValues: { ':seasonId': seasonId },
+    }) as unknown as SeasonStanding[];
+  }
+}

--- a/backend/lib/repositories/dynamo/TournamentsRepository.ts
+++ b/backend/lib/repositories/dynamo/TournamentsRepository.ts
@@ -1,0 +1,17 @@
+import { dynamoDb, TableNames } from '../../dynamodb';
+import type { TournamentsRepository } from '../TournamentsRepository';
+import type { Tournament } from '../types';
+
+export class DynamoTournamentsRepository implements TournamentsRepository {
+  async findById(tournamentId: string): Promise<Tournament | null> {
+    const result = await dynamoDb.get({
+      TableName: TableNames.TOURNAMENTS,
+      Key: { tournamentId },
+    });
+    return (result.Item as Tournament | undefined) ?? null;
+  }
+
+  async list(): Promise<Tournament[]> {
+    return await dynamoDb.scanAll({ TableName: TableNames.TOURNAMENTS }) as unknown as Tournament[];
+  }
+}

--- a/backend/lib/repositories/dynamo/index.ts
+++ b/backend/lib/repositories/dynamo/index.ts
@@ -19,6 +19,10 @@ import { DynamoTransfersRepository } from './TransfersRepository';
 import { DynamoStorylineRequestsRepository } from './StorylineRequestsRepository';
 import { DynamoEventsRepository } from './EventsRepository';
 import { DynamoPromosRepository } from './PromosRepository';
+import { DynamoMatchesRepository } from './MatchesRepository';
+import { DynamoChampionshipsRepository } from './ChampionshipsRepository';
+import { DynamoTournamentsRepository } from './TournamentsRepository';
+import { DynamoSeasonStandingsRepository } from './SeasonStandingsRepository';
 
 registerDriver('dynamo', (): Repositories => ({
   divisions: new DynamoDivisionsRepository(),
@@ -41,6 +45,10 @@ registerDriver('dynamo', (): Repositories => ({
   storylineRequests: new DynamoStorylineRequestsRepository(),
   events: new DynamoEventsRepository(),
   promos: new DynamoPromosRepository(),
+  matches: new DynamoMatchesRepository(),
+  championships: new DynamoChampionshipsRepository(),
+  tournaments: new DynamoTournamentsRepository(),
+  seasonStandings: new DynamoSeasonStandingsRepository(),
   runInTransaction: async () => {
     throw new Error('runInTransaction is not implemented in the dynamo driver yet (scheduled for Wave 7)');
   },

--- a/backend/lib/repositories/inMemory/ChampionshipsRepository.ts
+++ b/backend/lib/repositories/inMemory/ChampionshipsRepository.ts
@@ -1,0 +1,34 @@
+import type { ChampionshipsRepository } from '../ChampionshipsRepository';
+import type { Championship, ChampionshipHistoryEntry } from '../types';
+
+export class InMemoryChampionshipsRepository implements ChampionshipsRepository {
+  readonly store = new Map<string, Championship>();
+  readonly historyStore: ChampionshipHistoryEntry[] = [];
+
+  async findById(championshipId: string): Promise<Championship | null> {
+    return this.store.get(championshipId) ?? null;
+  }
+
+  async list(): Promise<Championship[]> {
+    return Array.from(this.store.values());
+  }
+
+  async listActive(): Promise<Championship[]> {
+    return Array.from(this.store.values()).filter((c) => c.isActive !== false);
+  }
+
+  async listHistory(championshipId: string): Promise<ChampionshipHistoryEntry[]> {
+    return this.historyStore.filter((h) => h.championshipId === championshipId);
+  }
+
+  async listAllHistory(): Promise<ChampionshipHistoryEntry[]> {
+    return [...this.historyStore];
+  }
+
+  async findCurrentReign(championshipId: string): Promise<ChampionshipHistoryEntry | null> {
+    const reigns = this.historyStore
+      .filter((h) => h.championshipId === championshipId && !h.lostDate)
+      .sort((a, b) => new Date(b.wonDate).getTime() - new Date(a.wonDate).getTime());
+    return reigns[0] ?? null;
+  }
+}

--- a/backend/lib/repositories/inMemory/MatchesRepository.ts
+++ b/backend/lib/repositories/inMemory/MatchesRepository.ts
@@ -1,0 +1,30 @@
+import type { MatchesRepository } from '../MatchesRepository';
+import type { Match } from '../types';
+
+export class InMemoryMatchesRepository implements MatchesRepository {
+  readonly store = new Map<string, Match>();
+
+  async findById(matchId: string): Promise<Match | null> {
+    return this.store.get(matchId) ?? null;
+  }
+
+  async list(): Promise<Match[]> {
+    return Array.from(this.store.values());
+  }
+
+  async listCompleted(): Promise<Match[]> {
+    return Array.from(this.store.values()).filter((m) => m.status === 'completed');
+  }
+
+  async listByStatus(status: string): Promise<Match[]> {
+    return Array.from(this.store.values()).filter((m) => m.status === status);
+  }
+
+  async listByTournament(tournamentId: string): Promise<Match[]> {
+    return Array.from(this.store.values()).filter((m) => m.tournamentId === tournamentId);
+  }
+
+  async listBySeason(seasonId: string): Promise<Match[]> {
+    return Array.from(this.store.values()).filter((m) => m.seasonId === seasonId);
+  }
+}

--- a/backend/lib/repositories/inMemory/SeasonStandingsRepository.ts
+++ b/backend/lib/repositories/inMemory/SeasonStandingsRepository.ts
@@ -1,0 +1,10 @@
+import type { SeasonStandingsRepository } from '../SeasonStandingsRepository';
+import type { SeasonStanding } from '../types';
+
+export class InMemorySeasonStandingsRepository implements SeasonStandingsRepository {
+  readonly store: SeasonStanding[] = [];
+
+  async listBySeason(seasonId: string): Promise<SeasonStanding[]> {
+    return this.store.filter((s) => s.seasonId === seasonId);
+  }
+}

--- a/backend/lib/repositories/inMemory/TournamentsRepository.ts
+++ b/backend/lib/repositories/inMemory/TournamentsRepository.ts
@@ -1,0 +1,14 @@
+import type { TournamentsRepository } from '../TournamentsRepository';
+import type { Tournament } from '../types';
+
+export class InMemoryTournamentsRepository implements TournamentsRepository {
+  readonly store = new Map<string, Tournament>();
+
+  async findById(tournamentId: string): Promise<Tournament | null> {
+    return this.store.get(tournamentId) ?? null;
+  }
+
+  async list(): Promise<Tournament[]> {
+    return Array.from(this.store.values());
+  }
+}

--- a/backend/lib/repositories/inMemory/index.ts
+++ b/backend/lib/repositories/inMemory/index.ts
@@ -19,6 +19,10 @@ import { InMemoryTransfersRepository } from './TransfersRepository';
 import { InMemoryStorylineRequestsRepository } from './StorylineRequestsRepository';
 import { InMemoryEventsRepository } from './EventsRepository';
 import { InMemoryPromosRepository } from './PromosRepository';
+import { InMemoryMatchesRepository } from './MatchesRepository';
+import { InMemoryChampionshipsRepository } from './ChampionshipsRepository';
+import { InMemoryTournamentsRepository } from './TournamentsRepository';
+import { InMemorySeasonStandingsRepository } from './SeasonStandingsRepository';
 
 export function buildInMemoryRepositories(): Repositories {
   return {
@@ -42,6 +46,10 @@ export function buildInMemoryRepositories(): Repositories {
     storylineRequests: new InMemoryStorylineRequestsRepository(),
     events: new InMemoryEventsRepository(),
     promos: new InMemoryPromosRepository(),
+    matches: new InMemoryMatchesRepository(),
+    championships: new InMemoryChampionshipsRepository(),
+    tournaments: new InMemoryTournamentsRepository(),
+    seasonStandings: new InMemorySeasonStandingsRepository(),
     runInTransaction: async () => {
       throw new Error('runInTransaction is not implemented in the in-memory driver yet (scheduled for Wave 7)');
     },
@@ -70,3 +78,7 @@ export { InMemoryTransfersRepository } from './TransfersRepository';
 export { InMemoryStorylineRequestsRepository } from './StorylineRequestsRepository';
 export { InMemoryEventsRepository } from './EventsRepository';
 export { InMemoryPromosRepository } from './PromosRepository';
+export { InMemoryMatchesRepository } from './MatchesRepository';
+export { InMemoryChampionshipsRepository } from './ChampionshipsRepository';
+export { InMemoryTournamentsRepository } from './TournamentsRepository';
+export { InMemorySeasonStandingsRepository } from './SeasonStandingsRepository';

--- a/backend/lib/repositories/index.ts
+++ b/backend/lib/repositories/index.ts
@@ -32,3 +32,7 @@ export type { TransfersRepository, TransferCreateInput, TransferReviewInput } fr
 export type { StorylineRequestsRepository, StorylineRequestCreateInput, StorylineRequestReviewInput } from './StorylineRequestsRepository';
 export type { EventsRepository, EventCreateInput, EventPatch } from './EventsRepository';
 export type { PromosRepository, PromoCreateInput } from './PromosRepository';
+export type { MatchesRepository } from './MatchesRepository';
+export type { ChampionshipsRepository } from './ChampionshipsRepository';
+export type { TournamentsRepository } from './TournamentsRepository';
+export type { SeasonStandingsRepository } from './SeasonStandingsRepository';

--- a/backend/lib/repositories/registry.ts
+++ b/backend/lib/repositories/registry.ts
@@ -18,6 +18,10 @@ import type { TransfersRepository } from './TransfersRepository';
 import type { StorylineRequestsRepository } from './StorylineRequestsRepository';
 import type { EventsRepository } from './EventsRepository';
 import type { PromosRepository } from './PromosRepository';
+import type { MatchesRepository } from './MatchesRepository';
+import type { ChampionshipsRepository } from './ChampionshipsRepository';
+import type { TournamentsRepository } from './TournamentsRepository';
+import type { SeasonStandingsRepository } from './SeasonStandingsRepository';
 import type { UnitOfWorkFactory } from './unitOfWork';
 
 export interface Repositories {
@@ -41,6 +45,10 @@ export interface Repositories {
   storylineRequests: StorylineRequestsRepository;
   events: EventsRepository;
   promos: PromosRepository;
+  matches: MatchesRepository;
+  championships: ChampionshipsRepository;
+  tournaments: TournamentsRepository;
+  seasonStandings: SeasonStandingsRepository;
   runInTransaction: UnitOfWorkFactory;
 }
 

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -309,3 +309,73 @@ export interface Promo {
   createdAt: string;
   updatedAt: string;
 }
+
+// ─── Wave 5 types ──────────────────────────────────────────────────
+
+export interface Match {
+  matchId: string;
+  date: string;
+  matchFormat?: string;
+  matchType?: string; // legacy field name
+  stipulationId?: string;
+  participants: string[];
+  teams?: string[][];
+  winners?: string[];
+  losers?: string[];
+  isDraw?: boolean;
+  isChampionship?: boolean;
+  championshipId?: string;
+  tournamentId?: string;
+  seasonId?: string;
+  eventId?: string;
+  status: 'scheduled' | 'completed' | 'cancelled';
+  starRating?: number;
+  matchOfTheNight?: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface Championship {
+  championshipId: string;
+  name: string;
+  type: 'singles' | 'tag';
+  currentChampion?: string | string[];
+  imageUrl?: string;
+  isActive?: boolean;
+  defenses?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChampionshipHistoryEntry {
+  championshipId: string;
+  wonDate: string;
+  champion: string | string[];
+  lostDate?: string;
+  daysHeld?: number;
+  defenses?: number;
+  matchId?: string;
+  updatedAt?: string;
+}
+
+export interface Tournament {
+  tournamentId: string;
+  name: string;
+  type: 'single-elimination' | 'round-robin';
+  status: string;
+  participants?: string[];
+  brackets?: unknown;
+  standings?: unknown;
+  winner?: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface SeasonStanding {
+  seasonId: string;
+  playerId: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  updatedAt: string;
+}

--- a/docs/plans/plan-database-interface-layer.md
+++ b/docs/plans/plan-database-interface-layer.md
@@ -14,7 +14,7 @@
 | 2 — Divisions/Stipulations/MatchTypes + generalized CRUD factory | ✅ Done | `9357c0e` |
 | 3 — Read-heavy leaves (Seasons, Announcements, Videos, Companies, Shows, Notifications, Overalls, SiteConfig, SeasonAwards) | ✅ Done | — |
 | 4 — Medium-complexity aggregates with GSIs (Players, Challenges, TagTeams, Stables, Transfers, StorylineRequests, Events, Promos) | ✅ Done | — |
-| 5 — Cross-aggregate reads (Standings, Dashboard, Rivalries, Statistics, Activity) | ⏳ | — |
+| 5 — Cross-aggregate reads (Standings, Dashboard, Rivalries, Statistics, Activity) | ✅ Done | — |
 | 6 — Contenders & Fantasy (batched writes) | ⏳ | — |
 | 7 — Transactional writes + `runInTransaction` + `recordResult.ts` | ⏳ | — |
 | 8 — Admin and seed scripts | ⏳ | — |
@@ -37,9 +37,19 @@ dissolveTagTeam, deleteTagTeam, respondToChallenge) retain `dynamoDb.transactWri
 calls pending Wave 7 UoW implementation. Cross-domain reads to Matches/Championships
 (Wave 5+) remain on direct dynamoDb.
 
-**Where to resume**: Wave 5 — cross-aggregate read handlers (Standings, Dashboard,
-Rivalries, Statistics, Activity). These compose reads from multiple repos without
-writes, validating the multi-repo composition story.
+**After Wave 5**: 967 tests passing, 0 failures. Typecheck and lint clean.
+5 cross-aggregate read handlers migrated: Standings, Dashboard, Rivalries,
+Statistics, Activity. 4 new repository interfaces created: MatchesRepository,
+ChampionshipsRepository (including history), TournamentsRepository,
+SeasonStandingsRepository. These are read-only interfaces — write methods will
+be added in Wave 7 when transactional handlers are migrated. N+1 pattern in
+getActivity eliminated (individual player/championship lookups replaced with
+batch list calls). All 9 test files updated to mock repository methods instead
+of DynamoDB SDK.
+
+**Where to resume**: Wave 6 — Contenders & Fantasy (batched writes). These write
+many items but don't need strict transactionality (async-invoked, idempotent
+rebuild jobs).
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Migrate 5 cross-aggregate read handlers to the repository layer: `getStandings`, `getDashboard`, `getRivalries`, `getStatistics`, `getActivity`
- Create 4 new repository interfaces (`MatchesRepository`, `ChampionshipsRepository`, `TournamentsRepository`, `SeasonStandingsRepository`) with Dynamo and InMemory implementations — read-only for now, write methods land in Wave 7
- Eliminate N+1 pattern in `getActivity` (individual player/championship lookups replaced with batch `list()` calls)
- Update all 9 test files to mock repository methods instead of DynamoDB SDK

## Details
- **New types**: `Match`, `Championship`, `ChampionshipHistoryEntry`, `Tournament`, `SeasonStanding` added to `types.ts`
- **32 files changed**: 1,224 insertions, 1,266 deletions (net reduction from removing type casts and DynamoDB boilerplate)
- **967 tests passing**, 0 failures. Typecheck and lint clean.

## Test plan
- [x] Backend typecheck (`npx tsc --project tsconfig.json --noEmit`)
- [x] Frontend typecheck (`npx tsc --project tsconfig.app.json --noEmit`)
- [x] Backend lint (`npm run lint`)
- [x] Backend tests — 967 passing, 0 failures
- [ ] Manual: `npm run offline` with DynamoDB Local — verify standings, dashboard, rivalries, statistics, activity endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)