### PR TITLE
feat(stables): add Reactivate action for disbanded stables

### DIFF
--- a/backend/functions/stables/handler.ts
+++ b/backend/functions/stables/handler.ts
@@ -9,6 +9,7 @@ import { handler as inviteToStableHandler } from './inviteToStable';
 import { handler as getInvitationsHandler } from './getInvitations';
 import { handler as respondToInvitationHandler } from './respondToInvitation';
 import { handler as disbandStableHandler } from './disbandStable';
+import { handler as reactivateStableHandler } from './reactivateStable';
 import { handler as removeMemberHandler } from './removeMember';
 import { handler as deleteStableHandler } from './deleteStable';
 import { createRouter, type RouteConfig } from '../../lib/router';
@@ -78,6 +79,12 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/stables/{stableId}/disband',
     method: 'POST',
     handler: disbandStableHandler,
+    requireAuth: true,
+  },
+  {
+    resource: '/stables/{stableId}/reactivate',
+    method: 'POST',
+    handler: reactivateStableHandler,
     requireAuth: true,
   },
   {

--- a/backend/functions/stables/reactivateStable.ts
+++ b/backend/functions/stables/reactivateStable.ts
@@ -1,0 +1,73 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+import { requireRole } from '../../lib/auth';
+
+interface SkippedMember {
+  playerId: string;
+  reason: 'not-found' | 'in-other-stable';
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const roleError = requireRole(event, 'Moderator');
+    if (roleError) return roleError;
+
+    const stableId = event.pathParameters?.stableId;
+    if (!stableId) {
+      return badRequest('stableId is required');
+    }
+
+    const { roster: { stables: stablesRepo, players: playersRepo } } = getRepositories();
+
+    const stable = await stablesRepo.findById(stableId);
+    if (!stable) {
+      return notFound('Stable not found');
+    }
+
+    if (stable.status !== 'disbanded') {
+      return badRequest(
+        `Stable is ${stable.status}; only disbanded stables can be reactivated`,
+      );
+    }
+
+    // Restore Player.stableId for each historical member, but never overwrite
+    // a player who has since joined a different stable.
+    const restoredMemberIds: string[] = [];
+    const skippedMembers: SkippedMember[] = [];
+
+    await Promise.all(
+      stable.memberIds.map(async (playerId) => {
+        const player = await playersRepo.findById(playerId);
+        if (!player) {
+          skippedMembers.push({ playerId, reason: 'not-found' });
+          return;
+        }
+        if (player.stableId && player.stableId !== stableId) {
+          skippedMembers.push({ playerId, reason: 'in-other-stable' });
+          return;
+        }
+        if (player.stableId !== stableId) {
+          await playersRepo.update(playerId, { stableId });
+        }
+        restoredMemberIds.push(playerId);
+      }),
+    );
+
+    // Flip status back to active. We intentionally leave `disbandedAt` set as
+    // a historical record — `status` is the source of truth for whether the
+    // stable is currently active.
+    await stablesRepo.update(stableId, { status: 'active' });
+
+    return success({
+      message: 'Stable reactivated',
+      stableId,
+      status: 'active',
+      restoredMemberIds,
+      skippedMembers,
+    });
+  } catch (err) {
+    console.error('Error reactivating stable:', err);
+    return serverError('Failed to reactivate stable');
+  }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -848,6 +848,10 @@ functions:
           method: post
           cors: *corsConfig
       - http:
+          path: stables/{stableId}/reactivate
+          method: post
+          cors: *corsConfig
+      - http:
           path: stables/{stableId}/remove-member
           method: post
           cors: *corsConfig

--- a/frontend/src/components/admin/ManageStables.css
+++ b/frontend/src/components/admin/ManageStables.css
@@ -170,6 +170,15 @@
   background-color: #4b5563 !important;
 }
 
+.admin-btn-reactivate {
+  background-color: #2563eb !important;
+  color: #fff !important;
+}
+
+.admin-btn-reactivate:hover {
+  background-color: #1d4ed8 !important;
+}
+
 .admin-stables-empty {
   text-align: center;
   padding: 3rem 1rem;

--- a/frontend/src/components/admin/ManageStables.tsx
+++ b/frontend/src/components/admin/ManageStables.tsx
@@ -98,6 +98,35 @@ export default function ManageStables() {
     }
   };
 
