### PR TITLE
refactor(api): collapse events/stables/tag-teams methods to ANY

### DIFF
--- a/backend/functions/events/__tests__/handler.test.ts
+++ b/backend/functions/events/__tests__/handler.test.ts
@@ -41,6 +41,10 @@ vi.mock('../../../lib/auth', () => ({
   requireRole: () => undefined,
 }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 import { handler } from '../handler';
 
 const ctx = {} as Context;

--- a/backend/functions/events/handler.ts
+++ b/backend/functions/events/handler.ts
@@ -25,41 +25,49 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/events',
     method: 'POST',
     handler: createEventHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}',
     method: 'PUT',
     handler: updateEventHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}',
     method: 'DELETE',
     handler: deleteEventHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}/check-in',
     method: 'POST',
     handler: checkInHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}/check-in/me',
     method: 'GET',
     handler: getMyCheckInHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}/check-in',
     method: 'DELETE',
     handler: deleteCheckInHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}/check-ins/summary',
     method: 'GET',
     handler: getCheckInSummaryHandler,
+    requireAuth: true,
   },
   {
     resource: '/events/{eventId}/check-ins',
     method: 'GET',
     handler: getCheckInsHandler,
+    requireAuth: true,
   },
 ];
 export const handler = createRouter(routes);

--- a/backend/functions/stables/handler.ts
+++ b/backend/functions/stables/handler.ts
@@ -36,51 +36,61 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/stables',
     method: 'POST',
     handler: createStableHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}',
     method: 'PUT',
     handler: updateStableHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/approve',
     method: 'POST',
     handler: approveStableHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/reject',
     method: 'POST',
     handler: rejectStableHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/invitations',
     method: 'GET',
     handler: getInvitationsHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/invitations',
     method: 'POST',
     handler: inviteToStableHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/invitations/{invitationId}/respond',
     method: 'POST',
     handler: respondToInvitationHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/disband',
     method: 'POST',
     handler: disbandStableHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}/remove-member',
     method: 'POST',
     handler: removeMemberHandler,
