### PR TITLE
feat(checkin-roster): mark already-booked wrestlers in Available column

### DIFF
--- a/frontend/src/components/events/EventCheckInRosterPanel.css
+++ b/frontend/src/components/events/EventCheckInRosterPanel.css
@@ -128,6 +128,24 @@
   border-radius: 6px;
 }
 
+.checkin-roster-chip--booked {
+  background: #1d2a1f;
+  border: 1px solid #2f6b3a;
+}
+
+.checkin-roster-chip-booked {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #052e0d;
+  background: #4ade80;
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+
 .checkin-roster-chip-avatar {
   width: 28px;
   height: 28px;

--- a/frontend/src/components/events/EventCheckInRosterPanel.tsx
+++ b/frontend/src/components/events/EventCheckInRosterPanel.tsx
@@ -12,6 +12,7 @@ import './EventCheckInRosterPanel.css';
 interface EventCheckInRosterPanelProps {
   eventId: string;
   compact?: boolean;
+  bookedPlayerIds?: ReadonlySet<string>;
 }
 
 type BucketKey = 'available' | 'tentative' | 'unavailable' | 'noResponse';
@@ -34,9 +35,19 @@ interface AvailableDivisionGroup {
   players: EventCheckInPlayerSummary[];
 }
 
-function PlayerChip({ player }: { player: EventCheckInPlayerSummary }) {
+function PlayerChip({
+  player,
+  isBooked = false,
+  bookedLabel,
+}: {
+  player: EventCheckInPlayerSummary;
+  isBooked?: boolean;
+  bookedLabel?: string;
+}) {
   return (
-    <li className="checkin-roster-chip">
+    <li
+      className={`checkin-roster-chip${isBooked ? ' checkin-roster-chip--booked' : ''}`}
+    >
       <img
         className="checkin-roster-chip-avatar"
         src={player.imageUrl || FALLBACK_AVATAR}
@@ -51,6 +62,15 @@ function PlayerChip({ player }: { player: EventCheckInPlayerSummary }) {
           {player.currentWrestler}
         </span>
       </div>
+      {isBooked && (
+        <span
+          className="checkin-roster-chip-booked"
+          title={bookedLabel}
+          aria-label={bookedLabel}
+        >
+          {bookedLabel}
+        </span>
+      )}
     </li>
   );
 }
@@ -58,6 +78,7 @@ function PlayerChip({ player }: { player: EventCheckInPlayerSummary }) {
 export default function EventCheckInRosterPanel({
   eventId,
   compact = false,
+  bookedPlayerIds,
 }: EventCheckInRosterPanelProps) {
   const { t } = useTranslation();
   const [roster, setRoster] = useState<EventCheckInRoster | null>(null);
@@ -121,6 +142,10 @@ export default function EventCheckInRosterPanel({
     }
     return ordered;
   }, [roster, divisions, t]);
+
+  const bookedLabel = t('events.checkIn.roster.booked', {
+    defaultValue: 'Booked',
+  });
 
   const fetchRoster = useCallback(async () => {
     setLoading(true);
@@ -221,7 +246,12 @@ export default function EventCheckInRosterPanel({
                 </h5>
                 <ul className="checkin-roster-list">
                   {group.players.map((player) => (
-                    <PlayerChip key={player.playerId} player={player} />
+                    <PlayerChip
+                      key={player.playerId}
+                      player={player}
+                      isBooked={bookedPlayerIds?.has(player.playerId)}
+                      bookedLabel={bookedLabel}
+                    />
                   ))}
                 </ul>
               </div>
@@ -230,7 +260,12 @@ export default function EventCheckInRosterPanel({
         ) : (
           <ul className="checkin-roster-list">
             {roster.available.map((player) => (
-              <PlayerChip key={player.playerId} player={player} />
+              <PlayerChip
+                key={player.playerId}
+                player={player}
+                isBooked={bookedPlayerIds?.has(player.playerId)}
+                bookedLabel={bookedLabel}
+              />
             ))}
           </ul>
         )}
@@ -312,6 +347,8 @@ export default function EventCheckInRosterPanel({
                             <PlayerChip
                               key={player.playerId}
                               player={player}
+                              isBooked={bookedPlayerIds?.has(player.playerId)}
+                              bookedLabel={bookedLabel}
                             />
                           ))}
                         </ul>
@@ -321,7 +358,16 @@ export default function EventCheckInRosterPanel({
                 ) : (
                   <ul className="checkin-roster-list">
                     {bucket.map((player) => (
-                      <PlayerChip key={player.playerId} player={player} />
+                      <PlayerChip
+                        key={player.playerId}
+                        player={player}
+                        isBooked={
+                          key === 'available'
+                            ? bookedPlayerIds?.has(player.playerId)
+                            : false
+                        }
+                        bookedLabel={bookedLabel}
+                      />
                     ))}
                   </ul>
                 )}

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -272,6 +272,19 @@ export default function EventDetail() {
     return map;
   }, [scheduledMatches]);
 
+  const bookedPlayerIds = useMemo(() => {
+    const ids = new Set<string>();
+    const matches = eventData?.enrichedMatches ?? [];
+    for (const match of matches) {
+      for (const participant of match.matchData.participants) {
+        if (participant.playerId) {
+          ids.add(participant.playerId);
+        }
+      }
+    }
+    return ids;
+  }, [eventData?.enrichedMatches]);
+
   if (loading) {
     return (
       <div className="event-detail-page">
@@ -600,7 +613,10 @@ export default function EventDetail() {
       </div>
 
       {isAdminOrModerator && eventId && (
-        <EventCheckInRosterPanel eventId={eventId} />
+        <EventCheckInRosterPanel
+          eventId={eventId}
+          bookedPlayerIds={bookedPlayerIds}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/events/__tests__/EventCheckInRosterPanel.test.tsx
+++ b/frontend/src/components/events/__tests__/EventCheckInRosterPanel.test.tsx
@@ -205,4 +205,37 @@ describe('EventCheckInRosterPanel', () => {
     expect(screen.getByText('Dave')).toBeInTheDocument();
     expect(screen.getAllByText(/Heavyweight \(1\)/)).toHaveLength(1);
   });
+
+  it('marks available wrestlers as Booked when their playerId is in bookedPlayerIds', async () => {
+    mockGetCheckIns.mockResolvedValue({
+      available: [
+        { playerId: 'p1', name: 'Alice', currentWrestler: 'Alpha' },
+        { playerId: 'p2', name: 'Bob', currentWrestler: 'Bravo' },
+      ],
+      tentative: [],
+      unavailable: [],
+      noResponse: [
+        // Carol is in noResponse AND in the booked set; should NOT show "Booked"
+        // since the indicator only applies to the Available column.
+        { playerId: 'p3', name: 'Carol', currentWrestler: 'Charlie' },
+      ],
+    });
+
+    const booked = new Set(['p1', 'p3']);
+    render(
+      <EventCheckInRosterPanel eventId="evt-123" bookedPlayerIds={booked} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    // Exactly one "Booked" badge — for Alice, in Available
+    const badges = screen.getAllByText('Booked');
+    expect(badges).toHaveLength(1);
+    // Bob (available, not booked) should not have a badge near him
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    // Carol (noResponse, booked) should NOT show a Booked indicator
+    expect(screen.getByText('Carol')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1064,6 +1064,7 @@
         "unavailable": "Nicht verfügbar",
         "noResponse": "Keine Antwort",
         "unassigned": "Keine Division",
+        "booked": "Gebucht",
         "copy": "Als Text kopieren",
         "refresh": "Aktualisieren",
         "copySuccess": "Kopiert!",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1065,6 +1065,7 @@
         "unavailable": "Unavailable",
         "noResponse": "No Response",
         "unassigned": "Unassigned",
+        "booked": "Booked",
         "copy": "Copy as text",
         "refresh": "Refresh",
         "copySuccess": "Copied!",


### PR DESCRIPTION
## Summary
- Adds a small **"Booked"** badge in the **Available** column of the Check-In Roster for any wrestler whose `playerId` already appears as a participant on the event's match card.
- Helps the matchmaker see at a glance who's already placed before drafting more matches.
- Indicator is shown only on the Available column — Tentative/Unavailable/No Response stay clean (per scope of the request).

## Implementation
- `EventDetail.tsx`: new `useMemo` builds a `Set<string>` of all `playerId`s from `enrichedMatches[*].matchData.participants` and passes it to `EventCheckInRosterPanel` as a new optional `bookedPlayerIds` prop.
- `EventCheckInRosterPanel.tsx`:
  - `EventCheckInRosterPanelProps` accepts `bookedPlayerIds?: ReadonlySet<string>`.
  - `PlayerChip` accepts optional `isBooked` and renders a green pill labeled "Booked" (i18n key `events.checkIn.roster.booked`).
  - `isBooked` is only passed through for chips in the Available column (compact and full mode, grouped and ungrouped paths).
- `EventCheckInRosterPanel.css`: `.checkin-roster-chip--booked` (subtle green tint) and `.checkin-roster-chip-booked` (green pill badge).
- i18n: added `events.checkIn.roster.booked` to `en.json` ("Booked") and `de.json` ("Gebucht").

## Test plan
- [x] `npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `npx vitest run src/components/events/__tests__/EventCheckInRosterPanel.test.tsx` — 8/8 passing, including a new test verifying that the badge appears once for an available player whose id is in `bookedPlayerIds` and does not appear for a player in another bucket whose id is also in the set
- [ ] Manual: open an event with players already booked into matches, confirm green "Booked" pill appears next to those players in Available, and that other columns are unaffected

https://claude.ai/code/session_01FfKy5ApKE7Mm4HuXTQqX2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfKy5ApKE7Mm4HuXTQqX2P)_