### PR TITLE
refactor(api): collapse /players methods to ANY to cut CFN resources

### DIFF
--- a/backend/functions/players/__tests__/handler.test.ts
+++ b/backend/functions/players/__tests__/handler.test.ts
@@ -52,6 +52,10 @@ vi.mock('../../../lib/auth', () => ({
   hasRole: () => true,
 }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 import { handler } from '../handler';
 
 const ctx = {} as Context;

--- a/backend/functions/players/handler.ts
+++ b/backend/functions/players/handler.ts
@@ -11,7 +11,8 @@ import { handler as getPlayerStatisticsHandler } from './getPlayerStatistics';
 
 /**
  * Single Lambda for players: routes by HTTP method and path.
- * Replaces getPlayers, createPlayer, updatePlayer, deletePlayer, getMyProfile, updateMyProfile, getPlayerStatistics.
+ * Fronted by a /{proxy+} API Gateway route; requireAuth routes run JWT
+ * verification in the router before dispatching to the handler.
  */
 
 const routes: ReadonlyArray<RouteConfig> = [
@@ -24,16 +25,19 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/players/me',
     method: 'GET',
     handler: getMyProfileHandler,
+    requireAuth: true,
   },
   {
     resource: '/players/me',
     method: 'PUT',
     handler: updateMyProfileHandler,
+    requireAuth: true,
   },
   {
     resource: '/players',
     method: 'POST',
     handler: createPlayerHandler,
+    requireAuth: true,
   },
   {
     resource: '/players/{playerId}',
@@ -49,11 +53,13 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/players/{playerId}',
     method: 'PUT',
     handler: updatePlayerHandler,
+    requireAuth: true,
   },
   {
     resource: '/players/{playerId}',
     method: 'DELETE',
     handler: deletePlayerHandler,
+    requireAuth: true,
   },
 ];
 export const handler = createRouter(routes);

--- a/backend/lib/__tests__/router.test.ts
+++ b/backend/lib/__tests__/router.test.ts
@@ -82,4 +82,166 @@ describe('createRouter', () => {
     expect(result?.statusCode).toBe(200);
     expect(getByTemplateHandler).toHaveBeenCalledTimes(1);
   });
+
+  describe('behind /{proxy+} integration', () => {
+    it('resolves route from event.path and sets pathParameters', async () => {
+      const getByIdHandler = vi
+        .fn()
+        .mockImplementation(async (event: APIGatewayProxyEvent) => ({
+          statusCode: 200,
+          body: JSON.stringify({ playerId: event.pathParameters?.playerId, resource: event.resource }),
+        }));
+      const routes: ReadonlyArray<RouteConfig> = [
+        { method: 'GET', resource: '/players', handler: vi.fn() as RouteConfig['handler'] },
+        { method: 'GET', resource: '/players/{playerId}', handler: getByIdHandler as RouteConfig['handler'] },
+      ];
+      const handler = createRouter(routes);
+
+      const result = await handler(
+        makeEvent({
+          httpMethod: 'GET',
+          path: '/players/abc123',
+          resource: '/players/{proxy+}',
+          pathParameters: { proxy: 'abc123' },
+        }),
+        ctx,
+        cb
+      );
+
+      expect(result?.statusCode).toBe(200);
+      expect(JSON.parse(result!.body)).toEqual({ playerId: 'abc123', resource: '/players/{playerId}' });
+      expect(getByIdHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefers the most specific route when static and parametric templates both match', async () => {
+      const meHandler = vi.fn().mockResolvedValue({ statusCode: 200, body: '{"me":true}' });
+      const byIdHandler = vi.fn().mockResolvedValue({ statusCode: 200, body: '{"byId":true}' });
+      const routes: ReadonlyArray<RouteConfig> = [
+        { method: 'GET', resource: '/players/{playerId}', handler: byIdHandler as RouteConfig['handler'] },
+        { method: 'GET', resource: '/players/me', handler: meHandler as RouteConfig['handler'] },
+      ];
+      const handler = createRouter(routes);
+
+      const result = await handler(
+        makeEvent({
+          httpMethod: 'GET',
+          path: '/players/me',
+          resource: '/players/{proxy+}',
+        }),
+        ctx,
+        cb
+      );
+
+      expect(result?.statusCode).toBe(200);
+      expect(meHandler).toHaveBeenCalledTimes(1);
+      expect(byIdHandler).not.toHaveBeenCalled();
+    });
+
+    it('returns 405 when path matches a registered route but method does not', async () => {
+      const routes: ReadonlyArray<RouteConfig> = [
+        { method: 'GET', resource: '/players/{playerId}', handler: vi.fn() as RouteConfig['handler'] },
+      ];
+      const handler = createRouter(routes);
+
+      const result = await handler(
+        makeEvent({
+          httpMethod: 'DELETE',
+          path: '/players/abc123',
+          resource: '/players/{proxy+}',
+        }),
+        ctx,
+        cb
+      );
+
+      expect(result?.statusCode).toBe(405);
+    });
+
+    it('returns 404 when no registered route matches the path', async () => {
+      const routes: ReadonlyArray<RouteConfig> = [
+        { method: 'GET', resource: '/players', handler: vi.fn() as RouteConfig['handler'] },
+      ];
+      const handler = createRouter(routes);
+
+      const result = await handler(
+        makeEvent({
+          httpMethod: 'GET',
+          path: '/players/abc/unknown',
+          resource: '/players/{proxy+}',
+        }),
+        ctx,
+        cb
+      );
+
+      expect(result?.statusCode).toBe(404);
+    });
+
+    it('returns 401 when requireAuth route has no bearer token (offline=false)', async () => {
+      const originalOffline = process.env.IS_OFFLINE;
+      process.env.IS_OFFLINE = 'false';
+      try {
+        const protectedHandler = vi.fn().mockResolvedValue({ statusCode: 200, body: '{}' });
+        const routes: ReadonlyArray<RouteConfig> = [
+          {
+            method: 'POST',
+            resource: '/players',
+            handler: protectedHandler as RouteConfig['handler'],
+            requireAuth: true,
+          },
+        ];
+        const handler = createRouter(routes);
+
+        const result = await handler(
+          makeEvent({
+            httpMethod: 'POST',
+            path: '/players',
+            resource: '/players',
+          }),
+          ctx,
+          cb
+        );
+
+        expect(result?.statusCode).toBe(401);
+        expect(protectedHandler).not.toHaveBeenCalled();
+      } finally {
+        process.env.IS_OFFLINE = originalOffline;
+      }
+    });
+
+    it('dispatches requireAuth routes in offline mode without a token', async () => {
+      const originalOffline = process.env.IS_OFFLINE;
+      process.env.IS_OFFLINE = 'true';
+      try {
+        const protectedHandler = vi
+          .fn()
+          .mockImplementation(async (event: APIGatewayProxyEvent) => ({
+            statusCode: 200,
+            body: JSON.stringify({ groups: event.requestContext.authorizer?.groups }),
+          }));
+        const routes: ReadonlyArray<RouteConfig> = [
+          {
+            method: 'POST',
+            resource: '/players',
+            handler: protectedHandler as RouteConfig['handler'],
+            requireAuth: true,
+          },
+        ];
+        const handler = createRouter(routes);
+
+        const result = await handler(
+          makeEvent({
+            httpMethod: 'POST',
+            path: '/players',
+            resource: '/players',
+          }),
+          ctx,
+          cb
+        );
+
+        expect(result?.statusCode).toBe(200);
+        expect(JSON.parse(result!.body)).toEqual({ groups: 'Admin' });
+      } finally {
+        process.env.IS_OFFLINE = originalOffline;
+      }
+    });
+  });
 });

