### PR TITLE
fix(announcements): resolve 500 on update and isActive toggle-off

### DIFF
--- a/backend/lib/repositories/dynamo/DynamoContentRepository.ts
+++ b/backend/lib/repositories/dynamo/DynamoContentRepository.ts
@@ -73,7 +73,7 @@ function buildAnnouncementsMethods(): AnnouncementsCrud {
         title: input.title.trim(),
         body: input.body.trim(),
         priority: typeof input.priority === 'number' ? input.priority : 1,
-        isActive: input.isActive === false ? 'false' : 'true',
+        isActive: input.isActive === false || (input.isActive as unknown) === 'false' ? 'false' : 'true',
         createdBy: input.createdBy,
         createdAt: now,
         updatedAt: now,
@@ -98,13 +98,14 @@ function buildAnnouncementsMethods(): AnnouncementsCrud {
       if (patch.title !== undefined) fields.title = patch.title;
       if (patch.body !== undefined) fields.body = patch.body;
       if (patch.priority !== undefined) fields.priority = patch.priority;
-      if (patch.isActive !== undefined) fields.isActive = patch.isActive ? 'true' : 'false';
+      if (patch.isActive !== undefined) {
+        fields.isActive = patch.isActive === false || (patch.isActive as unknown) === 'false' ? 'false' : 'true';
+      }
       if (patch.expiresAt !== undefined && patch.expiresAt !== null) {
         fields.expiresAt = patch.expiresAt;
       }
 
       const now = new Date().toISOString();
-      fields.updatedAt = now;
 
       const expr = buildUpdateExpression(fields, now);
 

--- a/backend/lib/repositories/inMemory/InMemoryContentRepository.ts
+++ b/backend/lib/repositories/inMemory/InMemoryContentRepository.ts
@@ -56,7 +56,7 @@ class AnnouncementsImpl implements AnnouncementsMethods {
       title: input.title.trim(),
       body: input.body.trim(),
       priority: typeof input.priority === 'number' ? input.priority : 1,
-      isActive: input.isActive === false ? 'false' : 'true',
+      isActive: input.isActive === false || (input.isActive as unknown) === 'false' ? 'false' : 'true',
       createdBy: input.createdBy,
       createdAt: now,
       updatedAt: now,
@@ -78,7 +78,9 @@ class AnnouncementsImpl implements AnnouncementsMethods {
     if (patch.title !== undefined) updated.title = patch.title;
     if (patch.body !== undefined) updated.body = patch.body;
     if (patch.priority !== undefined) updated.priority = patch.priority;
-    if (patch.isActive !== undefined) updated.isActive = patch.isActive ? 'true' : 'false';
+    if (patch.isActive !== undefined) {
+      updated.isActive = patch.isActive === false || (patch.isActive as unknown) === 'false' ? 'false' : 'true';
+    }
     if (patch.expiresAt === null) {
       delete updated.expiresAt;
     } else if (patch.expiresAt !== undefined) {


### PR DESCRIPTION
## Summary
- **500 on edit**: `DynamoContentRepository.announcements.update()` manually set `fields.updatedAt = now` before calling `buildUpdateExpression`, which always appends its own `#updatedAt = :updatedAt`. The resulting UpdateExpression had two overlapping SET paths, triggering a DynamoDB `ValidationException` surfaced as a 500 from `updateAnnouncement`. Manifested after creating a match card via the GM wizard and then editing the announcement.
- **isActive toggle-off silently failed**: `patch.isActive ? 'true' : 'false'` treated the string `'false'` as truthy (the backend stores `isActive` as the string `'true'|'false'` for a GSI and round-trips that form to the frontend form state). Editing an inactive announcement without touching the checkbox silently re-activated it. Fixed in both the Dynamo and in-memory repos for parity.

## Test plan
- [ ] Deploy to `devtest`.
- [ ] Use the GM wizard to publish a Match Card announcement.
- [ ] In **Manage Announcements**, click **Edit** on that announcement, change the title, save → confirm 200 + persisted change (no 500).
- [ ] Edit again, toggle **Active** off, save → reload list and confirm status reads **Inactive**.
- [ ] Edit an active announcement without touching the checkbox → status still **Active** after save.
- [ ] Edit the same announcement again, toggle off, save, then edit and save again without touching the checkbox → stays **Inactive**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)