### PR TITLE
Implements #294 P1 — Player linkage + wrestler assignment migration

### DIFF
--- a/backend/functions/players/__tests__/wrestlerAssignment.test.ts
+++ b/backend/functions/players/__tests__/wrestlerAssignment.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+// Hoisted dynamoDb mock (some callers still poke dynamoDb directly for
+// unrelated cleanup queries — e.g., deletePlayer season-standings scan).
+const { mockQuery: mockDynamoQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock('../../../lib/dynamodb', () => ({
+  dynamoDb: {
+    get: vi.fn(),
+    put: vi.fn(),
+    scan: vi.fn(),
+    query: mockDynamoQuery,
+    update: vi.fn(),
+    delete: vi.fn(),
+    scanAll: vi.fn(),
+    queryAll: vi.fn(),
+  },
+  TableNames: {
+    PLAYERS: 'Players',
+    WRESTLERS: 'Wrestlers',
+    DIVISIONS: 'Divisions',
+    CHAMPIONSHIPS: 'Championships',
+    SEASON_STANDINGS: 'SeasonStandings',
+    SEASONS: 'Seasons',
+    STABLES: 'Stables',
+    TAG_TEAMS: 'TagTeams',
+    STABLE_INVITATIONS: 'StableInvitations',
+  },
+}));
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+
+import { handler as createPlayer } from '../createPlayer';
+import { handler as updatePlayer } from '../updatePlayer';
+import { handler as deletePlayer } from '../deletePlayer';
+import { handler as updateMyProfile } from '../updateMyProfile';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: '/',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: { authorizer: {} } as unknown as APIGatewayProxyEvent['requestContext'],
+    ...overrides,
+  };
+}
+
+function withWrestlerAuth(event: APIGatewayProxyEvent, sub = 'user-sub-1') {
+  return {
+    ...event,
+    requestContext: {
+      ...event.requestContext,
+      authorizer: { groups: 'Wrestler', username: 't', email: 't@t', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seedWrestler(name: string) {
+  return repos.roster.wrestlers.create({
+    promotion: 'WWE',
+    name,
+    overallCap: 88,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+  mockDynamoQuery.mockResolvedValue({ Items: [] });
+});
+
+// ─── createPlayer with FK ────────────────────────────────────────────
+
+describe('createPlayer with wrestlerId FK', () => {
+  it('creates player, fills denormalized name from wrestler, marks wrestler in-use', async () => {
+    const rock = await seedWrestler('The Rock');
+
+    const event = makeEvent({
+      body: JSON.stringify({ name: 'John', currentWrestlerId: rock.wrestlerId }),
+    });
+    const result = await createPlayer(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const body = JSON.parse(result!.body);
+    expect(body.currentWrestlerId).toBe(rock.wrestlerId);
+    expect(body.currentWrestler).toBe('The Rock');
+
+    const after = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    expect(after?.isInUse).toBe(true);
+    expect(after?.assignedPlayerId).toBe(body.playerId);
+    expect(after?.assignedSlot).toBe('primary');
+  });
+
+  it('assigns both primary and alternate in a single request', async () => {
+    const rock = await seedWrestler('The Rock');
+    const cena = await seedWrestler('John Cena');
+
+    const event = makeEvent({
+      body: JSON.stringify({
+        name: 'Player A',
+        currentWrestlerId: rock.wrestlerId,
+        alternateWrestlerId: cena.wrestlerId,
+      }),
+    });
+    const result = await createPlayer(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const rockAfter = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    const cenaAfter = await repos.roster.wrestlers.findById(cena.wrestlerId);
+    expect(rockAfter?.assignedSlot).toBe('primary');
+    expect(cenaAfter?.assignedSlot).toBe('alternate');
+  });
+
+  it('rejects with 409 when wrestler is already assigned to another player', async () => {
+    const rock = await seedWrestler('The Rock');
+    await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'First', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+
+    const second = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'Second', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+
+    expect(second!.statusCode).toBe(409);
+  });
+
+  it('rejects with 404 when wrestlerId does not exist', async () => {
+    const result = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestlerId: 'does-not-exist' }) }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('rejects with 400 when same wrestler is used for both slots', async () => {
+    const rock = await seedWrestler('The Rock');
+    const result = await createPlayer(
+      makeEvent({
+        body: JSON.stringify({
+          name: 'X',
+          currentWrestlerId: rock.wrestlerId,
+          alternateWrestlerId: rock.wrestlerId,
+        }),
+      }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(400);
+  });
+
+  it('legacy free-text path still works when no FK is provided', async () => {
+    const result = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestler: 'Free Text' }) }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(201);
+    expect(JSON.parse(result!.body).currentWrestler).toBe('Free Text');
+    expect(JSON.parse(result!.body).currentWrestlerId).toBeUndefined();
+  });
+});
+
+// ─── updatePlayer FK transitions ─────────────────────────────────────
+
+describe('updatePlayer FK transitions', () => {
+  it('assigning a new currentWrestlerId releases the old one', async () => {
+    const rock = await seedWrestler('The Rock');
+    const cena = await seedWrestler('John Cena');
+    const createRes = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+    const playerId = JSON.parse(createRes!.body).playerId;
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId },
+        body: JSON.stringify({ currentWrestlerId: cena.wrestlerId }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    const rockAfter = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    const cenaAfter = await repos.roster.wrestlers.findById(cena.wrestlerId);
+    expect(rockAfter?.isInUse).toBe(false);
+    expect(rockAfter?.assignedPlayerId).toBeUndefined();
+    expect(cenaAfter?.isInUse).toBe(true);
+    expect(cenaAfter?.assignedPlayerId).toBe(playerId);
+  });
+
+  it('clears currentWrestlerId when set to null and releases wrestler', async () => {
+    const rock = await seedWrestler('The Rock');
+    const createRes = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+    const playerId = JSON.parse(createRes!.body).playerId;
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId },
+        body: JSON.stringify({ currentWrestlerId: null }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    const rockAfter = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    expect(rockAfter?.isInUse).toBe(false);
+  });
+
+  it('rejects with 409 when trying to pick another player’s wrestler', async () => {
+    const rock = await seedWrestler('The Rock');
+    await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'Owner', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+    const other = await repos.roster.players.create({ name: 'Other', currentWrestler: 'Tmp' });
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId: other.playerId },
+        body: JSON.stringify({ currentWrestlerId: rock.wrestlerId }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(409);
+  });
+
+  it('allows idempotent re-assignment of the same wrestler to same slot', async () => {
+    const rock = await seedWrestler('The Rock');
+    const createRes = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+    const playerId = JSON.parse(createRes!.body).playerId;
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId },
+        body: JSON.stringify({ currentWrestlerId: rock.wrestlerId }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+  });
+});
+
+// ─── deletePlayer releases wrestlers ────────────────────────────────
+
+describe('deletePlayer releases assigned wrestlers', () => {
+  it('releases both primary and alternate on player delete', async () => {
+    const rock = await seedWrestler('The Rock');
+    const cena = await seedWrestler('John Cena');
+    const createRes = await createPlayer(
+      makeEvent({
+        body: JSON.stringify({
+          name: 'X',
+          currentWrestlerId: rock.wrestlerId,
+          alternateWrestlerId: cena.wrestlerId,
+        }),
+      }),
+      ctx,
+      cb,
+    );
+    const playerId = JSON.parse(createRes!.body).playerId;
+
+    const result = await deletePlayer(
+      makeEvent({ httpMethod: 'DELETE', pathParameters: { playerId } }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(204);
+
+    const rockAfter = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    const cenaAfter = await repos.roster.wrestlers.findById(cena.wrestlerId);
+    expect(rockAfter?.isInUse).toBe(false);
+    expect(cenaAfter?.isInUse).toBe(false);
+  });
+});
+
+// ─── updateMyProfile FK transitions ─────────────────────────────────
+
+describe('updateMyProfile with FK fields', () => {
+  it('allows self-service to swap primary wrestler via FK', async () => {
+    const rock = await seedWrestler('The Rock');
+    const cena = await seedWrestler('John Cena');
+    const createRes = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+    const playerId = JSON.parse(createRes!.body).playerId;
+    await repos.roster.players.update(playerId, { userId: 'user-sub-1' });
+
+    const result = await updateMyProfile(
+      withWrestlerAuth(
+        makeEvent({
+          httpMethod: 'PUT',
+          body: JSON.stringify({ currentWrestlerId: cena.wrestlerId }),
+        }),
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).currentWrestlerId).toBe(cena.wrestlerId);
+    expect(JSON.parse(result!.body).currentWrestler).toBe('John Cena');
+
+    const rockAfter = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    expect(rockAfter?.isInUse).toBe(false);
+  });
+
+  it('rejects when self-service tries to claim another player’s wrestler', async () => {
+    const rock = await seedWrestler('The Rock');
+    await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'Owner', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+
+    const me = await repos.roster.players.create({ name: 'Me', currentWrestler: 'Tmp' });
+    await repos.roster.players.update(me.playerId, { userId: 'user-sub-1' });
+
+    const result = await updateMyProfile(
+      withWrestlerAuth(
+        makeEvent({
+          httpMethod: 'PUT',
+          body: JSON.stringify({ currentWrestlerId: rock.wrestlerId }),
+        }),
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(409);
+  });
+});

--- a/backend/functions/players/createPlayer.ts
+++ b/backend/functions/players/createPlayer.ts
@@ -1,21 +1,156 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
-import { notFound } from '../../lib/response';
-import { createHandlerFactory } from '../../lib/handlers';
+import { ConcurrencyError, ConflictError } from '../../lib/repositories/errors';
+import {
+  badRequest,
+  conflict,
+  created,
+  notFound,
+  serverError,
+} from '../../lib/response';
+import { parseBody } from '../../lib/parseBody';
 import type { PlayerCreateInput } from '../../lib/repositories';
-import type { Player } from '../../lib/repositories/types';
+import {
+  rejectDuplicateSlotAssignment,
+  resolveWrestlerForAssignment,
+} from './wrestlerAssignment';
 
-export const handler = createHandlerFactory<PlayerCreateInput, Player>({
-  repo: () => getRepositories().roster.players,
-  entityName: 'player',
-  requiredFields: ['name', 'currentWrestler'],
-  optionalFields: ['imageUrl', 'divisionId', 'psnId'],
-  validate: async (body) => {
-    if (body.divisionId) {
-      const division = await getRepositories().leagueOps.divisions.findById(body.divisionId as string);
+/**
+ * Create a player. Accepts either the legacy free-text `currentWrestler`
+ * string (kept for migration) or the new `currentWrestlerId` FK. When FKs
+ * are provided, the wrestlers' `isInUse` + `assignedPlayerId` + `assignedSlot`
+ * are staged in a single UoW after the player row is written. The player
+ * record carries both the denormalized name (display cache) and the FK.
+ */
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const { data: body, error: parseError } = parseBody(event);
+    if (parseError) return parseError;
+
+    const raw = body as Record<string, unknown>;
+
+    if (typeof raw.name !== 'string' || raw.name.trim().length === 0) {
+      return badRequest('name is required');
+    }
+
+    const currentWrestlerId =
+      typeof raw.currentWrestlerId === 'string' && raw.currentWrestlerId.length > 0
+        ? raw.currentWrestlerId
+        : undefined;
+    const alternateWrestlerId =
+      typeof raw.alternateWrestlerId === 'string' &&
+      raw.alternateWrestlerId.length > 0
+        ? raw.alternateWrestlerId
+        : undefined;
+
+    const dupError = rejectDuplicateSlotAssignment(
+      currentWrestlerId,
+      alternateWrestlerId,
+    );
+    if (dupError) return dupError;
+
+    // Resolve FK wrestlers up-front (if any) so we can populate the
+    // denormalized `currentWrestler` / `alternateWrestler` name fields from
+    // the roster and fail fast on conflicts before any writes.
+    let resolvedCurrent: string | undefined;
+    let resolvedAlternate: string | undefined;
+    if (currentWrestlerId) {
+      const r = await resolveWrestlerForAssignment(
+        currentWrestlerId,
+        null,
+        'primary',
+      );
+      if ('error' in r) return r.error;
+      resolvedCurrent = r.wrestler.name;
+    }
+    if (alternateWrestlerId) {
+      const r = await resolveWrestlerForAssignment(
+        alternateWrestlerId,
+        null,
+        'alternate',
+      );
+      if ('error' in r) return r.error;
+      resolvedAlternate = r.wrestler.name;
+    }
+
+    // Legacy path: admin supplies `currentWrestler` as free text. Required
+    // unless the new FK path is used.
+    const currentWrestlerFreeText =
+      typeof raw.currentWrestler === 'string' ? raw.currentWrestler : undefined;
+    const currentWrestler = resolvedCurrent ?? currentWrestlerFreeText;
+    if (!currentWrestler) {
+      return badRequest('currentWrestler or currentWrestlerId is required');
+    }
+
+    const alternateWrestlerFreeText =
+      typeof raw.alternateWrestler === 'string'
+        ? raw.alternateWrestler
+        : undefined;
+    const alternateWrestler = resolvedAlternate ?? alternateWrestlerFreeText;
+
+    if (typeof raw.divisionId === 'string' && raw.divisionId.length > 0) {
+      const division = await getRepositories().leagueOps.divisions.findById(
+        raw.divisionId,
+      );
       if (!division) {
-        return notFound(`Division ${body.divisionId} not found`);
+        return notFound(`Division ${raw.divisionId} not found`);
       }
     }
-    return null;
-  },
-});
+
+    const input: PlayerCreateInput = {
+      name: raw.name,
+      currentWrestler,
+      ...(alternateWrestler ? { alternateWrestler } : {}),
+      ...(currentWrestlerId ? { currentWrestlerId } : {}),
+      ...(alternateWrestlerId ? { alternateWrestlerId } : {}),
+      ...(typeof raw.imageUrl === 'string' ? { imageUrl: raw.imageUrl } : {}),
+      ...(typeof raw.psnId === 'string' ? { psnId: raw.psnId } : {}),
+      ...(typeof raw.divisionId === 'string' && raw.divisionId.length > 0
+        ? { divisionId: raw.divisionId }
+        : {}),
+    };
+
+    const { roster, runInTransaction } = getRepositories();
+    const player = await roster.players.create(input);
+
+    if (currentWrestlerId || alternateWrestlerId) {
+      try {
+        await runInTransaction(async (tx) => {
+          if (currentWrestlerId) {
+            tx.assignWrestlerToPlayer({
+              wrestlerId: currentWrestlerId,
+              playerId: player.playerId,
+              slot: 'primary',
+            });
+          }
+          if (alternateWrestlerId) {
+            tx.assignWrestlerToPlayer({
+              wrestlerId: alternateWrestlerId,
+              playerId: player.playerId,
+              slot: 'alternate',
+            });
+          }
+        });
+      } catch (assignErr) {
+        // Best-effort compensation: the player row is already written but the
+        // wrestler assignment failed. Remove the orphan so the admin can
+        // retry cleanly.
+        console.error(
+          'Wrestler assignment failed after player create; rolling back player',
+          assignErr,
+        );
+        await roster.players.delete(player.playerId).catch((cleanupErr) => {
+          console.error('Rollback delete also failed', cleanupErr);
+        });
+        throw assignErr;
+      }
+    }
+
+    return created(player);
+  } catch (err) {
+    if (err instanceof ConflictError) return conflict(err.message);
+    if (err instanceof ConcurrencyError) return conflict(err.message);
+    console.error('Error creating player:', err);
+    return serverError('Failed to create player');
+  }
+};

--- a/backend/functions/players/deletePlayer.ts
+++ b/backend/functions/players/deletePlayer.ts
@@ -105,6 +105,21 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       );
     }
 
+    // Release any assigned wrestlers so the roster entries become available
+    // again. Done before the player delete so the wrestler rows are freed
+    // even if the delete call surfaces an error later.
+    const toRelease: string[] = [];
+    if (player.currentWrestlerId) toRelease.push(player.currentWrestlerId);
+    if (player.alternateWrestlerId) toRelease.push(player.alternateWrestlerId);
+    if (toRelease.length > 0) {
+      const { runInTransaction } = getRepositories();
+      await runInTransaction(async (tx) => {
+        for (const wrestlerId of toRelease) {
+          tx.releaseWrestlerFromPlayer({ wrestlerId });
+        }
+      });
+    }
+
     // Delete the player
     await players.delete(playerId);
 

--- a/backend/functions/players/updateMyProfile.ts
+++ b/backend/functions/players/updateMyProfile.ts
@@ -5,10 +5,33 @@ import { success, badRequest, notFound, serverError } from '../../lib/response';
 import { parseBody } from '../../lib/parseBody';
 import { getAuthContext, requireRole } from '../../lib/auth';
 import type { PlayerPatch } from '../../lib/repositories';
+import {
+  rejectDuplicateSlotAssignment,
+  resolveWrestlerForAssignment,
+} from './wrestlerAssignment';
 
-const ALLOWED_FIELDS = ['name', 'currentWrestler', 'alternateWrestler', 'imageUrl', 'psnId', 'alignment'];
+const STRING_FIELDS = [
+  'name',
+  'currentWrestler',
+  'alternateWrestler',
+  'imageUrl',
+  'psnId',
+  'alignment',
+] as const;
+const FK_FIELDS = ['currentWrestlerId', 'alternateWrestlerId'] as const;
 const MAX_NAME_LENGTH = 100;
 const MAX_URL_LENGTH = 2048;
+
+type SlotChange = { present: false } | { present: true; newId: string | null };
+
+function parseSlotChange(value: unknown): SlotChange {
+  if (value === undefined) return { present: false };
+  if (value === null || value === '') return { present: true, newId: null };
+  if (typeof value === 'string' && value.length > 0) {
+    return { present: true, newId: value };
+  }
+  return { present: false };
+}
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   const denied = requireRole(event, 'Wrestler');
@@ -16,75 +39,152 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
   try {
     const { sub } = getAuthContext(event);
-
     const { data: body, error: parseError } = parseBody(event);
     if (parseError) return parseError;
 
-    // Look up the player by userId
-    const player = await getRepositories().roster.players.findByUserId(sub);
-
-    if (!player) {
-      return notFound('No player profile found for this user');
-    }
-
+    const { roster, runInTransaction } = getRepositories();
+    const player = await roster.players.findByUserId(sub);
+    if (!player) return notFound('No player profile found for this user');
     const playerId = player.playerId;
 
-    // Build patch from whitelisted fields only
     const patch: PlayerPatch = {};
     let hasChanges = false;
 
-    for (const field of ALLOWED_FIELDS) {
-      if (body[field] !== undefined) {
-        const value = body[field];
+    // Validate and apply string fields.
+    for (const field of STRING_FIELDS) {
+      if (body[field] === undefined) continue;
+      const value = body[field];
+      if (typeof value !== 'string') {
+        return badRequest(`Field ${field} must be a string`);
+      }
 
-        if (typeof value !== 'string') {
-          return badRequest(`Field ${field} must be a string`);
-        }
-
-        if (field === 'alternateWrestler' && value === '') {
+      if (field === 'alternateWrestler' && value === '') {
+        // Only let the legacy text clear when no FK is being set on the slot.
+        if (body.alternateWrestlerId === undefined) {
           patch.alternateWrestler = undefined;
+          hasChanges = true;
+        }
+        continue;
+      }
+
+      if (field === 'alignment') {
+        if (value === '') {
+          patch.alignment = undefined;
           hasChanges = true;
           continue;
         }
-
-        if (field === 'alignment') {
-          if (value === '') {
-            patch.alignment = undefined;
-            hasChanges = true;
-            continue;
-          }
-          if (!['face', 'heel', 'neutral'].includes(value)) {
-            return badRequest('Invalid alignment. Must be face, heel, or neutral');
-          }
+        if (!['face', 'heel', 'neutral'].includes(value)) {
+          return badRequest('Invalid alignment. Must be face, heel, or neutral');
         }
-
-        if ((field === 'name' || field === 'currentWrestler' || field === 'alternateWrestler') && value.length > MAX_NAME_LENGTH) {
-          return badRequest(`Field ${field} must be ${MAX_NAME_LENGTH} characters or less`);
-        }
-
-        if (field === 'name' && value.trim().length === 0) {
-          return badRequest('Name cannot be empty');
-        }
-
-        if (field === 'psnId' && value.length > MAX_NAME_LENGTH) {
-          return badRequest(`PSN ID must be ${MAX_NAME_LENGTH} characters or less`);
-        }
-
-        if (field === 'imageUrl' && value.length > MAX_URL_LENGTH) {
-          return badRequest(`Image URL must be ${MAX_URL_LENGTH} characters or less`);
-        }
-
-        // Set the field on the patch
-        (patch as Record<string, unknown>)[field] = value;
-        hasChanges = true;
       }
+
+      if (
+        (field === 'name' ||
+          field === 'currentWrestler' ||
+          field === 'alternateWrestler') &&
+        value.length > MAX_NAME_LENGTH
+      ) {
+        return badRequest(
+          `Field ${field} must be ${MAX_NAME_LENGTH} characters or less`,
+        );
+      }
+
+      if (field === 'name' && value.trim().length === 0) {
+        return badRequest('Name cannot be empty');
+      }
+
+      if (field === 'psnId' && value.length > MAX_NAME_LENGTH) {
+        return badRequest(`PSN ID must be ${MAX_NAME_LENGTH} characters or less`);
+      }
+
+      if (field === 'imageUrl' && value.length > MAX_URL_LENGTH) {
+        return badRequest(`Image URL must be ${MAX_URL_LENGTH} characters or less`);
+      }
+
+      // Skip the legacy text when an FK is set on the same slot — FK wins.
+      if (field === 'currentWrestler' && body.currentWrestlerId !== undefined) {
+        continue;
+      }
+      if (field === 'alternateWrestler' && body.alternateWrestlerId !== undefined) {
+        continue;
+      }
+
+      (patch as Record<string, unknown>)[field] = value;
+      hasChanges = true;
+    }
+
+    // Parse FK changes.
+    const currentChange = parseSlotChange(body.currentWrestlerId);
+    const alternateChange = parseSlotChange(body.alternateWrestlerId);
+
+    if (currentChange.present || alternateChange.present) {
+      const finalCurrent = currentChange.present
+        ? currentChange.newId
+        : (player.currentWrestlerId ?? null);
+      const finalAlternate = alternateChange.present
+        ? alternateChange.newId
+        : (player.alternateWrestlerId ?? null);
+      const dupError = rejectDuplicateSlotAssignment(finalCurrent, finalAlternate);
+      if (dupError) return dupError;
+    }
+
+    const toRelease: string[] = [];
+    const toAssign: Array<{ wrestlerId: string; slot: 'primary' | 'alternate' }> =
+      [];
+
+    if (currentChange.present) {
+      const oldId = player.currentWrestlerId;
+      const newId = currentChange.newId;
+      if (oldId && oldId !== newId) toRelease.push(oldId);
+      if (newId) {
+        const r = await resolveWrestlerForAssignment(newId, playerId, 'primary');
+        if ('error' in r) return r.error;
+        toAssign.push({ wrestlerId: newId, slot: 'primary' });
+        patch.currentWrestlerId = newId;
+        patch.currentWrestler = r.wrestler.name;
+      } else {
+        patch.currentWrestlerId = null;
+      }
+      hasChanges = true;
+    }
+
+    if (alternateChange.present) {
+      const oldId = player.alternateWrestlerId;
+      const newId = alternateChange.newId;
+      if (oldId && oldId !== newId) toRelease.push(oldId);
+      if (newId) {
+        const r = await resolveWrestlerForAssignment(newId, playerId, 'alternate');
+        if ('error' in r) return r.error;
+        toAssign.push({ wrestlerId: newId, slot: 'alternate' });
+        patch.alternateWrestlerId = newId;
+        patch.alternateWrestler = r.wrestler.name;
+      } else {
+        patch.alternateWrestlerId = null;
+        patch.alternateWrestler = undefined;
+      }
+      hasChanges = true;
     }
 
     if (!hasChanges) {
-      return badRequest('No valid fields to update. Allowed fields: ' + ALLOWED_FIELDS.join(', '));
+      const all = [...STRING_FIELDS, ...FK_FIELDS].join(', ');
+      return badRequest(`No valid fields to update. Allowed fields: ${all}`);
     }
 
-    const updated = await getRepositories().roster.players.update(playerId, patch);
+    if (toRelease.length > 0 || toAssign.length > 0) {
+      await runInTransaction(async (tx) => {
+        for (const wrestlerId of toRelease) {
+          tx.releaseWrestlerFromPlayer({ wrestlerId });
+        }
+        for (const { wrestlerId, slot } of toAssign) {
+          tx.assignWrestlerToPlayer({ wrestlerId, playerId, slot });
+        }
+        tx.updatePlayer(playerId, patch as Record<string, unknown>);
+      });
+      const refreshed = await roster.players.findById(playerId);
+      return success(refreshed);
+    }
+
+    const updated = await roster.players.update(playerId, patch);
     return success(updated);
   } catch (err) {
     if (err instanceof NotFoundError) return notFound(err.message);

--- a/backend/functions/players/updatePlayer.ts
+++ b/backend/functions/players/updatePlayer.ts
@@ -4,30 +4,41 @@ import { NotFoundError } from '../../lib/repositories/errors';
 import { success, badRequest, notFound, serverError } from '../../lib/response';
 import { parseBody } from '../../lib/parseBody';
 import type { PlayerPatch } from '../../lib/repositories';
+import {
+  rejectDuplicateSlotAssignment,
+  resolveWrestlerForAssignment,
+} from './wrestlerAssignment';
+
+/**
+ * Request shape for FK transitions on the two slots. `undefined` = no change,
+ * `null` = clear the assignment, string = set to that wrestlerId.
+ */
+type SlotChange = { present: false } | { present: true; newId: string | null };
+
+function parseSlotChange(value: unknown): SlotChange {
+  if (value === undefined) return { present: false };
+  if (value === null || value === '') return { present: true, newId: null };
+  if (typeof value === 'string' && value.length > 0) {
+    return { present: true, newId: value };
+  }
+  return { present: false };
+}
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
     const playerId = event.pathParameters?.playerId;
-
-    if (!playerId) {
-      return badRequest('Player ID is required');
-    }
+    if (!playerId) return badRequest('Player ID is required');
 
     const { data: body, error: parseError } = parseBody(event);
     if (parseError) return parseError;
 
-    const player = await getRepositories().roster.players.findById(playerId);
-    if (!player) {
-      return notFound('Player not found');
-    }
+    const { roster, leagueOps, runInTransaction } = getRepositories();
+    const player = await roster.players.findById(playerId);
+    if (!player) return notFound('Player not found');
 
     const patch: PlayerPatch = {};
     let hasChanges = false;
 
-    if (body.currentWrestler !== undefined) {
-      patch.currentWrestler = body.currentWrestler as string;
-      hasChanges = true;
-    }
     if (body.name !== undefined) {
       patch.name = body.name as string;
       hasChanges = true;
@@ -43,7 +54,6 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     if (body.alignment !== undefined) {
       if (body.alignment === '' || body.alignment === null) {
-        // Setting to undefined will be handled by the repo's buildUpdateExpression as REMOVE
         patch.alignment = undefined;
         hasChanges = true;
       } else if (['face', 'heel', 'neutral'].includes(body.alignment as string)) {
@@ -54,24 +64,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       }
     }
 
-    if (body.alternateWrestler !== undefined) {
-      if (body.alternateWrestler === '' || body.alternateWrestler === null) {
-        patch.alternateWrestler = undefined;
-        hasChanges = true;
-      } else {
-        patch.alternateWrestler = body.alternateWrestler as string;
-        hasChanges = true;
-      }
-    }
-
     if (body.divisionId !== undefined) {
       if (body.divisionId === '' || body.divisionId === null) {
-        // Remove divisionId if empty string or null
         patch.divisionId = undefined;
         hasChanges = true;
       } else {
-        // Validate that the division exists
-        const division = await getRepositories().leagueOps.divisions.findById(body.divisionId as string);
+        const division = await leagueOps.divisions.findById(
+          body.divisionId as string,
+        );
         if (!division) {
           return notFound(`Division ${body.divisionId} not found`);
         }
@@ -80,11 +80,101 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       }
     }
 
+    // Legacy free-text field: still accepted but only when the FK field is
+    // not being changed on the same slot. The FK path always wins.
+    if (
+      body.currentWrestler !== undefined &&
+      body.currentWrestlerId === undefined
+    ) {
+      patch.currentWrestler = body.currentWrestler as string;
+      hasChanges = true;
+    }
+    if (
+      body.alternateWrestler !== undefined &&
+      body.alternateWrestlerId === undefined
+    ) {
+      if (body.alternateWrestler === '' || body.alternateWrestler === null) {
+        patch.alternateWrestler = undefined;
+      } else {
+        patch.alternateWrestler = body.alternateWrestler as string;
+      }
+      hasChanges = true;
+    }
+
+    const currentChange = parseSlotChange(body.currentWrestlerId);
+    const alternateChange = parseSlotChange(body.alternateWrestlerId);
+
+    if (currentChange.present || alternateChange.present) {
+      // Guard against picking the same wrestler for both slots, accounting
+      // for whichever slot is unchanged.
+      const finalCurrent = currentChange.present
+        ? currentChange.newId
+        : (player.currentWrestlerId ?? null);
+      const finalAlternate = alternateChange.present
+        ? alternateChange.newId
+        : (player.alternateWrestlerId ?? null);
+      const dupError = rejectDuplicateSlotAssignment(finalCurrent, finalAlternate);
+      if (dupError) return dupError;
+    }
+
+    const toRelease: string[] = [];
+    const toAssign: Array<{ wrestlerId: string; slot: 'primary' | 'alternate' }> =
+      [];
+
+    if (currentChange.present) {
+      const oldId = player.currentWrestlerId;
+      const newId = currentChange.newId;
+      if (oldId && oldId !== newId) toRelease.push(oldId);
+      if (newId) {
+        const r = await resolveWrestlerForAssignment(newId, playerId, 'primary');
+        if ('error' in r) return r.error;
+        toAssign.push({ wrestlerId: newId, slot: 'primary' });
+        patch.currentWrestlerId = newId;
+        patch.currentWrestler = r.wrestler.name;
+      } else {
+        patch.currentWrestlerId = null;
+      }
+      hasChanges = true;
+    }
+
+    if (alternateChange.present) {
+      const oldId = player.alternateWrestlerId;
+      const newId = alternateChange.newId;
+      if (oldId && oldId !== newId) toRelease.push(oldId);
+      if (newId) {
+        const r = await resolveWrestlerForAssignment(newId, playerId, 'alternate');
+        if ('error' in r) return r.error;
+        toAssign.push({ wrestlerId: newId, slot: 'alternate' });
+        patch.alternateWrestlerId = newId;
+        patch.alternateWrestler = r.wrestler.name;
+      } else {
+        patch.alternateWrestlerId = null;
+        patch.alternateWrestler = undefined;
+      }
+      hasChanges = true;
+    }
+
     if (!hasChanges) {
       return badRequest('No valid fields to update');
     }
 
-    const updated = await getRepositories().roster.players.update(playerId, patch);
+    // If any FK transition happened, stage the player update + wrestler
+    // release/assign atomically. Otherwise fall through to the simple update.
+    if (toRelease.length > 0 || toAssign.length > 0) {
+      await runInTransaction(async (tx) => {
+        for (const wrestlerId of toRelease) {
+          tx.releaseWrestlerFromPlayer({ wrestlerId });
+        }
+        for (const { wrestlerId, slot } of toAssign) {
+          tx.assignWrestlerToPlayer({ wrestlerId, playerId, slot });
+        }
+        tx.updatePlayer(playerId, patch as Record<string, unknown>);
+      });
+      const refreshed = await roster.players.findById(playerId);
+      return success(refreshed);
+    }
+
+    const updated = await roster.players.update(playerId, patch);
     return success(updated);
   } catch (err) {
     if (err instanceof NotFoundError) return notFound(err.message);

--- a/backend/functions/players/wrestlerAssignment.ts
+++ b/backend/functions/players/wrestlerAssignment.ts
@@ -1,0 +1,55 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { badRequest, conflict, notFound } from '../../lib/response';
+import { getRepositories } from '../../lib/repositories';
+import type { Wrestler } from '../../lib/repositories/types';
+
+export interface ResolvedWrestler {
+  wrestler: Wrestler;
+}
+
+/**
+ * Resolve a wrestler FK and verify it's available for assignment to `playerId`
+ * on the given `slot`. A wrestler is available if it's not in use, or it's
+ * already assigned to this same player on the same slot (idempotent re-assign).
+ * Returns either the wrestler or an HTTP error response.
+ */
+export async function resolveWrestlerForAssignment(
+  wrestlerId: string,
+  playerId: string | null,
+  slot: 'primary' | 'alternate',
+): Promise<{ wrestler: Wrestler } | { error: APIGatewayProxyResult }> {
+  const wrestler = await getRepositories().roster.wrestlers.findById(wrestlerId);
+  if (!wrestler) {
+    return { error: notFound(`Wrestler ${wrestlerId} not found`) };
+  }
+  if (wrestler.isInUse) {
+    // Allow idempotent self-reassignment: same player + same slot.
+    const sameOwner =
+      playerId !== null &&
+      wrestler.assignedPlayerId === playerId &&
+      wrestler.assignedSlot === slot;
+    if (!sameOwner) {
+      return {
+        error: conflict(
+          `Wrestler ${wrestler.name} is already assigned to another player`,
+        ),
+      };
+    }
+  }
+  return { wrestler };
+}
+
+/**
+ * Reject when the same wrestler is picked for both slots on a single player.
+ */
+export function rejectDuplicateSlotAssignment(
+  currentId: string | null | undefined,
+  alternateId: string | null | undefined,
+): APIGatewayProxyResult | null {
+  if (currentId && alternateId && currentId === alternateId) {
+    return badRequest(
+      'currentWrestlerId and alternateWrestlerId cannot be the same wrestler',
+    );
+  }
+  return null;
+}

--- a/backend/lib/repositories/RosterRepository.ts
+++ b/backend/lib/repositories/RosterRepository.ts
@@ -21,6 +21,11 @@ export interface PlayerCreateInput {
   name: string;
   currentWrestler: string;
   alternateWrestler?: string;
+  // P1 FK fields. When present, handlers validate the wrestler exists and is
+  // available, then transactionally assign it. The denormalized name string
+  // is populated from the wrestler's `name` so reads stay cheap.
+  currentWrestlerId?: string;
+  alternateWrestlerId?: string;
   imageUrl?: string;
   psnId?: string;
   divisionId?: string;
@@ -32,6 +37,8 @@ export interface PlayerPatch {
   name?: string;
   currentWrestler?: string;
   alternateWrestler?: string;
+  currentWrestlerId?: string | null;
+  alternateWrestlerId?: string | null;
   imageUrl?: string;
   psnId?: string;
   divisionId?: string;

--- a/backend/lib/repositories/__tests__/unitOfWork-wrestlers.test.ts
+++ b/backend/lib/repositories/__tests__/unitOfWork-wrestlers.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildInMemoryRepositories } from '../inMemory';
+import type { Repositories } from '../registry';
+
+describe('UnitOfWork wrestler assignment methods', () => {
+  let repos: Repositories;
+
+  beforeEach(() => {
+    repos = buildInMemoryRepositories();
+  });
+
+  it('assignWrestlerToPlayer sets isInUse + assignedPlayerId + assignedSlot', async () => {
+    const wrestler = await repos.roster.wrestlers.create({
+      promotion: 'WWE',
+      name: 'The Rock',
+      overallCap: 90,
+    });
+    expect(wrestler.isInUse).toBe(false);
+
+    await repos.runInTransaction(async (tx) => {
+      tx.assignWrestlerToPlayer({
+        wrestlerId: wrestler.wrestlerId,
+        playerId: 'player-1',
+        slot: 'primary',
+      });
+    });
+
+    const after = await repos.roster.wrestlers.findById(wrestler.wrestlerId);
+    expect(after?.isInUse).toBe(true);
+    expect(after?.assignedPlayerId).toBe('player-1');
+    expect(after?.assignedSlot).toBe('primary');
+  });
+
+  it('releaseWrestlerFromPlayer clears assignment and flips isInUse', async () => {
+    const wrestler = await repos.roster.wrestlers.create({
+      promotion: 'WWE',
+      name: 'The Rock',
+      overallCap: 90,
+    });
+
+    await repos.runInTransaction(async (tx) => {
+      tx.assignWrestlerToPlayer({
+        wrestlerId: wrestler.wrestlerId,
+        playerId: 'player-1',
+        slot: 'alternate',
+      });
+    });
+    await repos.runInTransaction(async (tx) => {
+      tx.releaseWrestlerFromPlayer({ wrestlerId: wrestler.wrestlerId });
+    });
+
+    const after = await repos.roster.wrestlers.findById(wrestler.wrestlerId);
+    expect(after?.isInUse).toBe(false);
+    expect(after?.assignedPlayerId).toBeUndefined();
+    expect(after?.assignedSlot).toBeUndefined();
+  });
+
+  it('batches multiple assigns + releases atomically in one transaction', async () => {
+    const rock = await repos.roster.wrestlers.create({
+      promotion: 'WWE',
+      name: 'The Rock',
+      overallCap: 90,
+    });
+    const cena = await repos.roster.wrestlers.create({
+      promotion: 'WWE',
+      name: 'John Cena',
+      overallCap: 89,
+    });
+
+    // Set up: rock assigned to player-1 primary, cena assigned to player-2 primary
+    await repos.runInTransaction(async (tx) => {
+      tx.assignWrestlerToPlayer({
+        wrestlerId: rock.wrestlerId,
+        playerId: 'player-1',
+        slot: 'primary',
+      });
+      tx.assignWrestlerToPlayer({
+        wrestlerId: cena.wrestlerId,
+        playerId: 'player-2',
+        slot: 'primary',
+      });
+    });
+
+    // Swap: release both, then reassign to the opposite player
+    await repos.runInTransaction(async (tx) => {
+      tx.releaseWrestlerFromPlayer({ wrestlerId: rock.wrestlerId });
+      tx.releaseWrestlerFromPlayer({ wrestlerId: cena.wrestlerId });
+      tx.assignWrestlerToPlayer({
+        wrestlerId: rock.wrestlerId,
+        playerId: 'player-2',
+        slot: 'primary',
+      });
+      tx.assignWrestlerToPlayer({
+        wrestlerId: cena.wrestlerId,
+        playerId: 'player-1',
+        slot: 'primary',
+      });
+    });
+
+    const rockAfter = await repos.roster.wrestlers.findById(rock.wrestlerId);
+    const cenaAfter = await repos.roster.wrestlers.findById(cena.wrestlerId);
+    expect(rockAfter?.assignedPlayerId).toBe('player-2');
+    expect(cenaAfter?.assignedPlayerId).toBe('player-1');
+  });
+});

--- a/backend/lib/repositories/dynamo/DynamoRosterRepository.ts
+++ b/backend/lib/repositories/dynamo/DynamoRosterRepository.ts
@@ -52,6 +52,8 @@ export class DynamoRosterRepository implements RosterRepository {
       name: input.name,
       currentWrestler: input.currentWrestler,
       ...(input.alternateWrestler !== undefined ? { alternateWrestler: input.alternateWrestler } : {}),
+      ...(input.currentWrestlerId !== undefined ? { currentWrestlerId: input.currentWrestlerId } : {}),
+      ...(input.alternateWrestlerId !== undefined ? { alternateWrestlerId: input.alternateWrestlerId } : {}),
       ...(input.imageUrl !== undefined ? { imageUrl: input.imageUrl } : {}),
       ...(input.psnId !== undefined ? { psnId: input.psnId } : {}),
       ...(input.divisionId !== undefined ? { divisionId: input.divisionId } : {}),

--- a/backend/lib/repositories/dynamo/DynamoUnitOfWork.ts
+++ b/backend/lib/repositories/dynamo/DynamoUnitOfWork.ts
@@ -273,6 +273,46 @@ export class DynamoUnitOfWork implements UnitOfWork {
     });
   }
 
+  // ── Wrestlers ────────────────────────────────────────────────────
+  //
+  // `isInUse` is persisted as string "true"/"false" because DynamoDB GSI keys
+  // cannot be Boolean; the repository boundary converts back to boolean on
+  // read. See DynamoRosterRepository wrestlers.* for the read path.
+  assignWrestlerToPlayer(params: {
+    wrestlerId: string;
+    playerId: string;
+    slot: 'primary' | 'alternate';
+  }): void {
+    const now = new Date().toISOString();
+    this.staged.push({
+      Update: {
+        TableName: TableNames.WRESTLERS,
+        Key: { wrestlerId: params.wrestlerId },
+        UpdateExpression:
+          'SET isInUse = :isInUse, assignedPlayerId = :playerId, assignedSlot = :slot, updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':isInUse': 'true',
+          ':playerId': params.playerId,
+          ':slot': params.slot,
+          ':now': now,
+        },
+      },
+    });
+  }
+
+  releaseWrestlerFromPlayer(params: { wrestlerId: string }): void {
+    const now = new Date().toISOString();
+    this.staged.push({
+      Update: {
+        TableName: TableNames.WRESTLERS,
+        Key: { wrestlerId: params.wrestlerId },
+        UpdateExpression:
+          'SET isInUse = :isInUse, updatedAt = :now REMOVE assignedPlayerId, assignedSlot',
+        ExpressionAttributeValues: { ':isInUse': 'false', ':now': now },
+      },
+    });
+  }
+
   // ── Matches ──────────────────────────────────────────────────────
   updateMatch(matchId: string, date: string, patch: Record<string, unknown>): void {
     const now = new Date().toISOString();

--- a/backend/lib/repositories/inMemory/InMemoryRosterRepository.ts
+++ b/backend/lib/repositories/inMemory/InMemoryRosterRepository.ts
@@ -62,6 +62,8 @@ export class InMemoryRosterRepository implements RosterRepository {
         name: input.name,
         currentWrestler: input.currentWrestler,
         ...(input.alternateWrestler !== undefined ? { alternateWrestler: input.alternateWrestler } : {}),
+        ...(input.currentWrestlerId !== undefined ? { currentWrestlerId: input.currentWrestlerId } : {}),
+        ...(input.alternateWrestlerId !== undefined ? { alternateWrestlerId: input.alternateWrestlerId } : {}),
         ...(input.imageUrl !== undefined ? { imageUrl: input.imageUrl } : {}),
         ...(input.psnId !== undefined ? { psnId: input.psnId } : {}),
         ...(input.divisionId !== undefined ? { divisionId: input.divisionId } : {}),

--- a/backend/lib/repositories/inMemory/InMemoryUnitOfWork.ts
+++ b/backend/lib/repositories/inMemory/InMemoryUnitOfWork.ts
@@ -15,6 +15,7 @@ export class InMemoryUnitOfWork implements UnitOfWork {
       challenges: Map<string, Record<string, unknown>>;
       seasonStandings: Array<Record<string, unknown>>;
       matches: Map<string, Record<string, unknown>>;
+      wrestlers: Map<string, Record<string, unknown>>;
     },
   ) {}
 
@@ -156,6 +157,34 @@ export class InMemoryUnitOfWork implements UnitOfWork {
       const existing = this.stores.matches.get(matchId);
       if (existing) {
         this.stores.matches.set(matchId, { ...existing, ...patch, updatedAt: new Date().toISOString() });
+      }
+    });
+  }
+
+  assignWrestlerToPlayer(params: {
+    wrestlerId: string;
+    playerId: string;
+    slot: 'primary' | 'alternate';
+  }): void {
+    this.staged.push(() => {
+      const existing = this.stores.wrestlers.get(params.wrestlerId);
+      if (existing) {
+        existing.isInUse = true;
+        existing.assignedPlayerId = params.playerId;
+        existing.assignedSlot = params.slot;
+        existing.updatedAt = new Date().toISOString();
+      }
+    });
+  }
+
+  releaseWrestlerFromPlayer(params: { wrestlerId: string }): void {
+    this.staged.push(() => {
+      const existing = this.stores.wrestlers.get(params.wrestlerId);
+      if (existing) {
+        existing.isInUse = false;
+        delete existing.assignedPlayerId;
+        delete existing.assignedSlot;
+        existing.updatedAt = new Date().toISOString();
       }
     });
   }

--- a/backend/lib/repositories/inMemory/index.ts
+++ b/backend/lib/repositories/inMemory/index.ts
@@ -24,6 +24,7 @@ export function buildInMemoryRepositories(): Repositories {
       challenges: user.challengesStore as unknown as Map<string, Record<string, unknown>>,
       seasonStandings: season.standingsStore as unknown as Array<Record<string, unknown>>,
       matches: competition.matchesStore as unknown as Map<string, Record<string, unknown>>,
+      wrestlers: roster.wrestlersStore as unknown as Map<string, Record<string, unknown>>,
     });
     try {
       const result = await fn(uow);

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -124,6 +124,11 @@ export interface Player {
   name: string;
   currentWrestler: string;
   alternateWrestler?: string;
+  // FK to Wrestlers table (P1). The denormalized `currentWrestler` / `alternateWrestler`
+  // string fields remain as a display cache so existing read paths (Standings, Dashboard,
+  // PublicProfile) stay untouched.
+  currentWrestlerId?: string;
+  alternateWrestlerId?: string;
   wins: number;
   losses: number;
   draws: number;
@@ -250,6 +255,9 @@ export interface WrestlerPatch {
   name?: string;
   overallCap?: number;
   isInUse?: boolean;
+  // P1 assignment fields. Null clears the field (REMOVE).
+  assignedPlayerId?: string | null;
+  assignedSlot?: 'primary' | 'alternate' | null;
 }
 
 export interface WrestlerImportResult {

--- a/backend/lib/repositories/unitOfWork.ts
+++ b/backend/lib/repositories/unitOfWork.ts
@@ -68,6 +68,22 @@ export interface UnitOfWork {
   /** Stage a match field update. */
   updateMatch(matchId: string, date: string, patch: Record<string, unknown>): void;
 
+  /**
+   * Stage assigning a wrestler to a player's primary or alternate slot.
+   * Sets `isInUse=true` (string on-disk), `assignedPlayerId`, `assignedSlot`.
+   */
+  assignWrestlerToPlayer(params: {
+    wrestlerId: string;
+    playerId: string;
+    slot: 'primary' | 'alternate';
+  }): void;
+
+  /**
+   * Stage releasing a wrestler from its current player assignment.
+   * Sets `isInUse=false` (string on-disk), REMOVEs `assignedPlayerId`, `assignedSlot`.
+   */
+  releaseWrestlerFromPlayer(params: { wrestlerId: string }): void;
+
   /** Flush all staged operations. */
   commit(): Promise<void>;
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "clear-data": "ts-node scripts/clear-data.ts",
     "notify-pending-invites": "ts-node scripts/notify-pending-invites.ts",
     "notify-pending-invites:prod": "AWS_PROFILE=league-szn DYNAMODB_ENDPOINT=https://dynamodb.us-east-1.amazonaws.com SERVICE_NAME=wwe-2k-league-api STAGE=dev ts-node scripts/notify-pending-invites.ts",
+    "migrate:wrestlers-roster": "ts-node scripts/migrate-wrestlers-roster.ts",
     "lint": "eslint functions/ lib/",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/backend/scripts/migrate-wrestlers-roster.ts
+++ b/backend/scripts/migrate-wrestlers-roster.ts
@@ -1,0 +1,170 @@
+// Set up environment for local / devtest DynamoDB before importing anything.
+// The calling shell is expected to set AWS creds + WRESTLERS_TABLE / PLAYERS_TABLE
+// via `sls print` or equivalent. For local use, `IS_OFFLINE=true` targets the
+// DynamoDB Local container.
+process.env.DB_DRIVER = process.env.DB_DRIVER || 'dynamo';
+
+import { getRepositories } from '../lib/repositories';
+import '../lib/repositories/dynamo';
+import type { Player, WrestlerPromotion } from '../lib/repositories/types';
+
+/**
+ * One-time migration from the legacy free-text `currentWrestler` /
+ * `alternateWrestler` fields on Players to the new `currentWrestlerId` /
+ * `alternateWrestlerId` FKs + `Wrestlers` roster rows.
+ *
+ * Semantics:
+ * 1. Scan Players; collect unique (case-insensitive) wrestler names.
+ * 2. For each unique name, find or create a Wrestler row under promotion
+ *    `OTHER` with overallCap = the floor (70). Admins curate promotion +
+ *    overallCap later via ManageWrestlers.
+ * 3. Back-fill each Player: set `currentWrestlerId` / `alternateWrestlerId`
+ *    to the matching wrestler. Leave the denormalized string fields intact
+ *    (they're the display cache).
+ * 4. For the first player that claims a given wrestler, mark the wrestler
+ *    `isInUse=true` + `assignedPlayerId` + `assignedSlot`. Subsequent
+ *    claimants are logged as conflicts and left unassigned — admin fixes
+ *    them manually via ManageWrestlers.
+ *
+ * Rollback: drop the Wrestlers table; the FK fields on Players are additive
+ * and can be ignored by older code.
+ *
+ * Dry-run: pass `--dry-run` to log the plan without writing anything.
+ */
+
+const OTHER_PROMOTION: WrestlerPromotion = 'OTHER';
+const OVERALL_CAP_FLOOR = 70;
+
+interface MigrationSummary {
+  playersScanned: number;
+  uniqueNames: number;
+  wrestlersCreated: number;
+  wrestlersReused: number;
+  playersLinked: number;
+  conflicts: Array<{ wrestlerName: string; keptPlayerId: string; conflictingPlayerId: string; slot: 'primary' | 'alternate' }>;
+}
+
+function normalize(name: string | undefined): string | null {
+  if (!name) return null;
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed;
+}
+
+async function migrate(dryRun: boolean): Promise<MigrationSummary> {
+  const { roster, runInTransaction } = getRepositories();
+
+  console.log(`Starting wrestler-roster migration (dryRun=${dryRun})...`);
+
+  const players: Player[] = await roster.players.list();
+  const summary: MigrationSummary = {
+    playersScanned: players.length,
+    uniqueNames: 0,
+    wrestlersCreated: 0,
+    wrestlersReused: 0,
+    playersLinked: 0,
+    conflicts: [],
+  };
+
+  // normalizedName -> wrestlerId
+  const nameToWrestlerId = new Map<string, string>();
+  // wrestlerId -> { playerId, slot } — the first owner of that wrestler
+  const wrestlerOwners = new Map<string, { playerId: string; slot: 'primary' | 'alternate' }>();
+
+  for (const player of players) {
+    for (const slot of ['primary', 'alternate'] as const) {
+      const raw =
+        slot === 'primary' ? player.currentWrestler : player.alternateWrestler;
+      const name = normalize(raw);
+      if (!name) continue;
+
+      const key = name.toLowerCase();
+      let wrestlerId = nameToWrestlerId.get(key);
+
+      if (!wrestlerId) {
+        // Look for an existing OTHER-promotion wrestler with that name before
+        // creating a new one — makes the script idempotent across re-runs.
+        const existing = await roster.wrestlers.findByName(OTHER_PROMOTION, name);
+        if (existing) {
+          wrestlerId = existing.wrestlerId;
+          summary.wrestlersReused += 1;
+        } else if (dryRun) {
+          wrestlerId = `DRY-${key}`;
+          summary.wrestlersCreated += 1;
+        } else {
+          const created = await roster.wrestlers.create({
+            promotion: OTHER_PROMOTION,
+            name,
+            overallCap: OVERALL_CAP_FLOOR,
+          });
+          wrestlerId = created.wrestlerId;
+          summary.wrestlersCreated += 1;
+        }
+        nameToWrestlerId.set(key, wrestlerId);
+      }
+
+      const claimant = wrestlerOwners.get(wrestlerId);
+      if (claimant) {
+        // Second+ player claims this wrestler — conflict, log and skip.
+        summary.conflicts.push({
+          wrestlerName: name,
+          keptPlayerId: claimant.playerId,
+          conflictingPlayerId: player.playerId,
+          slot,
+        });
+        continue;
+      }
+
+      wrestlerOwners.set(wrestlerId, { playerId: player.playerId, slot });
+
+      if (dryRun) {
+        summary.playersLinked += 1;
+        continue;
+      }
+
+      // Stage the player FK set + wrestler assignment atomically.
+      await runInTransaction(async (tx) => {
+        tx.assignWrestlerToPlayer({
+          wrestlerId: wrestlerId!,
+          playerId: player.playerId,
+          slot,
+        });
+        tx.updatePlayer(player.playerId, {
+          [slot === 'primary' ? 'currentWrestlerId' : 'alternateWrestlerId']:
+            wrestlerId,
+        });
+      });
+      summary.playersLinked += 1;
+    }
+  }
+
+  summary.uniqueNames = nameToWrestlerId.size;
+  return summary;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+
+  try {
+    const summary = await migrate(dryRun);
+    console.log('\nMigration summary:');
+    console.log(`  Players scanned:      ${summary.playersScanned}`);
+    console.log(`  Unique wrestler names:${summary.uniqueNames}`);
+    console.log(`  Wrestlers created:    ${summary.wrestlersCreated}`);
+    console.log(`  Wrestlers reused:     ${summary.wrestlersReused}`);
+    console.log(`  Players linked:       ${summary.playersLinked}`);
+    console.log(`  Conflicts:            ${summary.conflicts.length}`);
+    for (const c of summary.conflicts) {
+      console.log(
+        `    - "${c.wrestlerName}" (slot ${c.slot}): kept=${c.keptPlayerId}, skipped=${c.conflictingPlayerId}`,
+      );
+    }
+    if (dryRun) console.log('\n(dry-run: no writes performed)');
+    process.exit(0);
+  } catch (err) {
+    console.error('Migration failed:', err);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,9 @@ export interface Player {
   name: string;
   currentWrestler: string;
   alternateWrestler?: string;
+  /** FK to Wrestlers table (P1 of #294). Denormalized name fields above remain as the display cache. */
+  currentWrestlerId?: string;
+  alternateWrestlerId?: string;
   wins: number;
   losses: number;
   draws: number;


### PR DESCRIPTION
Closes #294 P1. Follow-up to #301 (which shipped P0: the `Wrestlers` roster + admin screen).

## Summary

Wires the `Wrestlers` roster into the Player lifecycle. Every `createPlayer` / `updatePlayer` / `deletePlayer` / `updateMyProfile` call can now carry the new `currentWrestlerId` / `alternateWrestlerId` FK fields; the legacy free-text `currentWrestler` / `alternateWrestler` strings stay as the denormalized display cache so public read paths (Standings, Dashboard, PublicProfile) continue to work untouched.

## What's in the box

### Types
- `Player` + `PlayerCreateInput` + `PlayerPatch`: add optional `currentWrestlerId`, `alternateWrestlerId` (nullable on patch to allow clearing). Mirrored on the frontend `Player` type.
- `WrestlerPatch`: add nullable `assignedPlayerId`, `assignedSlot`.

### UnitOfWork
- New `assignWrestlerToPlayer({ wrestlerId, playerId, slot })` → stages `isInUse=true` + `assignedPlayerId` + `assignedSlot`.
- New `releaseWrestlerFromPlayer({ wrestlerId })` → stages `isInUse=false` + REMOVE of the assignment attrs.
- Both **Dynamo** (string `"true"`/`"false"` for the GSI key) and **InMemory** implementations. The `wrestlers` store is now wired into `InMemoryUnitOfWork`.

### Handlers
- **`createPlayer`** — rewritten as a custom handler (no longer uses `createHandlerFactory`): validates FK wrestlers up-front, populates the denormalized name from the roster, creates the player, then stages wrestler assignments in a UoW transaction. On assignment failure the orphan player row is best-effort rolled back.
- **`updatePlayer`** — FK transitions (old release + new assign + player patch) run in a single `runInTransaction`. Legacy string fields are still accepted when no FK is set on the same slot; FK always wins.
- **`deletePlayer`** — releases any assigned wrestlers in a transaction before deleting the player.
- **`updateMyProfile`** — same FK transition logic; whitelist extended to include `currentWrestlerId` / `alternateWrestlerId`.
- Shared `wrestlerAssignment.ts` helper enforces availability and rejects picking the same wrestler for both slots.

### Migration
- `backend/scripts/migrate-wrestlers-roster.ts` — scans Players, creates `OTHER`-promotion `Wrestler` rows for each unique free-text name, links Player FKs, and marks the first claimant of a duplicate name as the owner (conflicts logged for admin to resolve). Idempotent re-runs reuse existing rows via `findByName`.
- `npm run migrate:wrestlers-roster -- --dry-run` reports what would change without writing.

### Tests
- **+13 handler tests** covering FK create / update / delete / self-service flows, including the **409 conflict** on double-claiming, the **400** on same-wrestler-both-slots, idempotent self-reassignment, and FK transitions.
- **+3 direct UnitOfWork tests** for `assignWrestlerToPlayer` / `releaseWrestlerFromPlayer` including batched atomic swaps in a single transaction.

## Out of scope (intentional — comes in P2)

- `ManagePlayers` UI cutover from the two free-text inputs to a searchable dropdown fed by `wrestlersApi`. That ships in the next PR so this one's diff stays focused.
- Dropping the denormalized `currentWrestler` / `alternateWrestler` strings from the API surface — that's P4 cleanup, after every consumer reads from the FK.

## Test plan

- [x] Backend lint (clean)
- [x] Backend typecheck (clean)
- [x] Backend tests: **889/889** passing (+16 new: 13 handler + 3 UoW)
- [x] Frontend lint (clean)
- [x] Frontend typecheck (clean)
- [x] Frontend tests: **417/417** passing
- [ ] Manual QA on devtest after deploy:
  - Create a wrestler via ManageWrestlers; POST a player with `currentWrestlerId` set; confirm the wrestler flips to `isInUse=true` and the Player row carries both the FK and the denormalized name.
  - PUT the same player with a different `currentWrestlerId`; confirm old wrestler released, new wrestler assigned.
  - DELETE the player; confirm both slots' wrestlers released.
  - Run `npm run migrate:wrestlers-roster -- --dry-run` against devtest and review the plan; then run it for real and verify every pre-existing player got linked.

https://claude.ai/code/session_01V2Hhj8kMus7GJeJgn2Cu2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2Hhj8kMus7GJeJgn2Cu2V)_