--- a/backend/lib/authenticate.ts
+++ b/backend/lib/authenticate.ts
@@ -1,0 +1,62 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { CognitoJwtVerifier } from 'aws-jwt-verify';
+
+let verifier: ReturnType<typeof CognitoJwtVerifier.create> | null = null;
+
+const getVerifier = () => {
+  if (verifier) return verifier;
+  verifier = CognitoJwtVerifier.create({
+    userPoolId: process.env.COGNITO_USER_POOL_ID!,
+    tokenUse: 'access',
+    clientId: process.env.COGNITO_CLIENT_ID!,
+  });
+  return verifier;
+};
+
+export type AuthenticateResult = { ok: true } | { ok: false };
+
+/**
+ * Verify the Cognito JWT from the Authorization header and populate
+ * event.requestContext.authorizer with the same shape the Lambda token
+ * authorizer produces (principalId, username, email, groups). Handlers can
+ * then continue using getAuthContext / requireRole unchanged.
+ *
+ * In offline mode the JWT check is skipped and a synthetic Admin context is
+ * installed, matching the behaviour of functions/auth/authorizer.ts.
+ */
+export async function authenticate(event: APIGatewayProxyEvent): Promise<AuthenticateResult> {
+  if (process.env.IS_OFFLINE === 'true') {
+    event.requestContext.authorizer = {
+      ...(event.requestContext.authorizer || {}),
+      principalId: 'offline-admin',
+      username: 'offline-admin',
+      email: 'admin@dev.local',
+      groups: 'Admin',
+    };
+    return { ok: true };
+  }
+
+  const header = event.headers?.Authorization || event.headers?.authorization || '';
+  const [scheme, token] = header.split(' ');
+  if (!token || scheme.toLowerCase() !== 'bearer') {
+    return { ok: false };
+  }
+
+  try {
+    const payload = await getVerifier().verify(token);
+    const groups = (payload['cognito:groups'] as string[] | undefined) || [];
+    const username = typeof payload.username === 'string' ? payload.username : payload.sub;
+    const email = typeof payload.email === 'string' ? payload.email : '';
+    event.requestContext.authorizer = {
+      ...(event.requestContext.authorizer || {}),
+      principalId: payload.sub,
+      username,
+      email,
+      groups: groups.join(','),
+    };
+    return { ok: true };
+  } catch (err) {
+    console.error('JWT verification failed:', err);
+    return { ok: false };
+  }
+}

