### PR TITLE
fix(players): tx.updatePlayer REMOVEs undefined/null instead of SET-to-undefined

### DIFF
--- a/backend/functions/players/__tests__/wrestlerAssignment.test.ts
+++ b/backend/functions/players/__tests__/wrestlerAssignment.test.ts
@@ -271,6 +271,49 @@ describe('updatePlayer FK transitions', () => {
     expect(result!.statusCode).toBe(409);
   });
 
+  it('accepts the full ManagePlayers form payload with blank alternate/division/alignment', async () => {
+    // Regression test for the devtest "Failed to Update Player" bug:
+    // ManagePlayers sends a full object on every submit, including empty
+    // strings for slots the admin left blank. The backend has to translate
+    // those into REMOVEs on the underlying item — NOT SET-to-undefined,
+    // which DynamoDB rejects as an invalid ExpressionAttributeValue.
+    const rock = await seedWrestler('The Rock');
+    const cena = await seedWrestler('John Cena');
+    const createRes = await createPlayer(
+      makeEvent({ body: JSON.stringify({ name: 'X', currentWrestlerId: rock.wrestlerId }) }),
+      ctx,
+      cb,
+    );
+    const playerId = JSON.parse(createRes!.body).playerId;
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId },
+        body: JSON.stringify({
+          name: 'Updated Name',
+          currentWrestlerId: cena.wrestlerId,
+          alternateWrestlerId: '',
+          divisionId: '',
+          alignment: '',
+        }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    const after = JSON.parse(result!.body);
+    expect(after.name).toBe('Updated Name');
+    expect(after.currentWrestlerId).toBe(cena.wrestlerId);
+    // Cleared fields should not round-trip back as `undefined` keys on
+    // the object; they should be absent.
+    expect(after).not.toHaveProperty('alternateWrestlerId');
+    expect(after).not.toHaveProperty('alternateWrestler');
+    expect(after).not.toHaveProperty('divisionId');
+    expect(after).not.toHaveProperty('alignment');
+  });
+
   it('allows idempotent re-assignment of the same wrestler to same slot', async () => {
     const rock = await seedWrestler('The Rock');
     const createRes = await createPlayer(

--- a/backend/lib/repositories/dynamo/DynamoUnitOfWork.ts
+++ b/backend/lib/repositories/dynamo/DynamoUnitOfWork.ts
@@ -22,24 +22,36 @@ export class DynamoUnitOfWork implements UnitOfWork {
   // ── Players ──────────────────────────────────────────────────────
   updatePlayer(playerId: string, patch: Record<string, unknown>): void {
     const now = new Date().toISOString();
-    const sets: string[] = ['updatedAt = :updatedAt'];
-    const names: Record<string, string> = {};
+    const sets: string[] = ['#fUpdatedAt = :updatedAt'];
+    const removes: string[] = [];
+    const names: Record<string, string> = { '#fUpdatedAt': 'updatedAt' };
     const values: Record<string, unknown> = { ':updatedAt': now };
     let i = 0;
     for (const [key, val] of Object.entries(patch)) {
       const nameKey = `#f${i}`;
-      const valKey = `:v${i}`;
       names[nameKey] = key;
-      values[valKey] = val;
-      sets.push(`${nameKey} = ${valKey}`);
+      if (val === undefined || val === null) {
+        // Clear the attribute instead of storing a DynamoDB NULL — matches
+        // the semantics of `buildUpdateExpression` used by the non-tx repo
+        // `players.update()` path, so both paths produce identical items.
+        removes.push(nameKey);
+      } else {
+        const valKey = `:v${i}`;
+        values[valKey] = val;
+        sets.push(`${nameKey} = ${valKey}`);
+      }
       i++;
+    }
+    let expr = `SET ${sets.join(', ')}`;
+    if (removes.length > 0) {
+      expr += ` REMOVE ${removes.join(', ')}`;
     }
     this.staged.push({
       Update: {
         TableName: TableNames.PLAYERS,
         Key: { playerId },
-        UpdateExpression: `SET ${sets.join(', ')}`,
-        ExpressionAttributeNames: Object.keys(names).length > 0 ? names : undefined,
+        UpdateExpression: expr,
+        ExpressionAttributeNames: names,
         ExpressionAttributeValues: values,
       },
     });

--- a/backend/lib/repositories/dynamo/__tests__/DynamoUnitOfWork.test.ts
+++ b/backend/lib/repositories/dynamo/__tests__/DynamoUnitOfWork.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock TableNames and dynamoDb so the module imports cleanly without real AWS.
+vi.mock('../../dynamodb', () => ({
+  dynamoDb: { transactWrite: vi.fn() },
+  TableNames: {
+    PLAYERS: 'Players',
+    WRESTLERS: 'Wrestlers',
+    TAG_TEAMS: 'TagTeams',
+    CHAMPIONSHIPS: 'Championships',
+    CHAMPIONSHIP_HISTORY: 'ChampionshipHistory',
+    CHALLENGES: 'Challenges',
+    SEASON_STANDINGS: 'SeasonStandings',
+    MATCHES: 'Matches',
+  },
+}));
+
+import { DynamoUnitOfWork } from '../DynamoUnitOfWork';
+
+type StagedView = Array<{
+  Update?: {
+    UpdateExpression: string;
+    ExpressionAttributeNames?: Record<string, string>;
+    ExpressionAttributeValues?: Record<string, unknown>;
+  };
+}>;
+
+function staged(uow: DynamoUnitOfWork): StagedView {
+  return (uow as unknown as { staged: StagedView }).staged;
+}
+
+describe('DynamoUnitOfWork.updatePlayer', () => {
+  it('emits REMOVE for undefined/null fields and SET for concrete values', () => {
+    const uow = new DynamoUnitOfWork();
+    uow.updatePlayer('p-1', {
+      name: 'Updated',
+      currentWrestlerId: 'w-cena',
+      currentWrestler: 'John Cena',
+      alternateWrestlerId: null,
+      alternateWrestler: undefined,
+      divisionId: undefined,
+      alignment: undefined,
+    });
+
+    const items = staged(uow);
+    expect(items).toHaveLength(1);
+    const update = items[0].Update!;
+
+    // No ExpressionAttributeValue may be undefined — DynamoDB rejects those.
+    for (const [token, value] of Object.entries(update.ExpressionAttributeValues ?? {})) {
+      expect(value, `value for ${token} should not be undefined`).not.toBeUndefined();
+    }
+
+    // SET clause must include the concrete updates + updatedAt.
+    expect(update.UpdateExpression).toMatch(/^SET /);
+    expect(update.UpdateExpression).toContain('updatedAt');
+
+    // REMOVE clause must cover every cleared field. Parse the REMOVE
+    // portion of the expression, map its tokens back to field names.
+    const removeMatch = update.UpdateExpression.match(/REMOVE (.+)$/);
+    expect(removeMatch, 'expected a REMOVE clause').not.toBeNull();
+    const removedTokens = removeMatch![1].split(',').map((s) => s.trim());
+    const removedFieldNames = removedTokens.map(
+      (t) => (update.ExpressionAttributeNames ?? {})[t],
+    );
+    expect(removedFieldNames).toEqual(
+      expect.arrayContaining([
+        'alternateWrestlerId',
+        'alternateWrestler',
+        'divisionId',
+        'alignment',
+      ]),
+    );
+  });
+
+  it('omits the REMOVE clause entirely when every patch value is concrete', () => {
+    const uow = new DynamoUnitOfWork();
+    uow.updatePlayer('p-1', { name: 'Updated', currentWrestlerId: 'w-1' });
+
+    const update = staged(uow)[0].Update!;
+    expect(update.UpdateExpression).not.toContain('REMOVE');
+    expect(update.UpdateExpression).toMatch(/^SET /);
+  });
+});

--- a/backend/lib/repositories/inMemory/InMemoryUnitOfWork.ts
+++ b/backend/lib/repositories/inMemory/InMemoryUnitOfWork.ts
@@ -24,9 +24,18 @@ export class InMemoryUnitOfWork implements UnitOfWork {
   updatePlayer(playerId: string, patch: Record<string, unknown>): void {
     this.staged.push(() => {
       const existing = this.stores.players.get(playerId);
-      if (existing) {
-        this.stores.players.set(playerId, { ...existing, ...patch, updatedAt: new Date().toISOString() });
+      if (!existing) return;
+      // Match DynamoUnitOfWork.updatePlayer semantics: undefined/null = REMOVE.
+      const next: Record<string, unknown> = { ...existing };
+      for (const [key, val] of Object.entries(patch)) {
+        if (val === undefined || val === null) {
+          delete next[key];
+        } else {
+          next[key] = val;
+        }
       }
+      next.updatedAt = new Date().toISOString();
+      this.stores.players.set(playerId, next);
     });
   }
 


### PR DESCRIPTION
Fixes the **"Failed to Update Player"** error surfaced on devtest after #302 + #303 (P1 + P2 of #294) merged. Reproducible by editing any player in `ManagePlayers` and picking a wrestler from the new dropdown.

## Root cause

`ManagePlayers` submits a full object on every save — including empty strings for slots the admin left blank (`alternateWrestlerId`, `divisionId`, `alignment`). The updatePlayer handler translates those to `undefined` on the patch and, when an FK change triggered the transactional path, called `tx.updatePlayer(playerId, patch)`.

`DynamoUnitOfWork.updatePlayer` built `SET field = :v` for every patch entry without filtering, so `undefined` ended up in `ExpressionAttributeValues` — which DynamoDB rejects with `ValidationException: ExpressionAttributeValues contains invalid value`.

The pre-P1 non-transactional path (`players.update(patch)`) never hit this because it uses the shared `buildUpdateExpression` helper, which already skips undefined.

## Fix

Emit a `REMOVE` clause for every patch entry whose value is `undefined` or `null`, and only put concrete values in the `SET` list and `ExpressionAttributeValues` map. This matches `buildUpdateExpression`'s semantics so both the repo and UoW paths produce identical items.

Also aligned `InMemoryUnitOfWork.updatePlayer` to delete undefined/null keys (it previously spread them verbatim, which is why the InMemory-backed tests for P1/P2 didn't catch this before the DynamoDB-specific failure surfaced on devtest).

## Regression coverage

- **`DynamoUnitOfWork.test.ts`** (new) — asserts that no value in `ExpressionAttributeValues` is `undefined`, and that every cleared field lands in the `REMOVE` clause.
- **`wrestlerAssignment.test.ts`** — new case replays the exact ManagePlayers payload (name + `currentWrestlerId` + empty alternate / division / alignment) and asserts the cleared fields are absent on the response.

## Test plan

- [x] Backend lint (clean)
- [x] Backend typecheck (clean)
- [x] Backend tests: **892/892** passing (+3 new)
- [ ] Manual QA on devtest after deploy: edit a player, pick a wrestler from the dropdown while leaving the alternate/division/alignment blank — confirm 200 and the wrestler swap takes effect.

https://claude.ai/code/session_01V2Hhj8kMus7GJeJgn2Cu2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2Hhj8kMus7GJeJgn2Cu2V)_