### PR TITLE
feat(videos): allow flagged wrestlers to submit videos

### DIFF
--- a/backend/functions/players/updatePlayer.ts
+++ b/backend/functions/players/updatePlayer.ts
@@ -52,6 +52,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       hasChanges = true;
     }
 
+    if (body.canUploadVideos !== undefined) {
+      if (typeof body.canUploadVideos !== 'boolean') {
+        return badRequest('canUploadVideos must be a boolean');
+      }
+      patch.canUploadVideos = body.canUploadVideos;
+      hasChanges = true;
+    }
+
     if (body.alignment !== undefined) {
       if (body.alignment === '' || body.alignment === null) {
         patch.alignment = undefined;

--- a/backend/functions/videos/createVideo.ts
+++ b/backend/functions/videos/createVideo.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
-import { created, badRequest, serverError } from '../../lib/response';
-import { getAuthContext, requireRole } from '../../lib/auth';
+import { created, badRequest, forbidden, serverError } from '../../lib/response';
+import { getAuthContext, hasRole } from '../../lib/auth';
 import { parseBody } from '../../lib/parseBody';
 
 interface CreateVideoBody {
@@ -15,10 +15,27 @@ interface CreateVideoBody {
 }
 
 export const handler: APIGatewayProxyHandler = async (event) => {
-  const denied = requireRole(event, 'Admin', 'Moderator');
-  if (denied) return denied;
-
   try {
+    const auth = getAuthContext(event);
+    const isStaff = hasRole(auth, 'Admin', 'Moderator');
+    const isOffline = process.env.IS_OFFLINE === 'true';
+
+    const { roster: { players }, content: { videos } } = getRepositories();
+
+    // Wrestlers may submit videos only when their player record has the
+    // canUploadVideos flag set. Their submissions are always created as drafts.
+    let wrestlerPlayerId: string | undefined;
+    if (!isStaff && !isOffline) {
+      if (!hasRole(auth, 'Wrestler')) {
+        return forbidden('You do not have permission to perform this action');
+      }
+      const player = auth.sub ? await players.findByUserId(auth.sub) : null;
+      if (!player || !player.canUploadVideos) {
+        return forbidden('Your account is not permitted to upload videos');
+      }
+      wrestlerPlayerId = player.playerId;
+    }
+
     const { data: body, error: parseError } = parseBody<CreateVideoBody>(event);
     if (parseError) return parseError;
 
@@ -34,9 +51,6 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('category must be "match", "highlight", "promo", or "other"');
     }
 
-    const auth = getAuthContext(event);
-    const { content: { videos } } = getRepositories();
-
     const video = await videos.create({
       title,
       description,
@@ -44,8 +58,9 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       thumbnailUrl,
       category,
       tags,
-      isPublished,
-      uploadedBy: auth.username || auth.sub,
+      // Wrestler uploads are always drafts pending admin moderation.
+      isPublished: wrestlerPlayerId ? false : isPublished,
+      uploadedBy: wrestlerPlayerId ?? (auth.username || auth.sub),
     });
 
     return created(video);

--- a/backend/functions/videos/listVideos.ts
+++ b/backend/functions/videos/listVideos.ts
@@ -1,11 +1,26 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
 import { success, serverError } from '../../lib/response';
+import { getAuthContext, hasRole } from '../../lib/auth';
 
-export const handler: APIGatewayProxyHandler = async () => {
+export const handler: APIGatewayProxyHandler = async (event) => {
   try {
-    const { content: { videos } } = getRepositories();
+    const auth = getAuthContext(event);
+    const isStaff = hasRole(auth, 'Admin', 'Moderator');
+    const isOffline = process.env.IS_OFFLINE === 'true';
+
+    const { roster: { players }, content: { videos } } = getRepositories();
     const items = await videos.list();
+
+    // Wrestlers (and any non-staff caller) only see videos they uploaded so
+    // unpublished submissions from other users stay private.
+    if (!isStaff && !isOffline) {
+      const player = auth.sub ? await players.findByUserId(auth.sub) : null;
+      const playerId = player?.playerId;
+      const filtered = playerId ? items.filter((v) => v.uploadedBy === playerId) : [];
+      return success(filtered);
+    }
+
     return success(items);
   } catch (err) {
     console.error('Error listing videos:', err);

--- a/backend/lib/repositories/RosterRepository.ts
+++ b/backend/lib/repositories/RosterRepository.ts
@@ -47,6 +47,7 @@ export interface PlayerPatch {
   tagTeamId?: string | null;
   alignment?: 'face' | 'heel' | 'neutral';
   userId?: string;
+  canUploadVideos?: boolean;
 }
 
 // ─── Tag Team input types ───────────────────────────────────────────

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -140,6 +140,8 @@ export interface Player {
   tagTeamId?: string;
   alignment?: 'face' | 'heel' | 'neutral';
   mainOverall?: number;
+  /** When true, this wrestler may submit videos via /my-videos. Admin-managed. */
+  canUploadVideos?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,6 +62,7 @@ import MyTagTeam from './components/tagTeams/MyTagTeam';
 // Profile components
 import WrestlerProfile from './components/profile/WrestlerProfile';
 import PublicProfile from './components/profile/PublicProfile';
+import MyVideos from './components/profile/MyVideos';
 // Matchmaking components
 import FindMatchPage from './components/matchmaking/FindMatchPage';
 // Route guard
@@ -133,6 +134,13 @@ function AppLayout() {
             <Route path="/profile" element={
               <ProtectedRoute requiredRole="Wrestler">
                 <WrestlerProfile />
+              </ProtectedRoute>
+            } />
+
+            {/* Wrestler Video Submissions - gated server-side by canUploadVideos */}
+            <Route path="/my-videos" element={
+              <ProtectedRoute requiredRole="Wrestler">
+                <MyVideos />
               </ProtectedRoute>
             } />
 

--- a/frontend/src/components/admin/ManagePlayers.tsx
+++ b/frontend/src/components/admin/ManagePlayers.tsx
@@ -83,6 +83,7 @@ export default function ManagePlayers() {
     divisionId: '',
     psnId: '',
     alignment: '' as '' | 'face' | 'heel' | 'neutral',
+    canUploadVideos: false,
   });
 
   // Image upload state
@@ -220,6 +221,7 @@ export default function ManagePlayers() {
     divisionId: '',
     psnId: '',
     alignment: '' as '' | 'face' | 'heel' | 'neutral',
+    canUploadVideos: false,
   });
 
   const handleSubmit = async (e: FormEvent) => {
@@ -255,6 +257,7 @@ export default function ManagePlayers() {
           divisionId: formData.divisionId || '',
           psnId: formData.psnId.trim() || undefined,
           alignment: formData.alignment || '',
+          canUploadVideos: formData.canUploadVideos,
         });
       } else {
         await playersApi.create({
@@ -300,6 +303,7 @@ export default function ManagePlayers() {
       divisionId: player.divisionId || '',
       psnId: player.psnId || '',
       alignment: player.alignment || '',
+      canUploadVideos: player.canUploadVideos ?? false,
     });
     setImagePreview(player.imageUrl || null);
     setSelectedFile(null);
@@ -458,6 +462,18 @@ export default function ManagePlayers() {
                 <option value="neutral">⚖️ Neutral</option>
                 <option value="heel">😈 Heel</option>
               </select>
+            </div>
+
+            <div className="form-group form-checkbox">
+              <label htmlFor="canUploadVideos">
+                <input
+                  type="checkbox"
+                  id="canUploadVideos"
+                  checked={formData.canUploadVideos}
+                  onChange={(e) => setFormData({ ...formData, canUploadVideos: e.target.checked })}
+                />
+                {' '}Allow video uploads (wrestler can submit drafts via /my-videos)
+              </label>
             </div>
 
             <div className="form-group">

--- a/frontend/src/components/profile/MyVideos.tsx
+++ b/frontend/src/components/profile/MyVideos.tsx
@@ -1,0 +1,310 @@
+import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { videosApi, imagesApi, profileApi } from '../../services/api';
+import type { Player, Video, VideoCategory } from '../../types';
+import Skeleton from '../ui/Skeleton';
+import '../admin/ManageVideos.css';
+
+const CATEGORY_OPTIONS: VideoCategory[] = ['match', 'highlight', 'promo', 'other'];
+
+const DEFAULT_FORM = {
+  title: '',
+  description: '',
+  category: 'highlight' as VideoCategory,
+  tags: '',
+};
+
+export default function MyVideos() {
+  const { t } = useTranslation();
+  const [profile, setProfile] = useState<Player | null>(null);
+  const [profileLoading, setProfileLoading] = useState(true);
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState('');
+  const [formData, setFormData] = useState(DEFAULT_FORM);
+  const videoInputRef = useRef<HTMLInputElement>(null);
+  const thumbInputRef = useRef<HTMLInputElement>(null);
+
+  const loadProfile = useCallback(async (signal?: AbortSignal) => {
+    try {
+      setProfileLoading(true);
+      const me = await profileApi.getMyProfile(signal);
+      setProfile(me);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load profile');
+    } finally {
+      setProfileLoading(false);
+    }
+  }, []);
+
+  const loadVideos = useCallback(async (signal?: AbortSignal) => {
+    try {
+      setLoading(true);
+      const data = await videosApi.getAll(signal);
+      setVideos(data);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : t('videos.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    loadProfile(controller.signal);
+    loadVideos(controller.signal);
+    return () => controller.abort();
+  }, [loadProfile, loadVideos]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccessMsg(null);
+
+    if (!formData.title.trim()) {
+      setError(t('videos.titleRequired'));
+      return;
+    }
+
+    const videoFile = videoInputRef.current?.files?.[0];
+    if (!videoFile) {
+      setError(t('videos.videoRequired'));
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+
+      setUploadProgress(t('videos.uploadingVideo'));
+      const videoUpload = await imagesApi.generateUploadUrl(
+        videoFile.name,
+        videoFile.type,
+        'videos'
+      );
+      await imagesApi.uploadVideoToS3(videoUpload.uploadUrl, videoFile);
+
+      let thumbnailUrl: string | undefined;
+      const thumbFile = thumbInputRef.current?.files?.[0];
+      if (thumbFile) {
+        setUploadProgress(t('videos.uploadingThumbnail'));
+        const thumbUpload = await imagesApi.generateUploadUrl(
+          thumbFile.name,
+          thumbFile.type,
+          'videos'
+        );
+        await imagesApi.uploadToS3(thumbUpload.uploadUrl, thumbFile);
+        thumbnailUrl = thumbUpload.imageUrl;
+      }
+
+      setUploadProgress('');
+
+      const tags = formData.tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean);
+
+      // Backend forces isPublished=false for wrestler submissions, but send it
+      // explicitly so behavior is obvious from the call site.
+      await videosApi.create({
+        title: formData.title,
+        description: formData.description,
+        videoUrl: videoUpload.imageUrl,
+        thumbnailUrl,
+        category: formData.category,
+        tags,
+        isPublished: false,
+      });
+
+      setSuccessMsg('Video submitted! An admin will review it before publishing.');
+      setFormData(DEFAULT_FORM);
+      setShowForm(false);
+      if (videoInputRef.current) videoInputRef.current.value = '';
+      if (thumbInputRef.current) thumbInputRef.current.value = '';
+      await loadVideos();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('videos.saveError'));
+    } finally {
+      setSubmitting(false);
+      setUploadProgress('');
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData(DEFAULT_FORM);
+    setShowForm(false);
+    if (videoInputRef.current) videoInputRef.current.value = '';
+    if (thumbInputRef.current) thumbInputRef.current.value = '';
+  };
+
+  if (profileLoading) {
+    return <Skeleton variant="block" count={2} />;
+  }
+
+  if (!profile?.canUploadVideos) {
+    return (
+      <div className="manage-videos">
+        <h2>My Videos</h2>
+        <div className="empty-state">
+          <p>
+            Your account isn't permitted to upload videos. Ask an admin to
+            enable video uploads on your wrestler profile.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="manage-videos">
+      <div className="videos-header">
+        <h2>My Videos</h2>
+        {!showForm && (
+          <button onClick={() => setShowForm(true)}>
+            {t('videos.upload')}
+          </button>
+        )}
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+      {successMsg && <div className="success-message">{successMsg}</div>}
+
+      {showForm && (
+        <div className="video-form-container">
+          <h3>{t('videos.upload')}</h3>
+          <form onSubmit={handleSubmit} className="video-form">
+            <div className="form-group">
+              <label htmlFor="my-video-title">{t('videos.fields.title')}</label>
+              <input
+                type="text"
+                id="my-video-title"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                required
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="my-video-description">{t('videos.fields.description')}</label>
+              <textarea
+                id="my-video-description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={3}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="my-video-file">{t('videos.fields.videoFile')}</label>
+              <input
+                type="file"
+                id="my-video-file"
+                ref={videoInputRef}
+                accept="video/mp4,video/webm,video/quicktime"
+                required
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="my-video-thumbnail">{t('videos.fields.thumbnail')}</label>
+              <input
+                type="file"
+                id="my-video-thumbnail"
+                ref={thumbInputRef}
+                accept="image/jpeg,image/png,image/webp"
+              />
+            </div>
+
+            <div className="form-row">
+              <div className="form-group">
+                <label htmlFor="my-video-category">{t('videos.fields.category')}</label>
+                <select
+                  id="my-video-category"
+                  value={formData.category}
+                  onChange={(e) => setFormData({ ...formData, category: e.target.value as VideoCategory })}
+                >
+                  {CATEGORY_OPTIONS.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {t(`videos.categories.${cat}`)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="my-video-tags">{t('videos.fields.tags')}</label>
+                <input
+                  type="text"
+                  id="my-video-tags"
+                  value={formData.tags}
+                  onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
+                  placeholder={t('videos.tagsPlaceholder')}
+                />
+              </div>
+            </div>
+
+            {uploadProgress && <div className="upload-progress">{uploadProgress}</div>}
+
+            <div className="form-actions">
+              <button type="submit" disabled={submitting}>
+                {submitting ? t('common.saving') : t('videos.upload')}
+              </button>
+              <button type="button" onClick={handleCancel} className="cancel-btn">
+                {t('common.cancel')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="videos-list">
+        <h3>My Submissions ({videos.length})</h3>
+        {loading ? (
+          <Skeleton variant="block" count={2} />
+        ) : videos.length === 0 ? (
+          <div className="empty-state">
+            <p>You haven't submitted any videos yet.</p>
+          </div>
+        ) : (
+          <div className="videos-grid">
+            {videos.map((video) => (
+              <div key={video.videoId} className="video-card">
+                <div className="video-card-preview">
+                  {video.thumbnailUrl ? (
+                    <img src={video.thumbnailUrl} alt={video.title} className="video-thumbnail" />
+                  ) : (
+                    <div className="video-placeholder">
+                      <span>&#9654;</span>
+                    </div>
+                  )}
+                </div>
+                <div className="video-card-info">
+                  <h4>{video.title}</h4>
+                  <div className="video-meta">
+                    <span className={`category-badge category-${video.category}`}>
+                      {t(`videos.categories.${video.category}`)}
+                    </span>
+                    <span className={`status-badge ${video.isPublished ? 'active' : 'inactive'}`}>
+                      {video.isPublished ? t('videos.published') : t('videos.draft')}
+                    </span>
+                    <span className="video-date">
+                      {new Date(video.createdAt).toLocaleDateString()}
+                    </span>
+                  </div>
+                  {video.description && (
+                    <p className="video-description">{video.description}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/config/navConfig.ts
+++ b/frontend/src/config/navConfig.ts
@@ -68,6 +68,7 @@ export const USER_NAV_GROUPS: NavGroup[] = [
     i18nKey: 'nav.groups.wrestler',
     items: [
       { path: '/profile', i18nKey: 'nav.profile', role: 'Wrestler', roleLockedLabel: 'Wrestler Only' },
+      { path: '/my-videos', i18nKey: 'nav.myVideos', role: 'Wrestler', roleLockedLabel: 'Wrestler Only' },
       { path: '/promos', i18nKey: 'nav.promos', feature: 'promos' },
       { path: '/my-stable', i18nKey: 'nav.myStable', feature: 'stables', role: 'Wrestler', roleLockedLabel: 'Wrestler Only' },
       { path: '/my-tag-team', i18nKey: 'nav.myTagTeam', feature: 'stables', role: 'Wrestler', roleLockedLabel: 'Wrestler Only' },
@@ -187,7 +188,7 @@ export function getUserGroupForPath(pathname: string): string | null {
   const competition = ['/championships', '/events', '/matches', '/tournaments', '/awards'];
   const rankings = ['/contenders', '/stats', '/highlights'];
   const factions = ['/stables', '/tag-teams'];
-  const wrestler = ['/profile', '/promos', '/my-stable', '/my-tag-team'];
+  const wrestler = ['/profile', '/my-videos', '/promos', '/my-stable', '/my-tag-team'];
 
   if (league.some((p) => pathname === p)) return 'league';
   if (competition.some((p) => pathname === p || pathname.startsWith(p + '/'))) return 'competition';

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -210,6 +210,7 @@
     "myTagTeam": "Mein Tag Team",
     "highlights": "Highlights",
     "profile": "Mein Profil",
+    "myVideos": "Meine Videos",
     "groups": {
       "core": "Liga",
       "league": "Liga",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -210,6 +210,7 @@
     "myTagTeam": "My Tag Team",
     "highlights": "Highlights",
     "profile": "My Profile",
+    "myVideos": "My Videos",
     "groups": {
       "core": "League",
       "league": "League",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,6 +17,8 @@ export interface Player {
   tagTeamId?: string;
   alignment?: 'face' | 'heel' | 'neutral';
   mainOverall?: number;
+  /** Admin-managed flag granting access to wrestler video submissions. */
+  canUploadVideos?: boolean;
   createdAt: string;
   updatedAt: string;
   /** Last 5 match results (newest first): W win, L loss, D draw */


### PR DESCRIPTION
## Summary
- Add `canUploadVideos` flag to Player (admin-managed via ManagePlayers checkbox).
- New `/my-videos` route for wrestlers to submit videos using the same presigned-S3 + videos API as admins.
- Wrestler submissions are forced to `isPublished: false` and stamped with `uploadedBy = playerId` so admins can review before publishing.
- `GET /admin/videos` is filtered to the caller's own uploads when the caller is not Admin/Moderator, so wrestlers can see status of their submissions without seeing other users' drafts.

## Auth model
- `POST /admin/videos`: still passes through router auth; handler now allows Admin / Moderator OR a Wrestler whose Player record has `canUploadVideos === true`.
- `GET /admin/videos`: same auth, but list is filtered to own uploads for non-staff.
- All other video endpoints (PUT/DELETE) unchanged — admin-only by convention (pre-existing behavior).

## Test plan
- [ ] Admin sets `canUploadVideos` on a wrestler from ManagePlayers
- [ ] Wrestler logs in and sees "My Videos" in the Wrestler Zone nav
- [ ] Wrestler without the flag visits `/my-videos` and sees the gating message
- [ ] Wrestler with the flag uploads an mp4 + thumbnail; record appears in their submissions list as "Draft"
- [ ] Admin sees the submission in `/admin/videos`, attributed to the wrestler's playerId
- [ ] Wrestler cannot see other users' draft videos in their submissions list
- [ ] Backend (`vitest run`) and frontend (`vitest run`) tests pass; both `tsc --noEmit` clean

https://claude.ai/code/session_01NXj8EhXzhvbe1PwQUq3tYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXj8EhXzhvbe1PwQUq3tYV)_