### PR TITLE
refactor(api): collapse 10 more domains to ANY-per-path

### DIFF
--- a/backend/functions/announcements/handler.ts
+++ b/backend/functions/announcements/handler.ts
@@ -20,21 +20,25 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/admin/announcements',
     method: 'GET',
     handler: listAnnouncementsHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/announcements',
     method: 'POST',
     handler: createAnnouncementHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/announcements/{announcementId}',
     method: 'PUT',
     handler: updateAnnouncementHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/announcements/{announcementId}',
     method: 'DELETE',
     handler: deleteAnnouncementHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/challenges/__tests__/handler.test.ts
+++ b/backend/functions/challenges/__tests__/handler.test.ts
@@ -43,6 +43,10 @@ vi.mock('../../../lib/auth', () => ({
   hasRole: () => true,
 }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 import { handler } from '../handler';
 
 const ctx = {} as Context;

--- a/backend/functions/challenges/handler.ts
+++ b/backend/functions/challenges/handler.ts
@@ -26,26 +26,31 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/challenges',
     method: 'POST',
     handler: createChallengeHandler,
+    requireAuth: true,
   },
   {
     resource: '/challenges/{challengeId}/respond',
     method: 'POST',
     handler: respondToChallengeHandler,
+    requireAuth: true,
   },
   {
     resource: '/challenges/{challengeId}/cancel',
     method: 'POST',
     handler: cancelChallengeHandler,
+    requireAuth: true,
   },
   {
     resource: '/challenges/{challengeId}',
     method: 'DELETE',
     handler: deleteChallengeHandler,
+    requireAuth: true,
   },
   {
     resource: '/challenges/bulk-delete',
     method: 'POST',
     handler: bulkDeleteChallengesHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/championships/__tests__/handler.test.ts
+++ b/backend/functions/championships/__tests__/handler.test.ts
@@ -50,6 +50,10 @@ vi.mock('../../../lib/auth', () => ({
   requireRole: () => undefined,
 }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 import { handler } from '../handler';
 
 const ctx = {} as Context;

--- a/backend/functions/championships/handler.ts
+++ b/backend/functions/championships/handler.ts
@@ -20,6 +20,7 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/championships',
     method: 'POST',
     handler: createChampionshipHandler,
+    requireAuth: true,
   },
   {
     resource: '/championships/{championshipId}/history',
@@ -30,16 +31,19 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/championships/{championshipId}',
     method: 'PUT',
     handler: updateChampionshipHandler,
+    requireAuth: true,
   },
   {
     resource: '/championships/{championshipId}',
     method: 'DELETE',
     handler: deleteChampionshipHandler,
+    requireAuth: true,
   },
   {
     resource: '/championships/{championshipId}/vacate',
     method: 'POST',
     handler: vacateChampionshipHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/companies/handler.ts
+++ b/backend/functions/companies/handler.ts
@@ -15,6 +15,7 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/companies',
     method: 'POST',
     handler: createCompanyHandler,
+    requireAuth: true,
   },
   {
     resource: '/companies/{companyId}',
@@ -25,11 +26,13 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/companies/{companyId}',
     method: 'PUT',
     handler: updateCompanyHandler,
+    requireAuth: true,
   },
   {
     resource: '/companies/{companyId}',
     method: 'DELETE',
     handler: deleteCompanyHandler,
+    requireAuth: true,
   },
 ];
 export const handler = createRouter(routes);

--- a/backend/functions/contenders/__tests__/handler.test.ts
+++ b/backend/functions/contenders/__tests__/handler.test.ts
@@ -7,6 +7,10 @@ const mockCalculateRankings = vi.fn();
 vi.mock('../getContenders', () => ({ handler: (...args: unknown[]) => mockGetContenders(...args) }));
 vi.mock('../calculateRankings', () => ({ handler: (...args: unknown[]) => mockCalculateRankings(...args) }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 import { handler } from '../handler';
 
 const ctx = {} as Context;

--- a/backend/functions/contenders/handler.ts
+++ b/backend/functions/contenders/handler.ts
@@ -4,7 +4,8 @@ import {
   APIGatewayProxyResult,
   Context,
 } from 'aws-lambda';
-import { methodNotAllowed } from '../../lib/response';
+import { methodNotAllowed, unauthorized } from '../../lib/response';
+import { authenticate } from '../../lib/authenticate';
 import { handler as getContendersHandler } from './getContenders';
 import { handler as calculateRankingsHandler } from './calculateRankings';
 import { handler as setOverrideHandler } from './setOverride';
@@ -13,10 +14,18 @@ import { handler as getOverridesHandler } from './getOverrides';
 
 const noopCallback = () => {};
 
+async function requireAuth(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult | null> {
+  const authResult = await authenticate(event);
+  if (!authResult.ok) return unauthorized();
+  return null;
+}
+
 /**
  * Single Lambda for contenders: routes by HTTP method and path.
  * Replaces getContenders, calculateRankings, and override CRUD.
  * Timeout 29s for calculateRankings (set in serverless.yml).
+ * Admin routes authenticate in-Lambda via lib/authenticate (gateway-level
+ * authorizer removed as part of CloudFormation resource reduction).
  */
 export const handler: APIGatewayProxyHandler = async (
   event: APIGatewayProxyEvent,
@@ -36,17 +45,25 @@ export const handler: APIGatewayProxyHandler = async (
   // Override routes: POST, DELETE, GET on /overrides
   if (path.includes('overrides')) {
     if (method === 'POST') {
+      const denied = await requireAuth(event);
+      if (denied) return denied;
       return (await setOverrideHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
     }
     if (method === 'DELETE' && pathParams.championshipId && pathParams.playerId) {
+      const denied = await requireAuth(event);
+      if (denied) return denied;
       return (await removeOverrideHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
     }
     if (method === 'GET') {
+      const denied = await requireAuth(event);
+      if (denied) return denied;
       return (await getOverridesHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
     }
   }
 
   if (path.includes('recalculate') && method === 'POST') {
+    const denied = await requireAuth(event);
+    if (denied) return denied;
     return (await calculateRankingsHandler(event, context, callback ?? noopCallback)) as APIGatewayProxyResult;
   }
   if (method === 'GET' && pathParams.championshipId) {

--- a/backend/functions/matchTypes/handler.ts
+++ b/backend/functions/matchTypes/handler.ts
@@ -17,16 +17,19 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/match-types',
     method: 'POST',
     handler: createMatchTypeHandler,
+    requireAuth: true,
   },
   {
     resource: '/match-types/{matchTypeId}',
     method: 'PUT',
     handler: updateMatchTypeHandler,
+    requireAuth: true,
   },
   {
     resource: '/match-types/{matchTypeId}',
     method: 'DELETE',
     handler: deleteMatchTypeHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/matches/__tests__/handler.test.ts
+++ b/backend/functions/matches/__tests__/handler.test.ts
@@ -9,6 +9,10 @@ vi.mock('../getMatches', () => ({ handler: (...args: unknown[]) => mockGetMatche
 vi.mock('../scheduleMatch', () => ({ handler: (...args: unknown[]) => mockScheduleMatch(...args) }));
 vi.mock('../recordResult', () => ({ handler: (...args: unknown[]) => mockRecordResult(...args) }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 import { handler } from '../handler';
 
 const ctx = {} as Context;

--- a/backend/functions/matches/handler.ts
+++ b/backend/functions/matches/handler.ts
@@ -19,21 +19,25 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/matches',
     method: 'POST',
     handler: scheduleMatchHandler,
+    requireAuth: true,
   },
   {
     resource: '/matches/{matchId}/result',
     method: 'PUT',
     handler: recordResultHandler,
+    requireAuth: true,
   },
   {
     resource: '/matches/{matchId}',
     method: 'PUT',
     handler: updateMatchHandler,
+    requireAuth: true,
   },
   {
     resource: '/matches/{matchId}',
     method: 'DELETE',
     handler: deleteMatchHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/promos/__tests__/handler.test.ts
+++ b/backend/functions/promos/__tests__/handler.test.ts
@@ -40,6 +40,10 @@ vi.mock('../../../lib/auth', () => ({
   hasRole: () => true,
 }));
 
+vi.mock('../../../lib/authenticate', () => ({
+  authenticate: async () => ({ ok: true }),
+}));
+
 vi.mock('../../../lib/parseBody', () => ({
   parseBody: (event: { body: string | null }) => {
     if (!event.body) return { data: null, error: { statusCode: 400, body: JSON.stringify({ message: 'Bad' }) } };

--- a/backend/functions/promos/handler.ts
+++ b/backend/functions/promos/handler.ts
@@ -26,26 +26,31 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/promos',
     method: 'POST',
     handler: createPromoHandler,
+    requireAuth: true,
   },
   {
     resource: '/promos/{promoId}/react',
     method: 'POST',
     handler: reactToPromoHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/promos/{promoId}',
     method: 'PUT',
     handler: adminUpdatePromoHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/promos/{promoId}',
     method: 'DELETE',
     handler: deletePromoHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/promos/bulk-delete',
     method: 'POST',
     handler: bulkDeletePromosHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/functions/shows/handler.ts
+++ b/backend/functions/shows/handler.ts
@@ -15,6 +15,7 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/shows',
     method: 'POST',
     handler: createShowHandler,
+    requireAuth: true,
   },
   {
     resource: '/shows/{showId}',
@@ -25,11 +26,13 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/shows/{showId}',
     method: 'PUT',
     handler: updateShowHandler,
+    requireAuth: true,
   },
   {
     resource: '/shows/{showId}',
     method: 'DELETE',
     handler: deleteShowHandler,
+    requireAuth: true,
   },
 ];
 export const handler = createRouter(routes);

--- a/backend/functions/videos/handler.ts
+++ b/backend/functions/videos/handler.ts
@@ -21,21 +21,25 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/admin/videos',
     method: 'GET',
     handler: listVideosHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/videos',
     method: 'POST',
     handler: createVideoHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/videos/{videoId}',
     method: 'PUT',
     handler: updateVideoHandler,
+    requireAuth: true,
   },
   {
     resource: '/admin/videos/{videoId}',
     method: 'DELETE',
     handler: deleteVideoHandler,
+    requireAuth: true,
   },
 ];
 

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -373,28 +373,16 @@ functions:
     events:
       - http:
           path: matches
-          method: get
+          method: any
           cors: *corsConfig
-      - http:
-          path: matches
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: matches/{matchId}/result
           method: put
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: matches/{matchId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: matches/{matchId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Championships (Phase 2 consolidated: getChampionships, createChampionship, getChampionshipHistory, updateChampionship, deleteChampionship, vacateChampionship)
   championships:
@@ -402,32 +390,20 @@ functions:
     events:
       - http:
           path: championships
-          method: get
+          method: any
           cors: *corsConfig
-      - http:
-          path: championships
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: championships/{championshipId}/history
           method: get
           cors: *corsConfig
       - http:
           path: championships/{championshipId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: championships/{championshipId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: championships/{championshipId}/vacate
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Tournaments (Phase 3 consolidated: getTournaments, createTournament, updateTournament)
   tournaments:
@@ -524,27 +500,12 @@ functions:
     events:
       - http:
           path: companies
-          method: get
-          cors: *corsConfig
-      - http:
-          path: companies
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: companies/{companyId}
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: companies/{companyId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: companies/{companyId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Shows (CRUD for wrestling shows, linked to companies)
   shows:
@@ -552,27 +513,12 @@ functions:
     events:
       - http:
           path: shows
-          method: get
-          cors: *corsConfig
-      - http:
-          path: shows
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: shows/{showId}
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: shows/{showId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: shows/{showId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Divisions (Phase 1 consolidated: getDivisions, createDivision, updateDivision, deleteDivision)
   divisions:
@@ -628,23 +574,12 @@ functions:
     events:
       - http:
           path: match-types
-          method: get
+          method: any
           cors: *corsConfig
-      - http:
-          path: match-types
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: match-types/{matchTypeId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: match-types/{matchTypeId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Events (Phase 2 consolidated: getEvents, getEvent, createEvent, updateEvent, deleteEvent)
   events:
@@ -690,22 +625,14 @@ functions:
           path: admin/contenders/recalculate
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: admin/contenders/overrides
-          method: post
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: admin/contenders/overrides/{championshipId}/{playerId}
           method: delete
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: admin/contenders/overrides
-          method: get
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Images
   generateUploadUrl:
@@ -759,37 +686,24 @@ functions:
     events:
       - http:
           path: challenges
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: challenges/{challengeId}
-          method: get
-          cors: true
-      - http:
-          path: challenges
-          method: post
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: challenges/{challengeId}/respond
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: challenges/{challengeId}/cancel
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: challenges/{challengeId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: challenges/bulk-delete
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Matchmaking (consolidated: heartbeat, presence, queue join/leave/list, online, invite, invitations list/accept/decline)
   matchmaking:
@@ -852,37 +766,24 @@ functions:
     events:
       - http:
           path: promos
-          method: get
+          method: any
           cors: *corsConfig
       - http:
           path: promos/{promoId}
           method: get
           cors: *corsConfig
       - http:
-          path: promos
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
           path: promos/{promoId}/react
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: admin/promos/{promoId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: admin/promos/{promoId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: admin/promos/bulk-delete
           method: post
           cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Stables (consolidated: list, get, standings, create, update, approve, reject, invite, respond, disband, remove-member, delete)
   stables:
@@ -981,24 +882,12 @@ functions:
           cors: *corsConfig
       - http:
           path: admin/videos
-          method: get
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: admin/videos
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: admin/videos/{videoId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: admin/videos/{videoId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   announcements:
     handler: functions/announcements/handler.handler
@@ -1009,24 +898,12 @@ functions:
           cors: *corsConfig
       - http:
           path: admin/announcements
-          method: get
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: admin/announcements
-          method: post
-          cors: *corsConfig
-          authorizer: adminAuthorizer
       - http:
           path: admin/announcements/{announcementId}
-          method: put
+          method: any
           cors: *corsConfig
-          authorizer: adminAuthorizer
-      - http:
-          path: admin/announcements/{announcementId}
-          method: delete
-          cors: *corsConfig
-          authorizer: adminAuthorizer
 
   # Notifications (consolidated: list, unreadCount, markRead, markAllRead)
   notifications:


### PR DESCRIPTION
## Summary

Third batch of the CloudFormation resource reduction, continuing the pattern from #297 and #298. Ten more domains collapsed from multi-method-per-path to ANY-per-path, with gateway-level `authorizer: adminAuthorizer` wiring replaced by the in-Lambda `requireAuth` plumbing that landed in the players PR.

| Domain | Before | After | Saved |
|---|---|---|---|
| matches | 5 | 3 | 2 |
| championships | 6 | 4 | 2 |
| companies | 5 | 2 | 3 |
| shows | 5 | 2 | 3 |
| matchTypes | 4 | 2 | 2 |
| contenders | 5 | 4 | 1 |
| challenges | 7 | 5 | 2 |
| promos | 7 | 5 | 2 |
| videos | 6 | 4 | 2 |
| announcements | 5 | 3 | 2 |
| **Total** | **55** | **34** | **21** |

`serverless print` confirms total http events across the service: **145 → 124**. Each collapsed http event removes ~2 CFN resources (Method + Permission), so roughly **~42 more CFN resources** reclaimed on top of prior PRs.

### Noteworthy

- **`GET /challenges/{challengeId}`** previously had `cors: true` (wildcard preflight origin). It now shares `*corsConfig`, pinning `Allow-Origin` to the configured frontend. Same tightening applied to `/stables/{stableId}` and `/tag-teams/{tagTeamId}` in #298.
- **`functions/contenders/handler.ts`** doesn't use `createRouter` — it has a hand-rolled `if/else` dispatcher. Rather than refactoring it to `createRouter` (bigger change), added a small inline `requireAuth` helper that calls `lib/authenticate.authenticate()` and returns `unauthorized()` on failure, guarding each admin branch. Public `getContenders` path unchanged. The existing direct-Lambda invocation path (`source === 'recordResult'`) continues to bypass auth.
- **Tests**: added `vi.mock('../../../lib/authenticate', ...)` alongside the existing `lib/auth` mock in handler.test.ts for `matches`, `championships`, `contenders`, `challenges`, `promos`.

### Not in this PR

- **`notifications` (6 events)** — every path has exactly one method, no ANY collapse possible without changing public URLs.
- **The remaining 4-event-and-under domains** (`users`, `transfers`, `storylineRequests`, `stipulations`, `seasons`, `matchTypes`-wait-included, `divisions`, `tournaments`, `seasonAwards`, `overalls`, `admin`) — most are singleton-per-path shapes; any ANY collapse opportunities would be single-digit wins. Can revisit if we still need more headroom after this deploys.

## Test plan

- [x] Backend `tsc --noEmit`: clean
- [x] Backend `vitest run`: **828 / 828 passed**
- [x] Backend `eslint functions/ lib/`: clean
- [x] `serverless print` renders cleanly; http event count 124 (was 145)
- [ ] Dev deploy via CI: expects success, no path-variable shape changes
- [ ] Smoke test one or two of the migrated surfaces (championships admin, promo admin, announcement admin, video admin) — same 401 semantics change as prior PRs: unauthenticated admin requests now get a JSON 401 from Lambda instead of gateway
- [ ] Split-stacks summary line: should show the root stack ~42 resources lower than before

https://claude.ai/code/session_015TWGvnin3ZxbTNo4V744uJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015TWGvnin3ZxbTNo4V744uJ)_