### PR TITLE
feat(checkin-roster): group available wrestlers by division

### DIFF
--- a/frontend/src/components/events/EventCheckInRosterPanel.css
+++ b/frontend/src/components/events/EventCheckInRosterPanel.css
@@ -96,6 +96,29 @@
   gap: 6px;
 }
 
+.checkin-roster-division-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.checkin-roster-division-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.checkin-roster-division-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin: 0;
+  color: #9a9aa3;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #26262d;
+}
+
 .checkin-roster-chip {
   display: flex;
   align-items: center;

--- a/frontend/src/components/events/EventCheckInRosterPanel.tsx
+++ b/frontend/src/components/events/EventCheckInRosterPanel.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { eventsApi } from '../../services/api/events.api';
+import { divisionsApi } from '../../services/api/divisions.api';
+import type { Division } from '../../types';
 import type {
   EventCheckInRoster,
   EventCheckInPlayerSummary,
@@ -23,6 +25,14 @@ const BUCKET_ORDER: BucketKey[] = [
 
 const FALLBACK_AVATAR =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><rect width="40" height="40" fill="%23444"/><text x="50%25" y="55%25" dominant-baseline="middle" text-anchor="middle" fill="%23fff" font-size="16" font-family="sans-serif">?</text></svg>';
+
+const UNASSIGNED_KEY = '__unassigned__';
+
+interface AvailableDivisionGroup {
+  id: string;
+  name: string;
+  players: EventCheckInPlayerSummary[];
+}
 
 function PlayerChip({ player }: { player: EventCheckInPlayerSummary }) {
   return (
@@ -51,9 +61,66 @@ export default function EventCheckInRosterPanel({
 }: EventCheckInRosterPanelProps) {
   const { t } = useTranslation();
   const [roster, setRoster] = useState<EventCheckInRoster | null>(null);
+  const [divisions, setDivisions] = useState<Division[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    divisionsApi
+      .getAll()
+      .then((data) => {
+        if (!cancelled) setDivisions(data);
+      })
+      .catch(() => {
+        // Silently fall back to a flat list if divisions can't be loaded
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const availableGroups = useMemo<AvailableDivisionGroup[] | null>(() => {
+    if (!roster) return null;
+    if (divisions.length === 0) return null;
+    const divisionNames = new Map(divisions.map((d) => [d.divisionId, d.name]));
+    const buckets = new Map<string, EventCheckInPlayerSummary[]>();
+    for (const player of roster.available) {
+      const key =
+        player.divisionId && divisionNames.has(player.divisionId)
+          ? player.divisionId
+          : UNASSIGNED_KEY;
+      const list = buckets.get(key);
+      if (list) {
+        list.push(player);
+      } else {
+        buckets.set(key, [player]);
+      }
+    }
+    const ordered: AvailableDivisionGroup[] = [];
+    for (const division of divisions) {
+      const players = buckets.get(division.divisionId);
+      if (players && players.length > 0) {
+        ordered.push({
+          id: division.divisionId,
+          name: division.name,
+          players,
+        });
+      }
+    }
+    const unassigned = buckets.get(UNASSIGNED_KEY);
+    if (unassigned && unassigned.length > 0) {
+      ordered.push({
+        id: UNASSIGNED_KEY,
+        name: t('events.checkIn.roster.unassigned', {
+          defaultValue: 'Unassigned',
+        }),
+        players: unassigned,
+      });
+    }
+    return ordered;
+  }, [roster, divisions, t]);
 
   const fetchRoster = useCallback(async () => {
     setLoading(true);
@@ -145,6 +212,21 @@ export default function EventCheckInRosterPanel({
               defaultValue: 'No check-ins yet.',
             })}
           </p>
+        ) : availableGroups ? (
+          <div className="checkin-roster-division-groups">
+            {availableGroups.map((group) => (
+              <div key={group.id} className="checkin-roster-division-group">
+                <h5 className="checkin-roster-division-title">
+                  {group.name} ({group.players.length})
+                </h5>
+                <ul className="checkin-roster-list">
+                  {group.players.map((player) => (
+                    <PlayerChip key={player.playerId} player={player} />
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         ) : (
           <ul className="checkin-roster-list">
             {roster.available.map((player) => (
@@ -209,16 +291,40 @@ export default function EventCheckInRosterPanel({
                   ? 'No Response'
                   : key.charAt(0).toUpperCase() + key.slice(1),
             });
+            const showGrouped = key === 'available' && availableGroups;
             return (
               <div key={key} className="checkin-roster-column">
                 <h4 className="checkin-roster-column-title">
                   {label} ({bucket.length})
                 </h4>
-                <ul className="checkin-roster-list">
-                  {bucket.map((player) => (
-                    <PlayerChip key={player.playerId} player={player} />
-                  ))}
-                </ul>
+                {showGrouped ? (
+                  <div className="checkin-roster-division-groups">
+                    {availableGroups.map((group) => (
+                      <div
+                        key={group.id}
+                        className="checkin-roster-division-group"
+                      >
+                        <h5 className="checkin-roster-division-title">
+                          {group.name} ({group.players.length})
+                        </h5>
+                        <ul className="checkin-roster-list">
+                          {group.players.map((player) => (
+                            <PlayerChip
+                              key={player.playerId}
+                              player={player}
+                            />
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <ul className="checkin-roster-list">
+                    {bucket.map((player) => (
+                      <PlayerChip key={player.playerId} player={player} />
+                    ))}
+                  </ul>
+                )}
               </div>
             );
           })}

--- a/frontend/src/components/events/__tests__/EventCheckInRosterPanel.test.tsx
+++ b/frontend/src/components/events/__tests__/EventCheckInRosterPanel.test.tsx
@@ -4,13 +4,20 @@ import userEvent from '@testing-library/user-event';
 import type { EventCheckInRoster } from '../../../types/event';
 
 // --- Hoisted mocks ---
-const { mockGetCheckIns } = vi.hoisted(() => ({
+const { mockGetCheckIns, mockGetDivisions } = vi.hoisted(() => ({
   mockGetCheckIns: vi.fn(),
+  mockGetDivisions: vi.fn(),
 }));
 
 vi.mock('../../../services/api/events.api', () => ({
   eventsApi: {
     getCheckIns: mockGetCheckIns,
+  },
+}));
+
+vi.mock('../../../services/api/divisions.api', () => ({
+  divisionsApi: {
+    getAll: mockGetDivisions,
   },
 }));
 
@@ -66,6 +73,8 @@ describe('EventCheckInRosterPanel', () => {
   beforeEach(() => {
     mockGetCheckIns.mockReset();
     mockGetCheckIns.mockResolvedValue(sampleRoster);
+    mockGetDivisions.mockReset();
+    mockGetDivisions.mockResolvedValue([]);
   });
 
   it('calls getCheckIns on mount with the correct eventId', async () => {
@@ -161,5 +170,39 @@ describe('EventCheckInRosterPanel', () => {
         screen.getByText('Failed to load check-in roster.')
       ).toBeInTheDocument();
     });
+  });
+
+  it('groups available wrestlers by division when divisions are loaded', async () => {
+    mockGetCheckIns.mockResolvedValue({
+      available: [
+        { playerId: 'p1', name: 'Alice', currentWrestler: 'Alpha', divisionId: 'd1' },
+        { playerId: 'p2', name: 'Bob', currentWrestler: 'Bravo', divisionId: 'd2' },
+        { playerId: 'p3', name: 'Frank', currentWrestler: 'Foxtrot' },
+      ],
+      tentative: [],
+      unavailable: [],
+      noResponse: [
+        { playerId: 'p4', name: 'Dave', currentWrestler: 'Delta', divisionId: 'd1' },
+      ],
+    });
+    mockGetDivisions.mockResolvedValue([
+      { divisionId: 'd1', name: 'Heavyweight', createdAt: '', updatedAt: '' },
+      { divisionId: 'd2', name: 'Cruiserweight', createdAt: '', updatedAt: '' },
+    ]);
+
+    render(<EventCheckInRosterPanel eventId="evt-123" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Heavyweight \(1\)/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Cruiserweight \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Unassigned \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Frank')).toBeInTheDocument();
+    // Other buckets are not grouped: Dave (in noResponse, divisionId d1) should
+    // appear without a Heavyweight subheader inside that column.
+    expect(screen.getByText('Dave')).toBeInTheDocument();
+    expect(screen.getAllByText(/Heavyweight \(1\)/)).toHaveLength(1);
   });
 });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1063,6 +1063,7 @@
         "tentative": "Vielleicht",
         "unavailable": "Nicht verfügbar",
         "noResponse": "Keine Antwort",
+        "unassigned": "Keine Division",
         "copy": "Als Text kopieren",
         "refresh": "Aktualisieren",
         "copySuccess": "Kopiert!",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1064,6 +1064,7 @@
         "tentative": "Tentative",
         "unavailable": "Unavailable",
         "noResponse": "No Response",
+        "unassigned": "Unassigned",
         "copy": "Copy as text",
         "refresh": "Refresh",
         "copySuccess": "Copied!",


### PR DESCRIPTION
## Summary
- In the **Check-In Roster** panel, the **Available** column is now sub-grouped by division, with an **Unassigned** section for players not in a division.
- Other columns (Tentative, Unavailable, No Response) stay flat — only "the available ones" are grouped, per the request.
- Compact mode (Available-only) is also grouped.
- Silently falls back to the existing flat list if divisions cannot be loaded.

## Implementation
- `EventCheckInRosterPanel.tsx`: fetch `divisionsApi.getAll()` once on mount, then memoize an ordered list of `{ id, name, players }` groups built from `roster.available`. Render that grouped view in both compact and full modes; other buckets keep the original flat list.
- `EventCheckInRosterPanel.css`: minor styles for the per-division sub-headers (`.checkin-roster-division-groups`, `.checkin-roster-division-group`, `.checkin-roster-division-title`).
- i18n: added `events.checkIn.roster.unassigned` to `en.json` ("Unassigned") and `de.json` ("Keine Division").

## Test plan
- [x] `npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `npx vitest run src/components/events` — 31/31 passing, including a new test verifying division grouping for Available and that other buckets remain flat
- [ ] Manual check on an event detail page: confirm Available column shows division headers and Unassigned section appears only when needed

https://claude.ai/code/session_01FfKy5ApKE7Mm4HuXTQqX2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfKy5ApKE7Mm4HuXTQqX2P)_