--- a/backend/lib/router.ts
+++ b/backend/lib/router.ts
@@ -1,24 +1,130 @@
 import { APIGatewayProxyEvent, APIGatewayProxyHandler, APIGatewayProxyResult, Context } from "aws-lambda";
-import { methodNotAllowed } from "./response";
+import { methodNotAllowed, notFound, unauthorized } from "./response";
+import { authenticate } from "./authenticate";
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
 export type RouteConfig = {
     resource: string;
     method: HttpMethod;
     handler: APIGatewayProxyHandler;
-}
+    /**
+     * When true, the router verifies the Cognito JWT from the Authorization
+     * header and populates event.requestContext.authorizer before dispatching.
+     * Further role checks (Admin / Moderator / Wrestler / Fantasy) remain the
+     * handler's responsibility via requireRole / requireSuperAdmin.
+     */
+    requireAuth?: boolean;
+};
+
+type CompiledRoute = RouteConfig & {
+    regex: RegExp;
+    paramNames: string[];
+};
 
 const noopCallback = () => {};
-export function createRouter(routes: ReadonlyArray<RouteConfig>): APIGatewayProxyHandler { 
-    const routesMap = new Map<string, APIGatewayProxyHandler>(routes.map(route => [toRouteKey(route.method, route.resource), route.handler]));
-    return async function(event: APIGatewayProxyEvent, context: Context, callback: Parameters<APIGatewayProxyHandler>[2]): Promise<APIGatewayProxyResult> {
-        const routeKey = toRouteKey(event.httpMethod, event.resource);
-        const matchedHandler = routesMap.get(routeKey);
-        if (matchedHandler) {
-            return (await matchedHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
+
+export function createRouter(routes: ReadonlyArray<RouteConfig>): APIGatewayProxyHandler {
+    const compiled: ReadonlyArray<CompiledRoute> = routes.map((route) => {
+        const { regex, paramNames } = compileResource(route.resource);
+        return { ...route, regex, paramNames };
+    });
+    const exactLookup = new Map<string, CompiledRoute>(
+        compiled.map((r) => [toRouteKey(r.method, r.resource), r])
+    );
+
+    return async function (
+        event: APIGatewayProxyEvent,
+        context: Context,
+        callback: Parameters<APIGatewayProxyHandler>[2]
+    ): Promise<APIGatewayProxyResult> {
+        const method = (event.httpMethod || 'GET').toUpperCase();
+        const incomingResource = event.resource || '';
+
+        // Fast path: API Gateway already resolved the route template in
+        // event.resource (traditional per-http-event integration). Match it
+        // exactly — this keeps existing domains that have not been migrated
+        // to /{proxy+} working identically.
+        const exact = exactLookup.get(toRouteKey(method, incomingResource));
+        if (exact) {
+            return dispatch(exact, event, context, callback);
         }
-        return methodNotAllowed();
+        // For legacy per-http-event integrations, event.resource is always a
+        // concrete route template (no {proxy+}). If it isn't in our exact
+        // lookup, the method is unsupported for that template. Preserve the
+        // prior 405 behaviour without falling through to path matching, which
+        // could misroute if event.path carries a stage prefix.
+        if (!incomingResource.includes('{proxy+}')) {
+            return methodNotAllowed();
+        }
+
+        // Fallback: path-regex matching. Used when the Lambda is invoked
+        // behind a /{proxy+} route, where event.resource is something like
+        // '/players/{proxy+}' and the actual routing must be derived from
+        // event.path.
+        const path = normalizePath(event.path || '');
+        const pathMatches = compiled.filter((r) => r.regex.test(path));
+        if (pathMatches.length === 0) return notFound();
+
+        const methodMatches = pathMatches.filter((r) => r.method === method);
+        if (methodMatches.length === 0) return methodNotAllowed();
+
+        // Prefer the most specific match (fewest path parameters); ties go to
+        // declaration order.
+        const matched = methodMatches
+            .map((r, i) => ({ r, i }))
+            .sort((a, b) => a.r.paramNames.length - b.r.paramNames.length || a.i - b.i)[0].r;
+
+        const execResult = matched.regex.exec(path);
+        const existingParams = event.pathParameters || {};
+        const pathParameters: Record<string, string> = {};
+        for (const [k, v] of Object.entries(existingParams)) {
+            if (typeof v === 'string') pathParameters[k] = v;
+        }
+        if (execResult) {
+            matched.paramNames.forEach((name, i) => {
+                const raw = execResult[i + 1];
+                if (raw !== undefined) {
+                    pathParameters[name] = safeDecode(raw);
+                }
+            });
+        }
+        event.pathParameters = pathParameters;
+        event.resource = matched.resource;
+
+        return dispatch(matched, event, context, callback);
+    };
+}
+
+async function dispatch(
+    route: CompiledRoute,
+    event: APIGatewayProxyEvent,
+    context: Context,
+    callback: Parameters<APIGatewayProxyHandler>[2]
+): Promise<APIGatewayProxyResult> {
+    if (route.requireAuth) {
+        const authResult = await authenticate(event);
+        if (!authResult.ok) return unauthorized();
     }
+    return (await route.handler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
+}
+
+function compileResource(resource: string): { regex: RegExp; paramNames: string[] } {
+    const paramNames: string[] = [];
+    const PLACEHOLDER = '\x00';
+    const withPlaceholders = resource.replace(/\{([^}]+)\}/g, (_, name: string) => {
+        paramNames.push(name);
+        return PLACEHOLDER;
+    });
+    const escaped = withPlaceholders.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = escaped.replace(new RegExp(PLACEHOLDER, 'g'), '([^/]+)');
+    return { regex: new RegExp(`^${pattern}$`), paramNames };
+}
+
+function normalizePath(path: string): string {
+    const withLead = path.startsWith('/') ? path : `/${path}`;
+    if (withLead.length > 1 && withLead.endsWith('/')) return withLead.slice(0, -1);
+    return withLead;
 }
 
 function toRouteKey(method: string | undefined, resource: string | undefined): string {
@@ -27,4 +133,10 @@ function toRouteKey(method: string | undefined, resource: string | undefined): s
     return `${normalizedMethod} ${normalizedResource}`;
 }
 
-
+function safeDecode(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -282,19 +282,28 @@ functions:
   # Players (Phase 2 consolidated: getPlayers, createPlayer, updatePlayer, deletePlayer, getMyProfile, updateMyProfile)
   players:
     handler: functions/players/handler.handler
-    # Fronted by a single /{proxy+} route; internal routing + Cognito JWT
-    # verification live in functions/players/handler.ts via lib/router.ts.
-    # Collapses 8 API Gateway methods into 2 (ANY /players + ANY /players/{proxy+}),
-    # dropping CloudFormation stack resources and keeping the public API shape
-    # unchanged for the frontend.
+    # Single Lambda that routes all /players traffic. Per-path methods are
+    # collapsed to ANY (8 http events -> 4) and the gateway-level authorizer
+    # is removed -- JWT verification + role checks happen in-Lambda via
+    # lib/router.ts + lib/authenticate.ts + requireRole. This trims
+    # CloudFormation method/permission resources without introducing a
+    # {proxy+} sibling to {playerId}, which API Gateway rejects.
     events:
       - http:
           path: players
           method: any
           cors: *corsConfig
       - http:
-          path: players/{proxy+}
+          path: players/me
           method: any
+          cors: *corsConfig
+      - http:
+          path: players/{playerId}
+          method: any
+          cors: *corsConfig
+      - http:
+          path: players/{playerId}/statistics
+          method: get
           cors: *corsConfig
 
   # Overalls (Wrestler Overalls: submit, get own, admin get all)

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -282,43 +282,19 @@ functions:
   # Players (Phase 2 consolidated: getPlayers, createPlayer, updatePlayer, deletePlayer, getMyProfile, updateMyProfile)
   players:
     handler: functions/players/handler.handler
+    # Fronted by a single /{proxy+} route; internal routing + Cognito JWT
+    # verification live in functions/players/handler.ts via lib/router.ts.
+    # Collapses 8 API Gateway methods into 2 (ANY /players + ANY /players/{proxy+}),
+    # dropping CloudFormation stack resources and keeping the public API shape
+    # unchanged for the frontend.
     events:
       - http:
-          path: players/me
-          method: get
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: players/me
-          method: put
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
           path: players
-          method: get
+          method: any
           cors: *corsConfig
       - http:
-          path: players
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: players/{playerId}
-          method: put
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: players/{playerId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: players/{playerId}
-          method: get
-          cors: *corsConfig
-      - http:
-          path: players/{playerId}/statistics
-          method: get
+          path: players/{proxy+}
+          method: any
           cors: *corsConfig
 
   # Overalls (Wrestler Overalls: submit, get own, admin get all)


### PR DESCRIPTION
## Summary

Prototype of the CloudFormation-resource reduction plan, applied only to the `/players` domain. The REST API currently has ~172 HTTP events across ~49 Lambdas in a single stack, each event generating multiple CFN resources — which is pushing us toward the 500-resource hard limit.

### First attempt: `/{proxy+}`

The original idea was to front `/players` with a single `ANY /players/{proxy+}` route (8 methods → 2). The devtest deploy rejected that because API Gateway only allows **one** path-variable child per parent resource, and `{playerId}` was still there during the stack update. CloudFormation tried to create `{proxy+}` before deleting `{playerId}` and failed with `UPDATE_ROLLBACK_IN_PROGRESS` on `ApiGatewayResourcePlayersProxyVar`. Stack rolled back cleanly.

### Current approach: ANY-per-path

Keep the existing path shape (so CFN only has to replace Method resources, not path variables) and collapse the per-path method list to ANY:

| Path | Before | After |
|---|---|---|
| `/players` | GET + POST | ANY |
| `/players/me` | GET + PUT | ANY |
| `/players/{playerId}` | GET + PUT + DELETE | ANY |
| `/players/{playerId}/statistics` | GET | GET (unchanged) |

8 http events → 4. Each http event that goes away takes ~2 CFN resources with it (Method + Permission), so this alone should shave ~8 resources from the root stack for just the players function.

### How routing and auth still work

- `serverless.yml`: removes the gateway-level `authorizer: adminAuthorizer` wiring on the players function.
- `lib/router.ts`: path-regex fallback + exact-match fast path. With ANY-per-path, `event.resource` is always a concrete template, so the fast path always wins; the regex fallback is exercised only for future `{proxy+}` migrations.
- `lib/authenticate.ts` (new): verifies the Cognito JWT against the same user pool the Lambda authorizer uses and populates `event.requestContext.authorizer` in the same shape, so downstream `requireRole` / `getAuthContext` calls are unchanged. Offline mode preserved.
- `functions/players/handler.ts`: flags the routes that previously had `authorizer: adminAuthorizer` with `requireAuth: true`. Per-role checks inside handlers remain.

### Not changed

- Public API shape (frontend needs no updates).
- Other domains — same per-route integrations as before. This is opt-in per handler.
- Role enforcement semantics — handlers still call `requireRole` / `requireSuperAdmin`.

### Extrapolation

4 fewer http events here. Applied to the ~30 domains with similar shapes, the full rollout should free ~100–150 CFN resources. If we later want the extra reduction from `{proxy+}`, it needs a dedicated migration that orchestrates the path-variable swap (likely a deploy that removes `{playerId}`-style children first, then a follow-up that adds `{proxy+}`).

## Test plan

- [x] Backend type check clean (`tsc --noEmit`)
- [x] Backend test suite: 959 passed / 0 failed, incl. 6 new router tests for `{proxy+}` + auth (kept in place so the code path is covered for future work)
- [x] Backend lint clean for touched files
- [x] `serverless print` renders the new `players` config
- [ ] Dev deploy via CI → succeeds this time (no path-variable conflict)
- [ ] Smoke test: `GET /players`, `GET /players/me` (with + without token), `POST /players` (with + without token), `PUT /players/{id}` (auth), `DELETE /players/{id}` (auth), `GET /players/{id}/statistics`
- [ ] Confirm rejected/unauthenticated requests return 401 with CORS headers (now served by Lambda, was previously handled by API Gateway)
- [ ] CloudFormation stack resource count decreased by expected amount (~8 fewer)

If the prototype looks good on dev, the follow-up is to apply the same pattern across the other domains in small batches.

https://claude.ai/code/session_015TWGvnin3ZxbTNo4V744uJ