### PR TITLE
Implements #294 P2 — ManagePlayers dropdown UI cutover

### DIFF
--- a/frontend/src/components/admin/ManagePlayers.tsx
+++ b/frontend/src/components/admin/ManagePlayers.tsx
@@ -1,6 +1,11 @@
-import { useState, useEffect, FormEvent, ChangeEvent } from 'react';
+import { useState, useEffect, FormEvent, ChangeEvent, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { playersApi, imagesApi, divisionsApi } from '../../services/api';
+import {
+  playersApi,
+  imagesApi,
+  divisionsApi,
+  wrestlersApi,
+} from '../../services/api';
 import { sanitizeName } from '../../utils/sanitize';
 import { logger } from '../../utils/logger';
 import { FILE_UPLOAD_LIMITS, VALIDATION } from '../../constants';
@@ -9,12 +14,55 @@ import {
   applyImageFallback,
   resolveImageSrc,
 } from '../../constants/imageFallbacks';
-import type { Player, Division } from '../../types';
+import type {
+  Player,
+  Division,
+  Wrestler,
+  WrestlerPromotion,
+} from '../../types';
 import './ManagePlayers.css';
+
+type WrestlerSlotOptions = ReadonlyArray<{
+  promotion: WrestlerPromotion;
+  wrestlers: Wrestler[];
+}>;
+
+/**
+ * Build `<optgroup>`s of wrestlers for a dropdown. The selected wrestler (if
+ * any) is always included so the edit form renders its current pick even
+ * when that wrestler is `isInUse=true`. Other in-use wrestlers are hidden to
+ * prevent double-assignment.
+ */
+function buildOptionGroups(
+  allWrestlers: Wrestler[],
+  selectedWrestlerId: string | undefined,
+  excludeWrestlerId: string | undefined,
+): WrestlerSlotOptions {
+  const visible = allWrestlers.filter((w) => {
+    if (w.wrestlerId === excludeWrestlerId) return false; // never show the other-slot pick
+    if (!w.isInUse) return true;
+    return w.wrestlerId === selectedWrestlerId;
+  });
+
+  const byPromotion = new Map<WrestlerPromotion, Wrestler[]>();
+  for (const w of visible) {
+    const bucket = byPromotion.get(w.promotion) ?? [];
+    bucket.push(w);
+    byPromotion.set(w.promotion, bucket);
+  }
+
+  return Array.from(byPromotion.entries())
+    .map(([promotion, wrestlers]) => ({
+      promotion,
+      wrestlers: wrestlers.sort((a, b) => a.name.localeCompare(b.name)),
+    }))
+    .sort((a, b) => a.promotion.localeCompare(b.promotion));
+}
 
 export default function ManagePlayers() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [divisions, setDivisions] = useState<Division[]>([]);
+  const [wrestlers, setWrestlers] = useState<Wrestler[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -24,11 +72,13 @@ export default function ManagePlayers() {
   const [deleting, setDeleting] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  // Form state
+  // Form state — FK-backed. The legacy `currentWrestler` / `alternateWrestler`
+  // string inputs are gone; the backend denormalizes the name from the
+  // selected wrestler's roster row.
   const [formData, setFormData] = useState({
     name: '',
-    currentWrestler: '',
-    alternateWrestler: '',
+    currentWrestlerId: '',
+    alternateWrestlerId: '',
     imageUrl: '',
     divisionId: '',
     psnId: '',
@@ -46,12 +96,14 @@ export default function ManagePlayers() {
   const loadData = async () => {
     try {
       setLoading(true);
-      const [playersData, divisionsData] = await Promise.all([
+      const [playersData, divisionsData, wrestlersData] = await Promise.all([
         playersApi.getAll(),
         divisionsApi.getAll(),
+        wrestlersApi.getAll(),
       ]);
       setPlayers(playersData);
       setDivisions(divisionsData);
+      setWrestlers(wrestlersData);
     } catch (_err) {
       setError('Failed to load data');
     } finally {
@@ -64,6 +116,26 @@ export default function ManagePlayers() {
     const division = divisions.find(d => d.divisionId === divisionId);
     return division?.name || 'Unknown';
   };
+
+  const currentWrestlerOptions = useMemo(
+    () =>
+      buildOptionGroups(
+        wrestlers,
+        formData.currentWrestlerId || undefined,
+        formData.alternateWrestlerId || undefined,
+      ),
+    [wrestlers, formData.currentWrestlerId, formData.alternateWrestlerId],
+  );
+
+  const alternateWrestlerOptions = useMemo(
+    () =>
+      buildOptionGroups(
+        wrestlers,
+        formData.alternateWrestlerId || undefined,
+        formData.currentWrestlerId || undefined,
+      ),
+    [wrestlers, formData.currentWrestlerId, formData.alternateWrestlerId],
+  );
 
   const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -140,6 +212,16 @@ export default function ManagePlayers() {
     }
   };
 
+  const resetFormData = () => ({
+    name: '',
+    currentWrestlerId: '',
+    alternateWrestlerId: '',
+    imageUrl: '',
+    divisionId: '',
+    psnId: '',
+    alignment: '' as '' | 'face' | 'heel' | 'neutral',
+  });
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (submitting || uploading) return; // Prevent double submission
@@ -151,20 +233,24 @@ export default function ManagePlayers() {
       // Upload image first if one is selected
       const imageUrl = await uploadImage();
 
-      // Sanitize inputs before sending to API
       const sanitizedName = sanitizeName(formData.name, VALIDATION.MAX_NAME_LENGTH);
-      const sanitizedWrestler = sanitizeName(formData.currentWrestler, VALIDATION.MAX_NAME_LENGTH);
 
-      if (!sanitizedName || !sanitizedWrestler) {
-        setError('Name and wrestler fields cannot be empty');
+      if (!sanitizedName) {
+        setError('Player name cannot be empty');
+        return;
+      }
+      if (!formData.currentWrestlerId) {
+        setError('Please pick a wrestler from the roster');
         return;
       }
 
       if (editingPlayer) {
         await playersApi.update(editingPlayer.playerId, {
           name: sanitizedName,
-          currentWrestler: sanitizedWrestler,
-          alternateWrestler: formData.alternateWrestler.trim() || undefined,
+          currentWrestlerId: formData.currentWrestlerId,
+          // Empty string clears the FK server-side (mirrors how divisionId
+          // and alignment are cleared on this same endpoint).
+          alternateWrestlerId: formData.alternateWrestlerId || '',
           imageUrl: imageUrl || undefined,
           divisionId: formData.divisionId || '',
           psnId: formData.psnId.trim() || undefined,
@@ -173,8 +259,13 @@ export default function ManagePlayers() {
       } else {
         await playersApi.create({
           name: sanitizedName,
-          currentWrestler: sanitizedWrestler,
-          alternateWrestler: formData.alternateWrestler.trim() || undefined,
+          // Kept to satisfy the legacy Player type; backend overwrites this
+          // from the selected wrestler's name.
+          currentWrestler: '',
+          currentWrestlerId: formData.currentWrestlerId,
+          ...(formData.alternateWrestlerId
+            ? { alternateWrestlerId: formData.alternateWrestlerId }
+            : {}),
           imageUrl: imageUrl || undefined,
           divisionId: formData.divisionId || undefined,
           psnId: formData.psnId.trim() || undefined,
@@ -185,7 +276,7 @@ export default function ManagePlayers() {
         });
       }
 
-      setFormData({ name: '', currentWrestler: '', alternateWrestler: '', imageUrl: '', divisionId: '', psnId: '', alignment: '' });
+      setFormData(resetFormData());
       setSelectedFile(null);
       setImagePreview(null);
       setShowAddForm(false);
@@ -203,8 +294,8 @@ export default function ManagePlayers() {
     setEditingPlayer(player);
     setFormData({
       name: player.name,
-      currentWrestler: player.currentWrestler,
-      alternateWrestler: player.alternateWrestler || '',
+      currentWrestlerId: player.currentWrestlerId || '',
+      alternateWrestlerId: player.alternateWrestlerId || '',
       imageUrl: player.imageUrl || '',
       divisionId: player.divisionId || '',
       psnId: player.psnId || '',
@@ -216,7 +307,7 @@ export default function ManagePlayers() {
   };
 
   const handleCancel = () => {
-    setFormData({ name: '', currentWrestler: '', alternateWrestler: '', imageUrl: '', divisionId: '', psnId: '', alignment: '' });
+    setFormData(resetFormData());
     setSelectedFile(null);
     setImagePreview(null);
     setShowAddForm(false);
@@ -247,6 +338,19 @@ export default function ManagePlayers() {
     return <div className="loading">Loading players...</div>;
   }
 
+  const renderWrestlerOptions = (groups: WrestlerSlotOptions) =>
+    groups.map((group) => (
+      <optgroup key={group.promotion} label={group.promotion}>
+        {group.wrestlers.map((w) => (
+          <option key={w.wrestlerId} value={w.wrestlerId}>
+            {w.name} — OVR {w.overallCap}
+          </option>
+        ))}
+      </optgroup>
+    ));
+
+  const rosterEmpty = wrestlers.length === 0;
+
   return (
     <div className="manage-players">
       <div className="players-header">
@@ -265,6 +369,12 @@ export default function ManagePlayers() {
       {showAddForm && (
         <div className="player-form-container">
           <h3>{editingPlayer ? 'Edit Player' : 'Add New Player'}</h3>
+          {rosterEmpty && (
+            <div className="error-message">
+              No wrestlers in the roster yet. Add wrestlers via{' '}
+              <Link to="/admin/wrestlers">Manage Wrestlers</Link> before creating players.
+            </div>
+          )}
           <form onSubmit={handleSubmit} className="player-form">
             <div className="form-group">
               <label htmlFor="name">Player Name</label>
@@ -280,25 +390,33 @@ export default function ManagePlayers() {
 
             <div className="form-group">
               <label htmlFor="wrestler">Wrestler</label>
-              <input
-                type="text"
+              <select
                 id="wrestler"
-                value={formData.currentWrestler}
-                onChange={(e) => setFormData({ ...formData, currentWrestler: e.target.value })}
+                value={formData.currentWrestlerId}
+                onChange={(e) =>
+                  setFormData({ ...formData, currentWrestlerId: e.target.value })
+                }
                 required
-                placeholder="Stone Cold Steve Austin"
-              />
+                disabled={rosterEmpty}
+              >
+                <option value="">Pick from the roster…</option>
+                {renderWrestlerOptions(currentWrestlerOptions)}
+              </select>
             </div>
 
             <div className="form-group">
               <label htmlFor="alternateWrestler">Alternate Wrestler</label>
-              <input
-                type="text"
+              <select
                 id="alternateWrestler"
-                value={formData.alternateWrestler}
-                onChange={(e) => setFormData({ ...formData, alternateWrestler: e.target.value })}
-                placeholder="Backup wrestler (optional)"
-              />
+                value={formData.alternateWrestlerId}
+                onChange={(e) =>
+                  setFormData({ ...formData, alternateWrestlerId: e.target.value })
+                }
+                disabled={rosterEmpty}
+              >
+                <option value="">None</option>
+                {renderWrestlerOptions(alternateWrestlerOptions)}
+              </select>
             </div>
 
             <div className="form-group">
@@ -371,7 +489,7 @@ export default function ManagePlayers() {
             </div>
 
             <div className="form-actions">
-              <button type="submit" disabled={submitting || uploading}>
+              <button type="submit" disabled={submitting || uploading || rosterEmpty}>
                 {submitting ? 'Saving...' : uploading ? 'Uploading...' : editingPlayer ? 'Update Player' : 'Add Player'}
               </button>
               <button type="button" onClick={handleCancel} className="cancel-btn" disabled={submitting || uploading}>

--- a/frontend/src/components/admin/__tests__/ManagePlayers.test.tsx
+++ b/frontend/src/components/admin/__tests__/ManagePlayers.test.tsx
@@ -1,28 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 
 // --- Hoisted mocks ---
-const { mockPlayersApi, mockDivisionsApi, mockImagesApi } = vi.hoisted(() => ({
-  mockPlayersApi: {
-    getAll: vi.fn(),
-    create: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-  },
-  mockDivisionsApi: { getAll: vi.fn() },
-  mockImagesApi: { generateUploadUrl: vi.fn(), uploadToS3: vi.fn() },
-}));
+const { mockPlayersApi, mockDivisionsApi, mockImagesApi, mockWrestlersApi } =
+  vi.hoisted(() => ({
+    mockPlayersApi: {
+      getAll: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    mockDivisionsApi: { getAll: vi.fn() },
+    mockImagesApi: { generateUploadUrl: vi.fn(), uploadToS3: vi.fn() },
+    mockWrestlersApi: { getAll: vi.fn() },
+  }));
 
 vi.mock('../../../services/api', () => ({
   playersApi: mockPlayersApi,
   divisionsApi: mockDivisionsApi,
   imagesApi: mockImagesApi,
+  wrestlersApi: mockWrestlersApi,
 }));
 
 import ManagePlayers from '../ManagePlayers';
-import type { Player, Division } from '../../../types';
+import type { Player, Division, Wrestler } from '../../../types';
 
 // --- Test data ---
 const mockDivisions: Division[] = [
@@ -30,15 +33,50 @@ const mockDivisions: Division[] = [
   { divisionId: 'div-2', name: 'SmackDown', createdAt: '2024-01-01', updatedAt: '2024-01-01' },
 ];
 
+const rockWrestler: Wrestler = {
+  wrestlerId: 'w-rock',
+  promotion: 'WWE',
+  name: 'The Rock',
+  overallCap: 93,
+  isInUse: true,
+  assignedPlayerId: 'p1',
+  assignedSlot: 'primary',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+};
+const beckyWrestler: Wrestler = {
+  wrestlerId: 'w-becky',
+  promotion: 'WWE',
+  name: 'Becky Lynch',
+  overallCap: 91,
+  isInUse: true,
+  assignedPlayerId: 'p2',
+  assignedSlot: 'primary',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+};
+const omegaWrestler: Wrestler = {
+  wrestlerId: 'w-omega',
+  promotion: 'AEW',
+  name: 'Kenny Omega',
+  overallCap: 92,
+  isInUse: false,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+};
+const mockWrestlers: Wrestler[] = [rockWrestler, beckyWrestler, omegaWrestler];
+
 const mockPlayers: Player[] = [
   {
     playerId: 'p1', name: 'John', currentWrestler: 'The Rock',
+    currentWrestlerId: 'w-rock',
     wins: 10, losses: 3, draws: 1, divisionId: 'div-1',
     imageUrl: 'https://img.example.com/rock.png',
     createdAt: '2024-01-01', updatedAt: '2024-01-01',
   },
   {
     playerId: 'p2', name: 'Jane', currentWrestler: 'Becky Lynch',
+    currentWrestlerId: 'w-becky',
     wins: 8, losses: 5, draws: 0, userId: 'user-abc',
     createdAt: '2024-01-01', updatedAt: '2024-01-01',
   },
@@ -53,11 +91,13 @@ describe('ManagePlayers', () => {
     vi.clearAllMocks();
     mockPlayersApi.getAll.mockResolvedValue(mockPlayers);
     mockDivisionsApi.getAll.mockResolvedValue(mockDivisions);
+    mockWrestlersApi.getAll.mockResolvedValue(mockWrestlers);
   });
 
   it('shows loading state during initial fetch', () => {
     mockPlayersApi.getAll.mockReturnValue(new Promise(() => {}));
     mockDivisionsApi.getAll.mockReturnValue(new Promise(() => {}));
+    mockWrestlersApi.getAll.mockReturnValue(new Promise(() => {}));
     renderComponent();
     expect(screen.getByText('Loading players...')).toBeInTheDocument();
   });
@@ -95,12 +135,11 @@ describe('ManagePlayers', () => {
     await waitFor(() => {
       expect(screen.getByText('All Players (2)')).toBeInTheDocument();
     });
-    // Form is hidden until triggered via Edit button
     expect(screen.queryByText('Add New Player')).not.toBeInTheDocument();
     expect(screen.queryByText('Edit Player')).not.toBeInTheDocument();
   });
 
-  it('opens edit form pre-populated with player data', async () => {
+  it('opens edit form pre-populated with player data, dropdown shows current wrestler', async () => {
     const user = userEvent.setup();
     renderComponent();
 
@@ -113,43 +152,95 @@ describe('ManagePlayers', () => {
 
     expect(screen.getByText('Edit Player')).toBeInTheDocument();
     expect(screen.getByDisplayValue('John')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('The Rock')).toBeInTheDocument();
+
+    // The wrestler dropdown pre-selects the player's currentWrestlerId,
+    // even though the underlying wrestler is isInUse=true (the component
+    // always surfaces the current pick).
+    const wrestlerSelect = screen.getByLabelText('Wrestler') as HTMLSelectElement;
+    expect(wrestlerSelect.value).toBe('w-rock');
   });
 
-  it('edits existing player and saves changes via API', async () => {
+  it('wrestler dropdown hides wrestlers assigned to other players but keeps current selection', async () => {
     const user = userEvent.setup();
-    const updatedPlayer = { ...mockPlayers[0], name: 'John Updated', currentWrestler: 'The Boulder' };
-    mockPlayersApi.update.mockResolvedValue(updatedPlayer);
+    renderComponent();
+
+    await waitFor(() => { expect(screen.getByText('John')).toBeInTheDocument(); });
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    await user.click(editButtons[0]);
+
+    const wrestlerSelect = screen.getByLabelText('Wrestler') as HTMLSelectElement;
+    const optionLabels = Array.from(wrestlerSelect.options).map((o) => o.textContent ?? '');
+
+    // Includes the placeholder + Rock (current) + Omega (available)
+    expect(optionLabels.some((l) => l.includes('The Rock'))).toBe(true);
+    expect(optionLabels.some((l) => l.includes('Kenny Omega'))).toBe(true);
+    // Does NOT include Becky — she's assigned to Jane and is not the current pick
+    expect(optionLabels.some((l) => l.includes('Becky Lynch'))).toBe(false);
+  });
+
+  it('picking the same wrestler for both slots is prevented — the other slot drops it', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => { expect(screen.getByText('John')).toBeInTheDocument(); });
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    await user.click(editButtons[0]);
+
+    // After the primary is set to w-rock, the alternate dropdown excludes it.
+    const altSelect = screen.getByLabelText('Alternate Wrestler') as HTMLSelectElement;
+    const altLabels = Array.from(altSelect.options).map((o) => o.textContent ?? '');
+    expect(altLabels.some((l) => l.includes('The Rock'))).toBe(false);
+  });
+
+  it('edits existing player and submits the FK instead of free text', async () => {
+    const user = userEvent.setup();
+    mockPlayersApi.update.mockResolvedValue({
+      ...mockPlayers[0],
+      currentWrestler: 'Kenny Omega',
+      currentWrestlerId: 'w-omega',
+    });
 
     renderComponent();
     await waitFor(() => { expect(screen.getByText('John')).toBeInTheDocument(); });
 
-    // Open edit form
     const editButtons = screen.getAllByRole('button', { name: 'Edit' });
     await user.click(editButtons[0]);
 
-    // Verify pre-populated and modify
-    const nameInput = screen.getByLabelText('Player Name');
-    const wrestlerInput = screen.getByLabelText('Wrestler');
-    expect(nameInput).toHaveValue('John');
-    expect(wrestlerInput).toHaveValue('The Rock');
-
-    await user.clear(nameInput);
-    await user.type(nameInput, 'John Updated');
-    await user.clear(wrestlerInput);
-    await user.type(wrestlerInput, 'The Boulder');
+    const wrestlerSelect = screen.getByLabelText('Wrestler') as HTMLSelectElement;
+    await user.selectOptions(wrestlerSelect, 'w-omega');
+    expect(wrestlerSelect.value).toBe('w-omega');
 
     await user.click(screen.getByRole('button', { name: 'Update Player' }));
 
     await waitFor(() => {
       expect(mockPlayersApi.update).toHaveBeenCalledWith('p1', expect.objectContaining({
-        name: 'John Updated',
-        currentWrestler: 'The Boulder',
+        currentWrestlerId: 'w-omega',
       }));
     });
+    // Free-text `currentWrestler` is not sent — the backend derives it.
+    expect(mockPlayersApi.update.mock.calls[0][1]).not.toHaveProperty('currentWrestler');
     await waitFor(() => {
       expect(screen.getByText('Player updated successfully!')).toBeInTheDocument();
     });
+  });
+
+  it('rejects submit when no wrestler is selected', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => { expect(screen.getByText('John')).toBeInTheDocument(); });
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    await user.click(editButtons[0]);
+
+    const wrestlerSelect = screen.getByLabelText('Wrestler') as HTMLSelectElement;
+    // Clear the required select by picking the placeholder option.
+    await user.selectOptions(wrestlerSelect, '');
+
+    // Browser-level required-attribute blocks submission; the update API must
+    // never be called when the primary wrestler is empty.
+    await user.click(screen.getByRole('button', { name: 'Update Player' }));
+    expect(mockPlayersApi.update).not.toHaveBeenCalled();
   });
 
   it('deletes player with confirmation dialog', async () => {
@@ -205,7 +296,6 @@ describe('ManagePlayers', () => {
     renderComponent();
     await waitFor(() => { expect(screen.getByText('John')).toBeInTheDocument(); });
 
-    // Open edit form for player that already has an image
     const editButtons = screen.getAllByRole('button', { name: 'Edit' });
     await user.click(editButtons[0]);
 
@@ -265,5 +355,23 @@ describe('ManagePlayers', () => {
     await waitFor(() => {
       expect(screen.getByText('Server error')).toBeInTheDocument();
     });
+  });
+
+  it('roster groups options by promotion', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => { expect(screen.getByText('John')).toBeInTheDocument(); });
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    await user.click(editButtons[0]);
+
+    // Primary dropdown includes both promotions because Rock (the current
+    // pick) keeps the WWE group visible, and Omega (available) drives AEW.
+    const primarySelect = screen.getByLabelText('Wrestler') as HTMLSelectElement;
+    const primaryLabels = within(primarySelect)
+      .getAllByRole('group')
+      .map((g) => g.getAttribute('label'));
+    expect(primaryLabels).toContain('AEW');
+    expect(primaryLabels).toContain('WWE');
   });
 });


### PR DESCRIPTION
Closes #294 P2. Builds on #301 (P0 — roster infra + ManageWrestlers screen) and #302 (P1 — Player FK fields + transactional assign/release + migration).

## Summary

Completes the wrestler-roster rollout on the admin side: `ManagePlayers` no longer accepts free-text wrestler names. Admins pick from the curated `Wrestlers` roster via a dropdown grouped by promotion, with availability filtering so two players can't silently claim the same wrestler.

## What's in the box

### `ManagePlayers.tsx`
- Form state holds `currentWrestlerId` / `alternateWrestlerId` instead of the two free-text strings. On submit the component sends the FKs only; the backend denormalizes `currentWrestler` / `alternateWrestler` from the selected wrestler's name (the P1 contract).
- The two `<input type="text">` wrestler inputs become grouped `<select>` dropdowns (`<optgroup label={promotion}>`). Option label: `{name} — OVR {overallCap}`.
- Both dropdowns share one filter helper:
  - Only `isInUse=false` wrestlers **plus** the player's current pick are visible (so the edit form still shows the existing selection even though that wrestler is in use).
  - Whichever wrestler is picked for the **other** slot is always excluded, so the same wrestler can't be chosen twice on a single player.
- If the roster is empty the form shows an inline warning linking to **Manage Wrestlers** and disables submit.
- `currentWrestlerId` is required; submit is blocked if the admin clears the primary pick.

### Data fetching
- `loadData` now fans out `playersApi.getAll`, `divisionsApi.getAll`, and `wrestlersApi.getAll` via `Promise.all`.

### Tests
- `ManagePlayers.test.tsx` updated for the dropdown UI (mocks `wrestlersApi.getAll`, uses `selectOptions` instead of typing into text inputs).
- **+4 new test cases**:
  - Edit form pre-populates the current pick in the dropdown (even when `isInUse=true`).
  - In-use wrestlers from other players are hidden unless they're the current selection.
  - The two slots can never share a wrestler (the other slot's dropdown excludes it).
  - The update API is called with `currentWrestlerId` and **not** `currentWrestler` (the free-text field).

## Out of scope

- **ScheduleMatch** / other admin screens that pick players still show `player.currentWrestler` (the denormalized string). Unchanged — they read the display cache, which continues to work.
- Dropping the denormalized `currentWrestler` / `alternateWrestler` strings from the API surface — that's the P4 cleanup, after every consumer reads from the FK.
- Self-service `MyProfile` dropdown (the backend supports the FK path since P1; the MyProfile UI is a separate follow-up if desired).

## Test plan

- [x] Frontend lint (clean)
- [x] Frontend typecheck (clean)
- [x] Frontend tests: **421/421** passing (+4 new)
- [x] Backend tests: **889/889** still passing (no backend changes)
- [ ] Manual QA on devtest after deploy:
  - Create a fresh wrestler via **Manage Wrestlers**; open **Manage Players** → Edit → confirm the new wrestler appears in the dropdown under its promotion.
  - Edit a migrated player; confirm the existing pick is pre-selected even though `isInUse=true`; change to a different available wrestler and submit; confirm the backend swaps assignment atomically.
  - Pick the same wrestler for primary; confirm it disappears from the alternate dropdown.
  - Delete a player; confirm both wrestlers become available again in the dropdown on the next create.

https://claude.ai/code/session_01V2Hhj8kMus7GJeJgn2Cu2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2Hhj8kMus7GJeJgn2Cu2V)_