+    requireAuth: true,
   },
   {
     resource: '/stables/{stableId}',
     method: 'DELETE',
     handler: deleteStableHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/tagTeams/handler.ts
+++ b/backend/functions/tagTeams/handler.ts
@@ -33,36 +33,43 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/tag-teams',
     method: 'POST',
     handler: createTagTeamHandler,
+    requireAuth: true,
   },
   {
     resource: '/tag-teams/{tagTeamId}',
     method: 'PUT',
     handler: updateTagTeamHandler,
+    requireAuth: true,
   },
   {
     resource: '/tag-teams/{tagTeamId}/respond',
     method: 'POST',
     handler: respondToTagTeamHandler,
+    requireAuth: true,
   },
   {
     resource: '/tag-teams/{tagTeamId}/approve',
     method: 'POST',
     handler: approveTagTeamHandler,
+    requireAuth: true,
   },
   {
     resource: '/tag-teams/{tagTeamId}/reject',
     method: 'POST',
     handler: rejectTagTeamHandler,
+    requireAuth: true,
   },
   {
     resource: '/tag-teams/{tagTeamId}/dissolve',
     method: 'POST',
     handler: dissolveTagTeamHandler,
+    requireAuth: true,
   },
   {
     resource: '/tag-teams/{tagTeamId}',
     method: 'DELETE',
     handler: deleteTagTeamHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -657,55 +657,33 @@ functions:
   # Events (Phase 2 consolidated: getEvents, getEvent, createEvent, updateEvent, deleteEvent)
   events:
     handler: functions/events/handler.handler
+    # Routes consolidated to ANY-per-path; auth moved in-Lambda via lib/router
+    # requireAuth + lib/authenticate. 10 http events collapsed to 6.
     events:
       - http:
           path: events
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: events/{eventId}
-          method: get
+          method: any
           cors: *corsConfig
-      - http:
-          path: events
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: events/{eventId}
-          method: put
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: events/{eventId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: events/{eventId}/check-in
-          method: post
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: events/{eventId}/check-in/me
           method: get
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: events/{eventId}/check-in
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: events/{eventId}/check-ins/summary
           method: get
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: events/{eventId}/check-ins
           method: get
           cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Contenders (Phase 3 consolidated: getContenders, calculateRankings)
   contenders:
@@ -981,10 +959,14 @@ functions:
   # Stables (consolidated: list, get, standings, create, update, approve, reject, invite, respond, disband, remove-member, delete)
   stables:
     handler: functions/stables/handler.handler
+    # Routes consolidated to ANY-per-path; auth moved in-Lambda via lib/router
+    # requireAuth + lib/authenticate. 13 http events collapsed to 9.
+    # (GET /stables/{stableId} previously had cors:true; now uses the shared
+    # *corsConfig, tightening the preflight Allow-Origin to the frontend.)
     events:
       - http:
           path: stables
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: stables/standings
@@ -992,66 +974,45 @@ functions:
           cors: *corsConfig
       - http:
           path: stables/{stableId}
-          method: get
-          cors: true
-      - http:
-          path: stables
-          method: post
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: stables/{stableId}
-          method: put
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: stables/{stableId}/approve
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: stables/{stableId}/reject
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: stables/{stableId}/invitations
-          method: get
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: stables/{stableId}/invitations
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: stables/{stableId}/invitations/{invitationId}/respond
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: stables/{stableId}/disband
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: stables/{stableId}/remove-member
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: stables/{stableId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Tag Teams (consolidated: list, get, standings, create, update, respond, approve, reject, dissolve, delete)
   tagTeams:
     handler: functions/tagTeams/handler.handler
+    # Routes consolidated to ANY-per-path; auth moved in-Lambda via lib/router
+    # requireAuth + lib/authenticate. 10 http events collapsed to 7.
+    # (GET /tag-teams/{tagTeamId} previously had cors:true; now uses the
+    # shared *corsConfig, tightening the preflight Allow-Origin to the
+    # frontend.)
     events:
       - http:
           path: tag-teams
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: tag-teams/standings
@@ -1059,43 +1020,24 @@ functions:
           cors: *corsConfig
       - http:
           path: tag-teams/{tagTeamId}
-          method: get
-          cors: true
-      - http:
-          path: tag-teams
-          method: post
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: tag-teams/{tagTeamId}
-          method: put
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: tag-teams/{tagTeamId}/respond
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: tag-teams/{tagTeamId}/approve
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: tag-teams/{tagTeamId}/reject
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: tag-teams/{tagTeamId}/dissolve
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: tag-teams/{tagTeamId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Announcements (consolidated: getActive, adminList, create, update, delete)
   videos:


### PR DESCRIPTION
## Summary

Second batch of the CloudFormation resource reduction, continuing the pattern landed in #297. Three more domains collapsed from multi-method-per-path to ANY-per-path, with the gateway-level authorizer replaced by the in-Lambda `requireAuth` plumbing added in the players PR.

| Domain | Before | After | Saved |
|---|---|---|---|
| events | 10 http events | 6 | 4 |
| stables | 13 http events | 9 | 4 |
| tag-teams | 10 http events | 7 | 3 |
| **Total** | **33** | **22** | **11** |

`serverless print` confirms total events: 168 → **157**. Each http event removes ~2 CFN resources (Method + Permission), so roughly **22 resources reclaimed** from the root stack.

### What changed per domain

**events** — `ANY /events` (GET+POST), `ANY /events/{eventId}` (GET+PUT+DELETE), `ANY /events/{eventId}/check-in` (POST+DELETE). Three singleton GETs unchanged.

**stables** — `ANY /stables` (GET+POST), `ANY /stables/{stableId}` (GET+PUT+DELETE), `ANY /stables/{stableId}/invitations` (GET+POST). Seven singleton POSTs unchanged.

**tag-teams** — `ANY /tag-teams` (GET+POST), `ANY /tag-teams/{tagTeamId}` (GET+PUT+DELETE). Five singletons unchanged.

### Side effect worth calling out

`GET /stables/{stableId}` and `GET /tag-teams/{tagTeamId}` previously had `cors: true` (wildcard preflight `Access-Control-Allow-Origin: *`). After consolidation they share the domain's `*corsConfig` anchor, which pins preflight origin to the configured frontend (`https://dev.leagueszn.jpdxsolo.com` on dev, prod equivalent on prod). This is a tightening, not a loosening — the actual GET response origin was already restricted by `response.ts` — but if anyone was hitting those endpoints cross-origin from outside our frontend, the browser preflight will now fail.

### Not in this PR

- **fantasy** (12 events) — uses a hand-rolled path-string router instead of `lib/router.createRouter`. Converting it to the common pattern is a proper refactor and deserves its own PR so the diff is reviewable.
- **matchmaking** (10 events) — every path has exactly one HTTP method, so there's nothing to collapse via ANY without changing the public URL shape. Left alone.

### Auth mechanics (unchanged from #297)

Handlers in each migrated domain's `handler.ts` now have `requireAuth: true` on every route that previously had `authorizer: adminAuthorizer` at the gateway. The router invokes `lib/authenticate.ts` to verify the Cognito JWT and populates `event.requestContext.authorizer` in the same shape the Lambda authorizer produced, so downstream `requireRole` / `getAuthContext` calls need no changes.

## Test plan

- [x] Backend type check clean (`tsc --noEmit`)
- [x] Backend test suite: 959 passed / 0 failed (added `lib/authenticate` mock to `functions/events/__tests__/handler.test.ts`)
- [x] Backend lint clean for touched files
- [x] `serverless print` confirms the new config; total http events 157 (was 168)
- [ ] Dev deploy via CI → succeeds (no path-variable changes, so no CFN conflict of the `{proxy+}` sibling kind)
- [ ] Smoke test, per domain:
  - **events**: list events, view event detail, admin create/update/delete event, user check-in / undo check-in, admin view check-in summary + roster
  - **stables**: list stables, view stable, view standings, admin create/update/approve/reject/delete, owner invite member + respond, owner disband/remove-member
  - **tag-teams**: list tag-teams, view tag-team, view standings, admin create/update/respond/approve/reject/dissolve/delete
- [ ] Auth-failure check (any one of the three domains): admin action with a missing/invalid token returns **401** from the Lambda (not 403, not silent)
- [ ] CloudFormation stack resource count drops by the expected ~22

If green on dev, PR #3 will handle the fantasy handler refactor.

https://claude.ai/code/session_015TWGvnin3ZxbTNo4V744uJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015TWGvnin3ZxbTNo4V744uJ)_