+  const handleReactivate = async (stable: Stable) => {
+    const confirmMsg = t(
+      'stables.admin.confirmReactivate',
+      'Reactivate "{{name}}"? Members who have since joined another stable will be skipped.',
+      { name: stable.name },
+    );
+    if (!window.confirm(confirmMsg)) return;
+    setSubmitting(stable.stableId);
+    try {
+      const result = await stablesApi.reactivate(stable.stableId);
+      const skipped = result.skippedMembers.length;
+      const restored = result.restoredMemberIds.length;
+      const base = t('stables.admin.reactivated', 'Reactivated') + `: ${stable.name}`;
+      const detail =
+        skipped > 0
+          ? ` (${restored} restored, ${skipped} skipped)`
+          : ` (${restored} restored)`;
+      showFeedback(base + detail, 'success');
+      await loadStables();
+    } catch (err) {
+      showFeedback(
+        err instanceof Error ? err.message : 'Failed to reactivate stable',
+        'error',
+      );
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
   const handleDelete = async (stable: Stable) => {
     setSubmitting(stable.stableId);
     try {
@@ -243,6 +272,18 @@ export default function ManageStables() {
                         {submitting === stable.stableId
                           ? '...'
                           : t('stables.admin.disband', 'Disband')}
+                      </button>
+                    )}
+                    {stable.status === 'disbanded' && (
+                      <button
+                        type="button"
+                        className="admin-btn-reactivate"
+                        onClick={() => handleReactivate(stable)}
+                        disabled={submitting === stable.stableId}
+                      >
+                        {submitting === stable.stableId
+                          ? '...'
+                          : t('stables.admin.reactivate', 'Reactivate')}
                       </button>
                     )}
                     <button

--- a/frontend/src/services/api/stables.api.ts
+++ b/frontend/src/services/api/stables.api.ts
@@ -75,6 +75,20 @@ export const stablesApi = {
     });
   },
 
+  reactivate: async (
+    stableId: string,
+  ): Promise<{
+    message: string;
+    stableId: string;
+    status: 'active';
+    restoredMemberIds: string[];
+    skippedMembers: { playerId: string; reason: 'not-found' | 'in-other-stable' }[];
+  }> => {
+    return fetchWithAuth(`${API_BASE_URL}/stables/${stableId}/reactivate`, {
+      method: 'POST',
+    });
+  },
+
   removeMember: async (stableId: string, playerId: string): Promise<Stable> => {
     return fetchWithAuth(`${API_BASE_URL}/stables/${stableId}/members/${playerId}`, {
       method: 'DELETE',


### PR DESCRIPTION
## Summary
- Adds a **Reactivate** action for disbanded stables. Solves the recurring problem of accidental disbands (e.g. THE UNDERDOGS on prod) without needing a DB-level fix.
- Backend: `POST /stables/{stableId}/reactivate` (Moderator+). Sets `status='active'` and restores `Player.stableId` for each historical member, skipping any player who has since joined a different stable.
- Frontend: a "Reactivate" button appears on rows where `status === 'disbanded'` in **Manage Stables**, behind a confirmation prompt. Toast reports how many members were restored vs. skipped.

## Behavior notes
- **Membership recovery is possible because** `disbandStable.ts` only flipped `status` and cleared `Player.stableId` — it never touched the stable's own `memberIds[]` array. So we can re-link members by reading the stable record alone (no audit log needed).
- **`disbandedAt` is intentionally preserved** as a historical record. `status` is the source of truth for "is this stable currently active?", and nothing in the codebase reads `disbandedAt` for filtering on non-disbanded stables.
- **No overwrites:** if a former member is now in a different stable, they are skipped (returned as `skippedMembers` with reason `'in-other-stable'`). Players who no longer exist are skipped with reason `'not-found'`. The admin sees the count in the toast and can re-invite manually if desired.
- **Permission:** Moderator+ (matches `approveStable`). The original leader may no longer be associated with the stable post-disband, so leader-only would be unsafe.

## Files
- `backend/functions/stables/reactivateStable.ts` (new handler)
- `backend/functions/stables/handler.ts` (route registration)
- `backend/serverless.yml` (HTTP event)
- `frontend/src/services/api/stables.api.ts` (`reactivate` method)
- `frontend/src/components/admin/ManageStables.tsx` (button + handler with confirm + skipped/restored toast)
- `frontend/src/components/admin/ManageStables.css` (button style)

## Test plan
- [x] `cd backend && npx tsc --noEmit` — clean
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `cd backend && npx vitest run` — 895/895 passing
- [x] `cd frontend && npx vitest run` — 430/430 passing
- [ ] After deploy: in Manage Stables, filter by Disbanded, click Reactivate on THE UNDERDOGS, confirm status flips to active and all 4 members are restored (or skipped with explanation if any joined another stable)

## Recovery for THE UNDERDOGS
Once this is merged and deployed to prod, the admin can simply click "Reactivate" on the THE UNDERDOGS row in Manage Stables — no DB script needed.

https://claude.ai/code/session_01FfKy5ApKE7Mm4HuXTQqX2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfKy5ApKE7Mm4HuXTQqX2P)_