### PR TITLE
feat(shows): PPV date selection — book PPVs from the calendar

### DIFF
--- a/backend/functions/shows/createShow.ts
+++ b/backend/functions/shows/createShow.ts
@@ -7,7 +7,7 @@ export const handler = createHandlerFactory<ShowCreateInput, unknown>({
   repo: () => getRepositories().leagueOps.shows,
   entityName: 'show',
   requiredFields: ['name', 'companyId'],
-  optionalFields: ['description', 'schedule', 'dayOfWeek', 'imageUrl'],
+  optionalFields: ['description', 'schedule', 'dayOfWeek', 'ppvDate', 'imageUrl'],
   validate: async (body) => {
     if (body.companyId) {
       const { leagueOps: { companies } } = getRepositories();

--- a/backend/functions/shows/updateShow.ts
+++ b/backend/functions/shows/updateShow.ts
@@ -9,6 +9,7 @@ interface UpdateShowBody {
   description?: string;
   schedule?: string;
   dayOfWeek?: string;
+  ppvDate?: string;
   imageUrl?: string;
 }
 

--- a/backend/lib/repositories/LeagueOpsRepository.ts
+++ b/backend/lib/repositories/LeagueOpsRepository.ts
@@ -49,6 +49,7 @@ export interface ShowCreateInput {
   description?: string;
   schedule?: string;
   dayOfWeek?: string;
+  ppvDate?: string;
   imageUrl?: string;
 }
 
@@ -58,6 +59,7 @@ export interface ShowPatch {
   description?: string;
   schedule?: string;
   dayOfWeek?: string;
+  ppvDate?: string;
   imageUrl?: string;
 }
 

--- a/backend/lib/repositories/dynamo/DynamoLeagueOpsRepository.ts
+++ b/backend/lib/repositories/dynamo/DynamoLeagueOpsRepository.ts
@@ -82,6 +82,7 @@ export class DynamoLeagueOpsRepository implements LeagueOpsRepository {
       ...(input.description !== undefined ? { description: input.description } : {}),
       ...(input.schedule !== undefined ? { schedule: input.schedule } : {}),
       ...(input.dayOfWeek !== undefined ? { dayOfWeek: input.dayOfWeek } : {}),
+      ...(input.ppvDate !== undefined ? { ppvDate: input.ppvDate } : {}),
       ...(input.imageUrl !== undefined ? { imageUrl: input.imageUrl } : {}),
       createdAt: now,
       updatedAt: now,

--- a/backend/lib/repositories/inMemory/InMemoryLeagueOpsRepository.ts
+++ b/backend/lib/repositories/inMemory/InMemoryLeagueOpsRepository.ts
@@ -174,6 +174,7 @@ class ShowsSubRepo extends InMemoryCrudRepository<Show, ShowCreateInput, ShowPat
         ...(input.description !== undefined ? { description: input.description } : {}),
         ...(input.schedule !== undefined ? { schedule: input.schedule } : {}),
         ...(input.dayOfWeek !== undefined ? { dayOfWeek: input.dayOfWeek } : {}),
+        ...(input.ppvDate !== undefined ? { ppvDate: input.ppvDate } : {}),
         ...(input.imageUrl !== undefined ? { imageUrl: input.imageUrl } : {}),
         createdAt: now,
         updatedAt: now,

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -66,6 +66,7 @@ export interface Show {
   description?: string;
   schedule?: string;
   dayOfWeek?: string;
+  ppvDate?: string;
   imageUrl?: string;
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/components/admin/ManageShows.tsx
+++ b/frontend/src/components/admin/ManageShows.tsx
@@ -27,6 +27,7 @@ export default function ManageShows() {
     companyId: '',
     schedule: '' as '' | 'weekly' | 'ppv' | 'special',
     dayOfWeek: '' as '' | DayOfWeek,
+    ppvDate: '',
     description: '',
     imageUrl: '',
   });
@@ -123,12 +124,22 @@ export default function ManageShows() {
     try {
       const imageUrl = await uploadImage();
 
+      if (formData.schedule === 'ppv' && !formData.ppvDate) {
+        setError(t('shows.selectPpvDate'));
+        return;
+      }
+
+      const ppvDateIso = (formData.schedule === 'ppv' && formData.ppvDate)
+        ? new Date(formData.ppvDate).toISOString()
+        : undefined;
+
       if (editingShow) {
         await showsApi.update(editingShow.showId, {
           name: formData.name,
           companyId: formData.companyId,
           schedule: formData.schedule || undefined,
           dayOfWeek: (formData.schedule === 'weekly' && formData.dayOfWeek) ? formData.dayOfWeek : undefined,
+          ppvDate: ppvDateIso,
           description: formData.description || undefined,
           imageUrl: imageUrl || undefined,
         });
@@ -139,6 +150,7 @@ export default function ManageShows() {
           companyId: formData.companyId,
           schedule: formData.schedule || undefined,
           dayOfWeek: (formData.schedule === 'weekly' && formData.dayOfWeek) ? formData.dayOfWeek : undefined,
+          ppvDate: ppvDateIso,
           description: formData.description || undefined,
           imageUrl: imageUrl || undefined,
         });
@@ -153,7 +165,7 @@ export default function ManageShows() {
   };
 
   const resetForm = () => {
-    setFormData({ name: '', companyId: '', schedule: '', dayOfWeek: '', description: '', imageUrl: '' });
+    setFormData({ name: '', companyId: '', schedule: '', dayOfWeek: '', ppvDate: '', description: '', imageUrl: '' });
     setSelectedFile(null);
     setImagePreview(null);
     setShowAddForm(false);
@@ -167,6 +179,7 @@ export default function ManageShows() {
       companyId: show.companyId,
       schedule: show.schedule || '',
       dayOfWeek: show.dayOfWeek || '',
+      ppvDate: show.ppvDate ? show.ppvDate.slice(0, 10) : '',
       description: show.description || '',
       imageUrl: show.imageUrl || '',
     });
@@ -261,6 +274,15 @@ export default function ManageShows() {
               </div>
             )}
 
+            {formData.schedule === 'ppv' && (
+              <div className="form-group">
+                <label htmlFor="show-ppv-date">{t('shows.ppvDate')}</label>
+                <input type="date" id="show-ppv-date" value={formData.ppvDate}
+                  onChange={(e) => setFormData({ ...formData, ppvDate: e.target.value })}
+                  required />
+              </div>
+            )}
+
             <div className="form-group">
               <label htmlFor="show-description">{t('shows.description')}</label>
               <textarea id="show-description" value={formData.description}
@@ -327,6 +349,9 @@ export default function ManageShows() {
                         <span className="show-schedule-badge">{getScheduleLabel(show.schedule)}</span>
                         {show.dayOfWeek && show.schedule === 'weekly' && (
                           <span className="show-day-badge">{t(`shows.${show.dayOfWeek}`)}</span>
+                        )}
+                        {show.ppvDate && show.schedule === 'ppv' && (
+                          <span className="show-day-badge">{new Date(show.ppvDate).toLocaleDateString()}</span>
                         )}
                       </div>
                       {show.description && <p className="show-description">{show.description}</p>}

--- a/frontend/src/components/events/EventsCalendar.tsx
+++ b/frontend/src/components/events/EventsCalendar.tsx
@@ -19,6 +19,7 @@ const eventTypeColors: Record<string, string> = {
 };
 
 const showColor = '#60a5fa';
+const ppvShowColor = '#d4af37';
 
 type FilterTab = 'all' | EventType;
 
@@ -37,6 +38,7 @@ interface ShowCalendarEntry {
   show: Show;
   companyName: string;
   date: string; // ISO date for this specific occurrence
+  eventType: 'weekly' | 'ppv';
 }
 
 export default function EventsCalendar() {
@@ -77,7 +79,10 @@ export default function EventsCalendar() {
           showId: e.showId,
         }));
         setCalendarEntries(entries);
-        setShows(showsData.filter((s) => s.schedule === 'weekly' && s.dayOfWeek));
+        setShows(showsData.filter((s) =>
+          (s.schedule === 'weekly' && s.dayOfWeek) ||
+          (s.schedule === 'ppv' && s.ppvDate)
+        ));
         const names: Record<string, string> = {};
         companiesData.forEach((c) => { names[c.companyId] = c.name; });
         setCompanyNames(names);
@@ -132,40 +137,56 @@ export default function EventsCalendar() {
     });
   }, [filteredEntries, currentMonth, currentYear]);
 
-  // Generate weekly show entries for the current month
+  // Generate weekly + PPV show entries for the current month
   const showEntriesByDay = useMemo(() => {
-    if (activeFilter !== 'all' && activeFilter !== 'weekly') return {};
-
     const map: Record<number, ShowCalendarEntry[]> = {};
     const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
 
+    const eventExistsForShowOnDate = (showId: string, date: Date) =>
+      calendarEntries.some((e) => {
+        if (e.showId !== showId) return false;
+        const eDate = new Date(e.date);
+        return eDate.getFullYear() === date.getFullYear() &&
+          eDate.getMonth() === date.getMonth() &&
+          eDate.getDate() === date.getDate();
+      });
+
     shows.forEach((show) => {
-      if (!show.dayOfWeek) return;
-      const targetDay = dayOfWeekToNumber[show.dayOfWeek];
-      if (targetDay === undefined) return;
+      // Weekly recurring shows
+      if (show.schedule === 'weekly' && show.dayOfWeek) {
+        if (activeFilter !== 'all' && activeFilter !== 'weekly') return;
+        const targetDay = dayOfWeekToNumber[show.dayOfWeek];
+        if (targetDay === undefined) return;
 
-      for (let d = 1; d <= daysInMonth; d++) {
-        const date = new Date(currentYear, currentMonth, d);
-        if (date.getDay() === targetDay) {
-          const dateStr = date.toISOString();
-          // Check if an event already exists for this show on this date
-          const existingEvent = calendarEntries.find((e) => {
-            if (e.showId !== show.showId) return false;
-            const eDate = new Date(e.date);
-            return eDate.getFullYear() === date.getFullYear() &&
-              eDate.getMonth() === date.getMonth() &&
-              eDate.getDate() === date.getDate();
+        for (let d = 1; d <= daysInMonth; d++) {
+          const date = new Date(currentYear, currentMonth, d);
+          if (date.getDay() !== targetDay) continue;
+          if (eventExistsForShowOnDate(show.showId, date)) continue;
+          const arr = map[d] ?? (map[d] = []);
+          arr.push({
+            show,
+            companyName: companyNames[show.companyId] || '',
+            date: date.toISOString(),
+            eventType: 'weekly',
           });
-
-          if (!existingEvent) {
-            const arr = map[d] ?? (map[d] = []);
-            arr.push({
-              show,
-              companyName: companyNames[show.companyId] || '',
-              date: dateStr,
-            });
-          }
         }
+        return;
+      }
+
+      // PPV shows pinned to a specific date
+      if (show.schedule === 'ppv' && show.ppvDate) {
+        if (activeFilter !== 'all' && activeFilter !== 'ppv') return;
+        const ppvDate = new Date(show.ppvDate);
+        if (ppvDate.getFullYear() !== currentYear || ppvDate.getMonth() !== currentMonth) return;
+        if (eventExistsForShowOnDate(show.showId, ppvDate)) return;
+        const d = ppvDate.getDate();
+        const arr = map[d] ?? (map[d] = []);
+        arr.push({
+          show,
+          companyName: companyNames[show.companyId] || '',
+          date: ppvDate.toISOString(),
+          eventType: 'ppv',
+        });
       }
     });
     return map;
@@ -243,7 +264,7 @@ export default function EventsCalendar() {
     try {
       const event = await eventsApi.create({
         name: entry.show.name,
-        eventType: 'weekly',
+        eventType: entry.eventType,
         date: entry.date,
         showId: entry.show.showId,
         companyIds: [entry.show.companyId],
@@ -375,10 +396,12 @@ export default function EventsCalendar() {
                           )}
                         </Link>
                       ))}
-                      {dayShows?.map((entry) =>
-                        isAdminOrModerator ? (
+                      {dayShows?.map((entry) => {
+                        const barColor = entry.eventType === 'ppv' ? ppvShowColor : showColor;
+                        const itemKey = `show-${entry.show.showId}-${entry.date}`;
+                        return isAdminOrModerator ? (
                           <button
-                            key={`show-${entry.show.showId}`}
+                            key={itemKey}
                             className="calendar-item"
                             title={`${entry.show.name} (${entry.companyName})`}
                             aria-label={entry.show.name}
@@ -388,27 +411,27 @@ export default function EventsCalendar() {
                             {entry.show.imageUrl ? (
                               <img src={entry.show.imageUrl} alt={entry.show.name} className="calendar-item-img" />
                             ) : (
-                              <div className="calendar-item-bar" style={{ backgroundColor: showColor }}>
+                              <div className="calendar-item-bar" style={{ backgroundColor: barColor }}>
                                 <span className="calendar-item-label">{entry.show.name}</span>
                               </div>
                             )}
                           </button>
                         ) : (
                           <div
-                            key={`show-${entry.show.showId}`}
+                            key={itemKey}
                             className="calendar-item calendar-item-static"
                             title={entry.show.name}
                           >
                             {entry.show.imageUrl ? (
                               <img src={entry.show.imageUrl} alt={entry.show.name} className="calendar-item-img" />
                             ) : (
-                              <div className="calendar-item-bar" style={{ backgroundColor: showColor }}>
+                              <div className="calendar-item-bar" style={{ backgroundColor: barColor }}>
                                 <span className="calendar-item-label">{entry.show.name}</span>
                               </div>
                             )}
                           </div>
-                        )
-                      )}
+                        );
+                      })}
                     </div>
                   </>
                 )}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1222,6 +1222,8 @@
     "selectCompany": "Unternehmen auswählen",
     "dayOfWeek": "Wochentag",
     "selectDay": "Wochentag auswählen",
+    "ppvDate": "PPV-Datum",
+    "selectPpvDate": "Bitte wähle ein Datum für dieses PPV",
     "image": "Show-Bild",
     "uploadImage": "Bild hochladen",
     "removeImage": "Bild entfernen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1223,6 +1223,8 @@
     "selectCompany": "Select a company",
     "dayOfWeek": "Day of Week",
     "selectDay": "Select day of week",
+    "ppvDate": "PPV Date",
+    "selectPpvDate": "Please select a date for this PPV",
     "image": "Show Image",
     "uploadImage": "Upload Image",
     "removeImage": "Remove Image",

--- a/frontend/src/services/api/shows.api.ts
+++ b/frontend/src/services/api/shows.api.ts
@@ -13,7 +13,7 @@ export const showsApi = {
     return fetchWithAuth(`${API_BASE_URL}/shows/${showId}`);
   },
 
-  create: async (show: { name: string; companyId: string; description?: string; schedule?: 'weekly' | 'ppv' | 'special'; dayOfWeek?: string; imageUrl?: string }): Promise<Show> => {
+  create: async (show: { name: string; companyId: string; description?: string; schedule?: 'weekly' | 'ppv' | 'special'; dayOfWeek?: string; ppvDate?: string; imageUrl?: string }): Promise<Show> => {
     return fetchWithAuth(`${API_BASE_URL}/shows`, {
       method: 'POST',
       body: JSON.stringify(show),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -232,6 +232,7 @@ export interface Show {
   description?: string;
   schedule?: 'weekly' | 'ppv' | 'special';
   dayOfWeek?: DayOfWeek;
+  ppvDate?: string;
   imageUrl?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

When configuring a Show with `schedule = ppv`, admins can now pin it to a specific date via a new **PPV Date** picker in **Manage Shows**. That date drives a new flow on the events calendar:

- PPV-scheduled shows now appear on their `ppvDate` in the calendar (gold, like other PPVs)
- Admins click the calendar entry to create a `ppv` `LeagueEvent` for that date and jump straight to the event detail page to **book the card** (existing match-card UI)
- Public viewers see the PPV as a static (non-clickable) calendar item until an event is created

Previously only `weekly` shows (with `dayOfWeek`) surfaced on the calendar — there was no place to put a PPV without manually creating a one-off event.

## Changes

**Backend**
- `Show`, `ShowCreateInput`, `ShowPatch`: add optional `ppvDate` (ISO string)
- Dynamo + InMemory show repos persist `ppvDate`
- `createShow` / `updateShow` handlers accept `ppvDate`

**Frontend**
- `Show` type + `showsApi.create` accept `ppvDate`
- `ManageShows`: when schedule is `ppv`, render a required date picker; round-trip on edit; show the date as a badge on the show card
- `EventsCalendar`:
  - Loads weekly + PPV shows
  - `showEntriesByDay` now produces both weekly recurrences and PPV pins; respects the active filter tab (`ppv`/`weekly`/`all`)
  - PPV pins render in gold (`#d4af37`); clicking creates an event with `eventType: 'ppv'` and navigates to `/events/:id`
- New i18n keys: `shows.ppvDate`, `shows.selectPpvDate` (en + de)

## Test plan

- [ ] Create a show with schedule = PPV and a date → entry appears on the calendar gold-bar on that date
- [ ] As admin, click the PPV calendar entry → creates a PPV event and navigates to event detail
- [ ] Add matches to the card via the existing event detail UI
- [ ] As a non-admin, the PPV entry is visible but not clickable until an event exists
- [ ] Filter tabs: `ppv` shows only PPV entries (events + un-booked PPV shows); `weekly` excludes PPV shows
- [ ] Edit an existing PPV show: date prepopulates and round-trips
- [ ] Switch a show from PPV → weekly: `ppvDate` is dropped from the form and `dayOfWeek` is required instead
- [ ] Frontend `tsc` and existing `EventsCalendar` tests pass (verified locally)

https://claude.ai/code/session_01Hwtw4zJ9EQggG1cgKPYHhm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwtw4zJ9EQggG1cgKPYHhm)_