### PR TITLE
feat(stables): allow non-leader members to leave a stable

### DIFF
--- a/backend/functions/stables/removeMember.ts
+++ b/backend/functions/stables/removeMember.ts
@@ -36,17 +36,19 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return notFound('Stable not found');
     }
 
-    // Only leader or Admin can remove members
+    // Allowed callers: super admin, the stable leader, or a member removing themselves
     if (!isSuperAdmin(auth)) {
       const callerPlayer = await playersRepo.findByUserId(auth.sub);
-      if (!callerPlayer || callerPlayer.playerId !== stable.leaderId) {
-        return badRequest('Only the stable leader or an admin can remove members');
+      const isLeader = callerPlayer?.playerId === stable.leaderId;
+      const isSelfRemoval = callerPlayer?.playerId === playerId;
+      if (!callerPlayer || (!isLeader && !isSelfRemoval)) {
+        return badRequest('Only the stable leader, an admin, or the member themselves can remove a member');
       }
     }
 
-    // Cannot remove the leader
+    // The leader cannot leave or be removed via this endpoint — they must disband
     if (playerId === stable.leaderId) {
-      return badRequest('Cannot remove the leader. Disband the stable instead.');
+      return badRequest('The leader cannot leave the stable. Disband it instead.');
     }
 
     // Verify player is a member

--- a/frontend/src/components/stables/MyStable.tsx
+++ b/frontend/src/components/stables/MyStable.tsx
@@ -26,6 +26,7 @@ export default function MyStable() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [disbanding, setDisbanding] = useState(false);
+  const [leaving, setLeaving] = useState(false);
 
   const loadData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -110,6 +111,30 @@ export default function MyStable() {
       setTimeout(() => setActionFeedback(null), 3000);
     }
   }, [stable, t]);
+
+  const handleLeave = useCallback(async () => {
+    if (!stable || !profile) return;
+    const confirmed = window.confirm(
+      t('stables.my.leaveConfirm', 'Are you sure you want to leave this stable?')
+    );
+    if (!confirmed) return;
+
+    setLeaving(true);
+    try {
+      await stablesApi.leave(stable.stableId, profile.playerId);
+      setActionFeedback(t('stables.my.left', 'You have left the stable.'));
+      setStable(null);
+      const updatedProfile = await profileApi.getMyProfile();
+      setProfile(updatedProfile);
+    } catch (err) {
+      setActionFeedback(
+        `Error: ${err instanceof Error ? err.message : t('common.error', 'Failed')}`
+      );
+    } finally {
+      setLeaving(false);
+      setTimeout(() => setActionFeedback(null), 3000);
+    }
+  }, [stable, profile, t]);
 
   const handleRespondToInvitation = useCallback(async (
     stableId: string,
@@ -332,6 +357,21 @@ export default function MyStable() {
                 {disbanding
                   ? t('common.processing', 'Processing...')
                   : t('stables.my.disband', 'Disband Stable')}
+              </button>
+            </div>
+          )}
+
+          {/* Member actions (non-leader) */}
+          {!isLeader && isApprovedOrActive && (
+            <div className="my-stable__member-actions">
+              <button
+                className="btn-danger"
+                onClick={handleLeave}
+                disabled={leaving}
+              >
+                {leaving
+                  ? t('common.processing', 'Processing...')
+                  : t('stables.my.leave', 'Leave Stable')}
               </button>
             </div>
           )}

--- a/frontend/src/services/api/stables.api.ts
+++ b/frontend/src/services/api/stables.api.ts
@@ -90,8 +90,16 @@ export const stablesApi = {
   },
 
   removeMember: async (stableId: string, playerId: string): Promise<Stable> => {
-    return fetchWithAuth(`${API_BASE_URL}/stables/${stableId}/members/${playerId}`, {
-      method: 'DELETE',
+    return fetchWithAuth(`${API_BASE_URL}/stables/${stableId}/remove-member`, {
+      method: 'POST',
+      body: JSON.stringify({ playerId }),
+    });
+  },
+
+  leave: async (stableId: string, playerId: string): Promise<Stable> => {
+    return fetchWithAuth(`${API_BASE_URL}/stables/${stableId}/remove-member`, {
+      method: 'POST',
+      body: JSON.stringify({ playerId }),
     });
   },
 

--- a/plan-rivalries.md
+++ b/plan-rivalries.md
@@ -1,0 +1,202 @@
+# Plan: Rivalries Feature
+
+## Context
+
+A new first-class feature: wrestlers can request a **Rivalry** with another wrestler — a long-form, ongoing storyline container that aggregates everything tied to that pairing in one place: storyline notes, GM-authored plans, completed match results, scheduled future matches, promos, and a private threaded conversation between the wrestler(s) and the GMs (admins/moderators).
+
+This is **distinct from Challenges**. Challenges are short-lived, one-off match requests with a 7-day expiry. Rivalries are persistent, multi-match story arcs that may produce many challenges, matches, and promos over weeks or months. A rivalry pairs two wrestlers, has a status (`pending` → `active` → `concluded` / `rejected`), and is moderated by a GM.
+
+The closest existing analog is **Challenges**, which we will model the lifecycle/admin-moderation pattern after. The closest existing UI analog for the messaging panel is the existing **Promos thread** view. There is **no existing thread/conversation primitive** in the codebase — the only inter-user surface today is one-way `Notifications` (system → user). The Messages portion of this feature introduces the first real two-way threaded messaging in the app, scoped to a single rivalry.
+
+A separate Google Stitch project (`projects/10219259134533090941` — "League SZN — Rivalries Feature") was created to host visual mockups for the four key screens (Hub, Detail, Messages, Request form). Mockup generation timed out during the planning session — re-run via the Stitch MCP later if needed.
+
+## Files to Modify
+
+### Backend
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `backend/serverless.yml` | Modify | Add 3 new DynamoDB tables (Rivalries, RivalryMessages, RivalryNotes), 3 GSIs, 14 new HTTP events with auth + handler refs, env vars on all rivalry handlers |
+| `backend/functions/rivalries/handler.ts` | Create | Single Lambda dispatcher routing 7 rivalry handlers (mirror `challenges/handler.ts:1-52`) |
+| `backend/functions/rivalries/createRivalry.ts` | Create | Wrestler-initiated rivalry request; validates wrestler role, the pair doesn't already have an active rivalry, and second participant exists |
+| `backend/functions/rivalries/getRivalries.ts` | Create | List rivalries with filters (status, participantId, seasonId, page) for public board |
+| `backend/functions/rivalries/getRivalry.ts` | Create | Single rivalry hub — returns rivalry record + computed stats (head-to-head record, match counts) + pre-fetched related entities (recent promos, next match, latest GM-published notes) |
+| `backend/functions/rivalries/respondRivalry.ts` | Create | GM-only: approve/reject/conclude a pending or active rivalry; records reason in `gmResponse` |
+| `backend/functions/rivalries/updateRivalry.ts` | Create | GM-only: edit title, heat level, status (active → concluded), seasonId; wrestler-allowed for limited fields (e.g. cancel their own pending request) |
+| `backend/functions/rivalries/deleteRivalry.ts` | Create | GM-only: soft-delete (mirror challenges delete); cascades to RivalryMessages + RivalryNotes |
+| `backend/functions/rivalries/messages/postMessage.ts` | Create | Append a message to a rivalry's thread; participants are the two wrestlers + assigned GMs; creates a `Notification` for other participants |
+| `backend/functions/rivalries/messages/listMessages.ts` | Create | Paginated message history (newest-first by `createdAt`), gated on participant membership |
+| `backend/functions/rivalries/notes/upsertNote.ts` | Create | Create or update a storyline note (GM-only) or "plan" entry (GM-only). Wrestler-authored notes are allowed but flagged `authorRole: 'wrestler'` and visible to GMs only by default. |
+| `backend/functions/rivalries/notes/listNotes.ts` | Create | Returns notes filtered by `noteType` (`storyline` / `plan`) and visibility |
+| `backend/functions/rivalries/__tests__/*.test.ts` | Create | Vitest unit tests per handler. Mock `getRepositories()` per the new repository pattern in [CLAUDE.md](CLAUDE.md#repository-pattern-database-interface-layer) |
+| `backend/lib/repositories/rivalries.ts` | Create | New `RivalriesRepository` and `RivalryMessagesRepository` interfaces + DynamoDB implementations. Domain methods only — no PK/SK leakage. Methods: `findById`, `listByParticipant`, `listByStatus`, `create`, `update`, `delete`. Messages: `appendMessage`, `listByRivalry`, `markRead`. |
+| `backend/lib/repositories/index.ts` | Modify | Register the new repos in `getRepositories()` factory; export types |
+| `backend/lib/repositories/unitOfWork.ts` | Modify | Add `createRivalry`, `updateRivalry`, `appendRivalryMessage` methods to the `UnitOfWork` interface and its DynamoDB implementation. Used by `respondRivalry` (atomic status flip + notification + system message) |
+| `backend/lib/notifications.ts` | Modify | Add new notification types: `'rivalry_message'`, `'rivalry_request'`, `'rivalry_status_change'`. Export helper `createRivalryNotification(rivalryId, recipientUserId, type, message)` for handler reuse |
+| `backend/functions/matches/getMatches.ts` | Modify | Add an optional `rivalryId` filter param. When present, look up the rivalry's two participants and return matches whose `participants` array contains both. (Today this would be a client-side filter on `list()` — see file at lines 27-103 for the existing client-filter pattern.) |
+| `backend/functions/matches/createMatch.ts` | Modify | Accept optional `rivalryId` field; if present, validate that both `participants` are in the rivalry's pair. Persist on the Matches record so the rivalry hub can attribute matches authoritatively (cheaper than recomputing on every fetch). |
+| `backend/functions/promos/createPromo.ts` | Modify | Accept optional `rivalryId` field; if a `call-out` or `response` promo is tagged to a rivalry, persist it. Rivalry hub queries promos by `rivalryId` rather than recomputing from `playerId` + `targetPlayerId` overlap. |
+| `backend/scripts/seed-data.ts` | Modify | Seed 2-3 example rivalries with messages, notes, and tagged matches/promos for local dev |
+
+### Frontend
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/types/rivalry.ts` | Create | TS interfaces: `Rivalry`, `RivalryStatus`, `RivalryHeat`, `RivalryMessage`, `RivalryNote`, `RivalryNoteType`, `RivalryParticipantRole`, `CreateRivalryInput`, etc. |
+| `frontend/src/types/index.ts` | Modify | Re-export the new rivalry types alongside the existing barrel exports |
+| `frontend/src/services/api.ts` | Modify | Add `rivalriesApi` namespace with: `list`, `get`, `create`, `respond`, `update`, `delete`, `messages.list`, `messages.post`, `notes.list`, `notes.upsert` — mirroring existing namespaces like `challengesApi` and `promosApi` |
+| `frontend/src/components/rivalries/RivalryHub.tsx` | Create | Public board listing all rivalries, with tabs for "Active" vs "My Rivalries", filter chips by heat/status, grid of `RivalryCard`s, and a "Recent Activity" feed below the grid |
+| `frontend/src/components/rivalries/RivalryCard.tsx` | Create | Card primitive: two wrestler portraits face-off, title, heat meter, match count, status pill |
+| `frontend/src/components/rivalries/RivalryDetail.tsx` | Create | Hub page for a single rivalry. Hero header with both wrestlers and head-to-head record. Tab bar: Overview, Match History, Future Matches, Promos, Notes & Plans, Messages. Each tab loads its own data. |
+| `frontend/src/components/rivalries/tabs/OverviewTab.tsx` | Create | Storyline notes summary + GM plans timeline + next-match card + recent-promos preview |
+| `frontend/src/components/rivalries/tabs/MatchHistoryTab.tsx` | Create | List of completed matches between the pair (uses existing match list components if reusable, otherwise simpler list) |
+| `frontend/src/components/rivalries/tabs/FutureMatchesTab.tsx` | Create | Scheduled matches; admin-only "Schedule Match for this Rivalry" CTA links to `ScheduleMatch.tsx` pre-filled with the pair + `rivalryId` (analog of the challenge→schedule flow described in [TO-DOS.md](TO-DOS.md) line 17) |
+| `frontend/src/components/rivalries/tabs/PromosTab.tsx` | Create | List of promos tagged to this rivalry; CTA to compose a new promo pre-filled with `rivalryId` and `targetPlayerId` |
+| `frontend/src/components/rivalries/tabs/NotesPlansTab.tsx` | Create | Two columns: storyline notes (GM-published, wrestler-readable) and plans timeline (GM-only). Inline edit affordance for GMs. |
+| `frontend/src/components/rivalries/tabs/MessagesTab.tsx` | Create | Two-way threaded chat; left rail with participants + settings, right pane with message bubbles. Composer with attach + emoji + send. Polls or refetches every 15s — no WebSockets (per [CLAUDE.md "Known Limitations" #7](CLAUDE.md#known-limitations--todo)) |
+| `frontend/src/components/rivalries/RequestRivalry.tsx` | Create | Two-step form: step 1 (opponent + heat + title + reason), step 2 (storyline pitch + GM tagging). Submits via `rivalriesApi.create`. |
+| `frontend/src/components/admin/AdminRivalries.tsx` | Create | GM moderation: list pending requests, approve/reject inline, set status, message wrestler. Mirror `AdminChallenges.tsx` row patterns. |
+| `frontend/src/App.tsx` | Modify | Register routes: `/rivalries`, `/rivalries/new`, `/rivalries/:rivalryId`, `/rivalries/:rivalryId/:tab`, `/admin/rivalries`. Wrap public routes in `<FeatureRoute feature="rivalries">` per existing pattern. |
+| `frontend/src/config/navConfig.ts` | Modify | Add `rivalries` entry to wrestler nav group (after `promos`); add `rivalries` entry to admin `/admin/content` nav group |
+| `frontend/src/components/Dashboard.tsx` | Modify | Add a "My Active Rivalries" card showing the logged-in wrestler's top 2-3 active rivalries with a deep-link to the hub |
+| `frontend/src/components/admin/AdminPanel.tsx` | Modify | Register the new `AdminRivalries` tab in the admin tab router |
+| `frontend/src/i18n/locales/en.json` | Modify | Add `rivalries.*` namespace: `hub.*` (title, tabs, filters), `card.*` (heatLevels, statusLabels), `detail.*` (tabs, headers, actions), `messages.*` (composer, hints), `notes.*` (storylineTitle, plansTitle, addNote), `request.*` (steps, fields, hints), `admin.*` (approve, reject, conclude), `status.*`, `heat.*` |
+| `frontend/src/i18n/locales/de.json` | Modify | German translations for every key above (mirror existing translation coverage in `challenges.*` and `promos.*` blocks) |
+| `frontend/public/wiki/index.json` | Modify | Append two entries: `{slug: "rivalries", titleKey: "wiki.articles.rivalries", file: "rivalries.md"}` and `{slug: "admin-rivalries", titleKey: "wiki.articles.adminRivalries", file: "admin-rivalries.md", adminOnly: true}` |
+| `frontend/public/wiki/rivalries.md` | Create | User-facing wiki article: how to request a rivalry, what info to include, how messaging works |
+| `frontend/public/wiki/admin-rivalries.md` | Create | GM-facing wiki article: how to triage requests, when to approve vs reject, how to conclude |
+| `frontend/public/wiki/de/rivalries.md` | Create | German translation |
+| `frontend/public/wiki/de/admin-rivalries.md` | Create | German translation |
+| `frontend/src/components/rivalries/__tests__/*.test.tsx` | Create | Vitest + React Testing Library tests for the major components (RequestRivalry submission, RivalryDetail tab routing, MessagesTab posting) |
+
+## Implementation Steps
+
+### Phase 1 — Data model & types (foundation; nothing else can land without this)
+
+1. **Define the TypeScript types in [frontend/src/types/rivalry.ts](frontend/src/types/rivalry.ts).** Include `Rivalry` (rivalryId, participantA, participantB, title, status, heatLevel, requestedBy, assignedGMs[], seasonId, **eventId?** (link to the Episode/PPV the rivalry culminates at — see Stitch hub mockup framing of rivalries inside "EPISODE 01: GENESIS"), **defaultMessageAudience: `'gm-only' | 'all-participants'`** (controls the "Loop in Opponent" toggle in the Messages screen — defaults to `'gm-only'`), gmResponse, createdAt, updatedAt), `RivalryStatus` = `'pending' | 'active' | 'concluded' | 'rejected' | 'cancelled'`, `RivalryHeat` = `'slow-burn' | 'brewing' | 'heated' | 'personal'`, `RivalryMessage` (messageId, rivalryId, authorUserId, authorRole, content, isSystem, **audience: `'gm-only' | 'all-participants'`** (per-message override of the rivalry default), createdAt), `RivalryNote` (noteId, rivalryId, noteType: `'storyline' | 'plan'`, content, authorUserId, authorRole, visibility: `'gm-only' | 'participants' | 'public'`, scheduledFor?, **linkedMatchId?**, **linkedEventId?** (the GM Plans timeline in the Detail mockup shows entries like "Royal Rumble Confrontation" and "Main Event: World Title Match" — plans need to deep-link to their target match or event), createdAt). Re-export from `frontend/src/types/index.ts`.
+
+2. **Add three DynamoDB tables to [backend/serverless.yml](backend/serverless.yml).** Mirror the existing ChallengesTable definition (~line 1705-1750 of serverless.yml) for table style and PAY_PER_REQUEST billing.
+   - `RivalriesTable` — PK `rivalryId`. GSIs: `ParticipantIndex` (`participantId`, `createdAt` — note: requires denormalizing both participants into a list-able shape; either two writes per rivalry or use a separate `RivalryParticipants` join table — go with two writes, simpler), `StatusIndex` (`status`, `createdAt`).
+   - `RivalryMessagesTable` — PK `rivalryId`, SK `createdAt`. Naturally orders messages chronologically per rivalry.
+   - `RivalryNotesTable` — PK `rivalryId`, SK `noteId`. GSI `NoteTypeIndex` (`rivalryId`, `noteType`) for filtering.
+   - Add `RIVALRIES_TABLE`, `RIVALRY_MESSAGES_TABLE`, `RIVALRY_NOTES_TABLE` env vars to all rivalry handler functions.
+   - Add IAM permissions on each new table to the rivalry handler statements.
+
+3. **Build the repository layer in [backend/lib/repositories/rivalries.ts](backend/lib/repositories/rivalries.ts).** Define `RivalriesRepository`, `RivalryMessagesRepository`, `RivalryNotesRepository` interfaces with **domain-named methods only** (no `pk`, `sk`, `gsi` in signatures — see CLAUDE.md "Repository Pattern" section). Implement DynamoDB-backed versions. Register in [backend/lib/repositories/index.ts](backend/lib/repositories/index.ts) under `getRepositories()`.
+
+4. **Extend [backend/lib/repositories/unitOfWork.ts](backend/lib/repositories/unitOfWork.ts).** Add `createRivalry`, `updateRivalry`, `appendRivalryMessage`, `createRivalryNote` to the `UnitOfWork` interface and its DynamoDB transaction-staging implementation. The `respondRivalry` handler will use these to atomically: flip status, append a system message ("GM approved this rivalry"), and create notifications.
+
+### Phase 2 — Backend handlers (pure CRUD first, then composite operations)
+
+5. **Build [backend/functions/rivalries/createRivalry.ts](backend/functions/rivalries/createRivalry.ts).** Validate wrestler role via `requireWrestler()` from `backend/lib/auth.ts`. Check that no `active` or `pending` rivalry exists between the same two participants (call `rivalries.listByParticipant(authorPlayerId)` and filter). Default status to `pending`. Use `getHandlerFactory`-style structure — but since this isn't pure CRUD, write it manually. Return 201 with the created rivalry.
+
+6. **Build the read handlers** — `getRivalries.ts`, `getRivalry.ts`, **`getRivalryActivity.ts`**. `getRivalry.ts` should hydrate the response with: rivalry record, head-to-head match record (call `matches.list({ rivalryId })` once `createMatch.ts` carries `rivalryId`), **next scheduled event** (the Detail mockup foregrounds a "NEXT SCHEDULED EVENT" card showing days-to-event countdown — query the existing Events table for the soonest event matching the rivalry's `eventId` or any event containing a match tagged with this `rivalryId`), most-recent 5 promos (call `promos.list({ rivalryId })`), most-recent 3 messages, and visible notes filtered by the caller's role. **`getRivalryActivity.ts`** powers the hub's "Recent Rivalry Activity" feed (Stitch hub mockup) — it merges the latest events from messages, promos, matches, and notes across the caller's visible rivalries into a single chronologically-sorted, paginated stream. Compute on-the-fly with a small in-handler cache; if it becomes a hot path, materialize a derived `RivalryActivity` table later.
+
+7. **Build [backend/functions/rivalries/respondRivalry.ts](backend/functions/rivalries/respondRivalry.ts) and [backend/functions/rivalries/updateRivalry.ts](backend/functions/rivalries/updateRivalry.ts).** These are GM-only (assert `requireAdminOrModerator()`). `respondRivalry` accepts `{ action: 'approve' | 'reject' | 'conclude', message?: string }` and uses `runInTransaction` from the UnitOfWork to atomically: update rivalry status, append a system message, create a notification for the requesting wrestler.
+
+8. **Build [backend/functions/rivalries/deleteRivalry.ts](backend/functions/rivalries/deleteRivalry.ts).** GM-only. Cascades by enumerating and deleting all messages + notes for the rivalry, then the rivalry itself. Single transaction or chunked transactions if >100 items (per UnitOfWork's 100-item flush).
+
+9. **Build the messaging handlers** — `messages/postMessage.ts` and `messages/listMessages.ts`. `postMessage` accepts an optional `audience` field (defaults to the rivalry's `defaultMessageAudience`). It validates that `req.user.userId` is in the rivalry's allowed participant set (the two wrestlers + assigned GMs). On success, creates a `'rivalry_message'` notification for every other participant **filtered by audience** (a `'gm-only'` message only notifies the GMs and the author, not the opposing wrestler — matches the "Type your message to the GMs..." composer hint in the Stitch Messages mockup). `listMessages` is paginated; gated on the same membership check **and on per-message audience** — a wrestler should not see `'gm-only'` messages authored by the opposing wrestler.
+
+10. **Build the notes handlers** — `notes/upsertNote.ts` and `notes/listNotes.ts`. `upsertNote` enforces: GMs can write any noteType and any visibility; wrestlers can only write `storyline` notes with visibility `'gm-only'` (suggestions to the GM). `listNotes` filters by caller role — wrestlers never see `gm-only` notes authored by other wrestlers, and never see `'plan'` notes unless explicitly published `'participants'`.
+
+11. **Build [backend/functions/rivalries/handler.ts](backend/functions/rivalries/handler.ts).** Single-Lambda dispatcher mirroring [backend/functions/challenges/handler.ts:1-52](backend/functions/challenges/handler.ts). Maps each `event.routeKey` to its handler.
+
+12. **Wire HTTP events in [backend/serverless.yml](backend/serverless.yml).** Mirror the challenges block. Public routes: `GET /rivalries`, `GET /rivalries/{id}` (read auth optional — guests can browse, but `messages` & `gm-only` notes are filtered server-side by absence of identity). Authenticated routes: `POST /rivalries`, `POST /rivalries/{id}/respond` (admin authorizer), `PUT /rivalries/{id}`, `DELETE /rivalries/{id}` (admin authorizer), `GET /rivalries/{id}/messages`, `POST /rivalries/{id}/messages`, `GET /rivalries/{id}/notes`, `POST /rivalries/{id}/notes`. Use the existing custom JWT authorizer for protected routes.
+
+13. **Modify [backend/functions/matches/createMatch.ts](backend/functions/matches/createMatch.ts) and [backend/functions/matches/getMatches.ts](backend/functions/matches/getMatches.ts).** Persist optional `rivalryId` on the match record. Add `rivalryId` filter to `getMatches`. The match-by-participants client-filter pattern at [backend/functions/matches/getMatches.ts:59-63](backend/functions/matches/getMatches.ts#L59-L63) is the existing precedent — `rivalryId` should be a more efficient direct field comparison.
+
+14. **Modify [backend/functions/promos/createPromo.ts](backend/functions/promos/createPromo.ts).** Persist optional `rivalryId` on the promo record so the rivalry hub can query promos by `rivalryId` directly (cheaper than reconstructing the set from `playerId` + `targetPlayerId` overlap with the rivalry pair).
+
+15. **Add notification types in [backend/lib/notifications.ts](backend/lib/notifications.ts).** New types: `'rivalry_message'`, `'rivalry_request'`, `'rivalry_status_change'`. The existing `createNotification` helper is fine — just call it with these new types from the handlers.
+
+16. **Write Vitest unit tests for every backend handler.** Mock `getRepositories` per the CLAUDE.md pattern. Cover: success cases, role rejections, validation failures (e.g. duplicate active rivalry), cascade-delete, transactional respond.
+
+### Phase 3 — Frontend service layer & types
+
+17. **Add `rivalriesApi` namespace to [frontend/src/services/api.ts](frontend/src/services/api.ts).** Mirror the structure of existing `challengesApi` and `promosApi` namespaces. Methods: `list({ status?, participantId?, seasonId?, page? })`, `get(rivalryId)`, `create(input)`, `respond(rivalryId, action, message?)`, `update(rivalryId, patch)`, `delete(rivalryId)`, `messages.list(rivalryId, { cursor? })`, `messages.post(rivalryId, content)`, `notes.list(rivalryId, { noteType? })`, `notes.upsert(rivalryId, note)`.
+
+### Phase 4 — Frontend components (build inside-out: card → hub; tabs → detail)
+
+18. **Build [frontend/src/components/rivalries/RivalryCard.tsx](frontend/src/components/rivalries/RivalryCard.tsx).** Pure presentational card; props are a `Rivalry` plus participant-resolved player avatars. Handle the heat meter (1-5 gold flames mapped from `'slow-burn' | 'brewing' | 'heated' | 'personal'`). Reuse the existing player avatar component from the challenges feature.
+
+19. **Build [frontend/src/components/rivalries/RivalryHub.tsx](frontend/src/components/rivalries/RivalryHub.tsx).** **Three tabs** (Active / My Rivalries / **Legacy Archive** — the third tab surfaces `concluded` rivalries; pure UI filter, no schema impact). The hub is **scoped to the active Episode/Event** by default (matches the "EPISODE 01: GENESIS" framing in the Stitch hub mockup) — show an Event selector in the page header so users can switch episodes. Filter chip row (All / Heated / Brewing / Concluded / Personal), grid of cards, "Recent Activity" feed below. Use `rivalriesApi.list` with the appropriate filters.
+
+20. **Build the six tab components in [frontend/src/components/rivalries/tabs/](frontend/src/components/rivalries/tabs/).** Each tab is independent and lazily fetches its own data when opened. Read tab from URL (`/rivalries/:rivalryId/:tab`) so deep-links work. Default tab is `overview`.
+
+21. **Build [frontend/src/components/rivalries/RivalryDetail.tsx](frontend/src/components/rivalries/RivalryDetail.tsx).** Hero header (both wrestlers, vs divider, head-to-head record, status pill). Tab bar above the tab content area. Bottom-right floating "Message GM" button shortcuts to the Messages tab.
+
+22. **Build [frontend/src/components/rivalries/RequestRivalry.tsx](frontend/src/components/rivalries/RequestRivalry.tsx).** Two-step form. Opponent picker should hit the existing players API for autocomplete. Submit calls `rivalriesApi.create` → on success navigates to the new rivalry's detail page.
+
+23. **Build [frontend/src/components/admin/AdminRivalries.tsx](frontend/src/components/admin/AdminRivalries.tsx).** Mirror the table layout of [frontend/src/components/admin/AdminChallenges.tsx](frontend/src/components/admin/AdminChallenges.tsx). Approve / Reject / Conclude row actions; status filter chips; bulk-clear button (mirrors the [TO-DOS.md](TO-DOS.md) bulk-delete pattern at line 25).
+
+24. **Wire routes in [frontend/src/App.tsx](frontend/src/App.tsx).** Register the new public + admin routes. Wrap public ones in `<FeatureRoute feature="rivalries">` so the feature can be flagged off if needed (existing pattern).
+
+25. **Add nav entries in [frontend/src/config/navConfig.ts](frontend/src/config/navConfig.ts).** Add `rivalries` to the wrestler group (after `promos`, around line 70) and to the admin content group (around line 142).
+
+26. **Add Dashboard surface in [frontend/src/components/Dashboard.tsx](frontend/src/components/Dashboard.tsx).** "My Active Rivalries" card for logged-in wrestlers — top 2-3 with deep-links.
+
+### Phase 5 — Localization, docs, seed data
+
+27. **Add the `rivalries.*` block to [frontend/src/i18n/locales/en.json](frontend/src/i18n/locales/en.json) and [frontend/src/i18n/locales/de.json](frontend/src/i18n/locales/de.json).** Mirror the depth/structure of the existing `challenges.*` block.
+
+28. **Add the two wiki articles** under [frontend/public/wiki/](frontend/public/wiki/) — English + German — and append the entries to [frontend/public/wiki/index.json](frontend/public/wiki/index.json). Add corresponding `wiki.articles.rivalries` and `wiki.articles.adminRivalries` keys to both locale files.
+
+29. **Update [backend/scripts/seed-data.ts](backend/scripts/seed-data.ts).** Seed 2-3 rivalries between existing seeded players, each with: 5-10 messages, 2-3 storyline notes, 1-2 GM plans, 2-3 tagged matches, 2-3 tagged promos. Use a mix of statuses (`active`, `concluded`, `pending`) for visual coverage.
+
+### Phase 6 — Tests & verification
+
+30. **Add component tests under [frontend/src/components/rivalries/__tests__/](frontend/src/components/rivalries/__tests__/).** Cover: RequestRivalry submission and validation, RivalryDetail tab routing, MessagesTab post + display, AdminRivalries approve/reject row actions.
+
+31. **Run frontend + backend lint, typecheck, and test suites.** Resolve all errors before raising the PR.
+
+## Dependencies & Order
+
+Phase 1 must finish before Phase 2 (handlers depend on repositories + types). Phase 2 must finish before Phase 3 (frontend service layer talks to the deployed API shape). Phase 4 depends on Phase 3. Phases 5 and 6 can run in parallel with the tail of Phase 4.
+
+**Critical hot path:** Step 2 (DynamoDB tables) → Step 3 (repositories) → Step 5 (createRivalry) → Step 11/12 (dispatcher + serverless events) → Step 17 (frontend api client) → Step 21 (RivalryDetail.tsx). Everything else is leaves off this trunk.
+
+**Steps 13-15** (matches/promos/notifications additions) are non-blocking for the rivalry hub itself — the hub will just render empty match/promo lists until those are wired. Land them early in Phase 2 anyway so the hub demo is meaningful.
+
+## Testing & Verification
+
+**Manual (local with seed data + DynamoDB Local):**
+- Wrestler A logs in → Dashboard shows "My Active Rivalries" card → click through to a seeded rivalry's detail → Overview tab populated, Match History shows seeded matches.
+- Wrestler A clicks "Request a Rivalry" → completes both steps → submits → lands on new rivalry detail with status "pending".
+- Admin logs in → `/admin/rivalries` shows the pending request → approves → wrestler A receives a notification → status flips to active → system message appears in Messages tab.
+- Wrestler A posts a message in Messages tab → admin sees it on refresh → admin replies → wrestler A sees it on refresh.
+- Admin schedules a match from the Future Matches tab → match is created with `rivalryId` → appears in both Future Matches tab and Match History after recording.
+- Admin tags a promo with `rivalryId` from the promo composer → appears in the Promos tab.
+- Switch language to German → all rivalry strings render translated.
+
+**Automated:** `cd backend && npx vitest run` and `cd frontend && npx vitest run` must pass. TS strict checks on both halves must pass.
+
+**Existing tests at risk:**
+- `getMatches` tests — adding the `rivalryId` filter param needs new test cases and should not regress existing filter tests.
+- `createMatch` tests — verify optional `rivalryId` accepts undefined and validates participant pairing.
+- `createPromo` tests — verify optional `rivalryId` accepts undefined.
+- Admin nav config tests (if any) — adding nav entries may shift index-based assertions.
+
+**New tests to write:** Per Phase 6 — backend handler tests for every rivalry handler, component tests for the major frontend components.
+
+## Risks & Edge Cases
+
+- **First two-way messaging primitive.** The codebase has no precedent for a thread/conversation entity. The DynamoDB table shape (PK `rivalryId`, SK `createdAt`) is intentionally minimal. If we later need cross-rivalry inboxes ("show me all my unread messages across all rivalries"), we'll need a per-user GSI. Document this as deferred.
+
+- **Notification volume.** Every rivalry message creates a notification per recipient. A chatty rivalry with 4 participants (2 wrestlers + 2 GMs) produces 3 notifications per message. Consider client-side debouncing on the recipient side, or batching multiple messages into a single "X new messages in Rivalry Y" notification on the server. Defer batching unless the firehose becomes a problem.
+
+- **No real-time updates.** Per [CLAUDE.md "Known Limitations" #7](CLAUDE.md#known-limitations--todo) there's no WebSocket support — Messages tab will need a polling refresh (every 15-30s) or a manual "Refresh" button. Optimistic UI updates on send will mask the latency for the sender.
+
+- **Cascade delete cost.** A long-running rivalry could accumulate hundreds of messages and dozens of notes. The cascade-delete in `deleteRivalry.ts` must chunk into 100-item transaction batches (the UnitOfWork's hard cap). Soft-delete (a `deletedAt` flag) is a safer alternative — choose this if the implementer is uncertain.
+
+- **Rivalry uniqueness.** Two wrestlers can have at most one `active` or `pending` rivalry between them at a time. Enforce via a check in `createRivalry.ts` — the alternative is a DynamoDB conditional write with a synthesized unique key (`min(idA, idB)#max(idA, idB)#status`), which is more robust but more code. Start with the read-then-write check; tighten to conditional write later if concurrent creates become a real issue.
+
+- **Notes visibility.** GM "plans" notes can spoil future storyline beats. Default visibility for `'plan'` notes must be `'gm-only'`. The notes list handler must enforce this server-side — never trust the client to filter.
+
+- **Backwards compatibility for matches/promos.** Adding `rivalryId` as optional does not break existing data. Existing matches and promos with `rivalryId === undefined` must still render in their normal listings. No migration needed.
+
+- **Auth on read.** The hub and detail are publicly browsable, but messages and `gm-only` notes are NOT. The handlers must filter by caller identity (or absence of identity) — do not rely on the frontend hiding these. Add explicit handler tests for the unauthenticated path.
+
+- **GM assignment.** `assignedGMs` defaults to all admins/moderators. Allowing the requesting wrestler to "tag" a specific GM in the request form is a UX nicety — implement as a hint, not as exclusive routing. Any GM should still be able to act on any rivalry.
+
+- **Stitch mockups.** All four screens rendered in Stitch project `projects/10219259134533090941`: Rivalries Hub (`screens/23c257203a23450c855d1b0348adba65`), Rivalry Detail (`screens/3e9ac9e3e3084994a0d597fe237f582a`), GM Messages (`screens/617995aa3b1b47b99127ce0262e4d0d7`), Request a Rivalry (`screens/f98b693dbcfc4d0e9689c2d9d1bcb9e0`). The visual design surfaced four schema/UX details that were folded back into this plan: (1) hub framed inside an Episode/Event scope, (2) third "Legacy Archive" tab on the hub, (3) "Loop in Opponent" toggle / per-message `audience` field with GM-only as the default, (4) GM Plans timeline entries deep-linking to specific Matches and Events, (5) "Recent Rivalry Activity" cross-source feed requiring a dedicated activity handler.

--- a/tickets-rivalries/01-data-model-foundation.md
+++ b/tickets-rivalries/01-data-model-foundation.md
@@ -1,0 +1,44 @@
+# [RIV-01] Data model foundation
+
+**Phase:** 1 — Foundation
+**Estimate:** M
+**Blocked by:** none
+**Blocks:** RIV-02, RIV-03, RIV-04, RIV-05, RIV-06, RIV-07
+**Reference:** [plan-rivalries.md § Phase 1, steps 1-4](../plan-rivalries.md)
+
+## Goal
+Stand up the schema, types, and repository layer the rest of the feature builds on. No HTTP routes, no UI — just the foundation pieces every other ticket depends on.
+
+## Scope
+**In:** TS types, 3 DynamoDB tables + GSIs + IAM, repository interfaces + DynamoDB implementations, UnitOfWork extensions.
+**Out:** Any handler logic, any UI, the activity-feed handler (RIV-03).
+
+## Subtasks
+- [ ] Define `Rivalry`, `RivalryStatus`, `RivalryHeat`, `RivalryMessage`, `RivalryNote`, `RivalryNoteType`, `RivalryParticipantRole`, `CreateRivalryInput` in `frontend/src/types/rivalry.ts`. Include `eventId?`, `defaultMessageAudience: 'gm-only' | 'all-participants'` on `Rivalry`; `audience` on `RivalryMessage`; `linkedMatchId?`, `linkedEventId?`, `scheduledFor?` on `RivalryNote`.
+- [ ] Re-export the new types from `frontend/src/types/index.ts`.
+- [ ] Add `RivalriesTable` to `backend/serverless.yml` — PK `rivalryId`, GSIs `ParticipantIndex` (participantId, createdAt) and `StatusIndex` (status, createdAt). PAY_PER_REQUEST. Mirror ChallengesTable style at line ~1705.
+- [ ] Add `RivalryMessagesTable` — PK `rivalryId`, SK `createdAt`.
+- [ ] Add `RivalryNotesTable` — PK `rivalryId`, SK `noteId`. GSI `NoteTypeIndex` (rivalryId, noteType).
+- [ ] Add `RIVALRIES_TABLE`, `RIVALRY_MESSAGES_TABLE`, `RIVALRY_NOTES_TABLE` env vars and IAM grants on every rivalry handler function (handlers themselves land in RIV-02; pre-stub the function definitions or wait — see Notes).
+- [ ] Create `backend/lib/repositories/rivalries.ts` with `RivalriesRepository`, `RivalryMessagesRepository`, `RivalryNotesRepository` interfaces. Domain methods only (no `pk`/`sk`/`gsi` in signatures). Implement DynamoDB-backed versions.
+- [ ] Register new repos in `backend/lib/repositories/index.ts` under `getRepositories()`. Export new types.
+- [ ] Extend `backend/lib/repositories/unitOfWork.ts`: add `createRivalry`, `updateRivalry`, `appendRivalryMessage`, `createRivalryNote` to the interface and the DynamoDB transaction-staging implementation.
+
+## Files Touched
+- `frontend/src/types/rivalry.ts` (create)
+- `frontend/src/types/index.ts` (modify — re-export)
+- `backend/serverless.yml` (modify — 3 tables, env vars, IAM)
+- `backend/lib/repositories/rivalries.ts` (create)
+- `backend/lib/repositories/index.ts` (modify — register)
+- `backend/lib/repositories/unitOfWork.ts` (modify — add methods)
+
+## Acceptance Criteria
+- `cd backend && npx tsc --project tsconfig.json --noEmit` passes.
+- `cd frontend && npx tsc --project tsconfig.app.json --noEmit` passes.
+- `npx serverless package --aws-profile league-szn` succeeds against the new tables (validates the YAML).
+- `getRepositories()` returns instances of all three new repos and the existing ones still work.
+- Existing test suite still green: `cd backend && npx vitest run` and `cd frontend && npx vitest run`.
+
+## Notes / Risks
+- The function definitions in serverless.yml that reference handlers from RIV-02 won't deploy until those handler files exist. Either land RIV-01 + RIV-02 together as one PR, or merge RIV-01 with the handler functions stubbed (returning 501) and let RIV-02 fill them in.
+- Two-write strategy for the `ParticipantIndex` GSI (one row per participant) is acceptable and cheaper than a join table — keep the duplication encapsulated inside the repository so handlers never see it.

--- a/tickets-rivalries/02-core-crud-handlers.md
+++ b/tickets-rivalries/02-core-crud-handlers.md
@@ -1,0 +1,48 @@
+# [RIV-02] Core CRUD handlers + dispatcher + serverless events
+
+**Phase:** 2 — Backend handlers
+**Estimate:** L
+**Blocked by:** RIV-01
+**Blocks:** RIV-07 (frontend API client), RIV-15 (admin panel)
+**Reference:** [plan-rivalries.md § Phase 2, steps 5-8, 11-12](../plan-rivalries.md)
+
+## Goal
+Implement create / read / respond / update / delete for the Rivalry aggregate, wire them through a single Lambda dispatcher, and expose the HTTP routes via API Gateway.
+
+## Scope
+**In:** Handlers for `createRivalry`, `getRivalries`, `getRivalry`, `respondRivalry`, `updateRivalry`, `deleteRivalry`. Dispatcher. Serverless HTTP events with auth. Vitest unit tests.
+**Out:** Activity-feed handler (RIV-03), messaging handlers (RIV-04), notes handlers (RIV-05).
+
+## Subtasks
+- [ ] `backend/functions/rivalries/createRivalry.ts` — wrestler-only via `requireWrestler()`. Validate no existing `pending` or `active` rivalry between the same two participants. Default status `pending`. Return 201.
+- [ ] `backend/functions/rivalries/getRivalries.ts` — list with filters: `status`, `participantId`, `seasonId`, `eventId`, `page`. Public read.
+- [ ] `backend/functions/rivalries/getRivalry.ts` — hydrate response with rivalry record + head-to-head match record + next scheduled event (query Events table for soonest event matching `eventId` or any event containing a match tagged with this `rivalryId`) + most-recent 5 promos + most-recent 3 messages + visible notes filtered by caller role.
+- [ ] `backend/functions/rivalries/respondRivalry.ts` — GM-only via `requireAdminOrModerator()`. Accepts `{ action: 'approve' | 'reject' | 'conclude', message? }`. Use `runInTransaction` to atomically: update status, append a system message, create notification for requesting wrestler.
+- [ ] `backend/functions/rivalries/updateRivalry.ts` — GM-only for most fields; allow requesting wrestler to cancel their own `pending` request.
+- [ ] `backend/functions/rivalries/deleteRivalry.ts` — GM-only. Cascade delete RivalryMessages + RivalryNotes in chunked transactions (≤100 items per batch per UnitOfWork hard cap).
+- [ ] `backend/functions/rivalries/handler.ts` — single dispatcher routing on `event.routeKey`. Mirror `backend/functions/challenges/handler.ts:1-52`.
+- [ ] Wire HTTP events in `backend/serverless.yml`: `GET /rivalries`, `GET /rivalries/{id}` (public), `POST /rivalries`, `PUT /rivalries/{id}`, `POST /rivalries/{id}/respond` (admin), `DELETE /rivalries/{id}` (admin). Use existing JWT custom authorizer for protected routes.
+- [ ] Vitest tests under `backend/functions/rivalries/__tests__/`. Mock `getRepositories` per CLAUDE.md "Repository Pattern" section. Cover: success, role rejection, duplicate-active rivalry, transactional respond, cascade delete with >100 items.
+
+## Files Touched
+- `backend/functions/rivalries/createRivalry.ts` (create)
+- `backend/functions/rivalries/getRivalries.ts` (create)
+- `backend/functions/rivalries/getRivalry.ts` (create)
+- `backend/functions/rivalries/respondRivalry.ts` (create)
+- `backend/functions/rivalries/updateRivalry.ts` (create)
+- `backend/functions/rivalries/deleteRivalry.ts` (create)
+- `backend/functions/rivalries/handler.ts` (create)
+- `backend/functions/rivalries/__tests__/*.test.ts` (create — one per handler)
+- `backend/serverless.yml` (modify — HTTP events block)
+
+## Acceptance Criteria
+- All handler tests pass: `cd backend && npx vitest run functions/rivalries`.
+- `npx serverless deploy --stage devtest --aws-profile league-szn` succeeds.
+- Manual smoke (against devtest): create → respond (approve) → list → get returns hydrated payload with computed head-to-head record.
+- Duplicate-active check: creating a second rivalry between the same pair while one is `active` returns 409.
+- Cascade delete with seeded fixture of 250 messages succeeds without DynamoDB transaction-cap errors.
+
+## Notes / Risks
+- Rivalry uniqueness — start with read-then-write check inside `createRivalry`. Defer the synthesized-key conditional-write to a follow-up if real concurrent creates surface.
+- Soft-delete (`deletedAt` flag) is the safer alternative to hard cascade delete. If the implementer is uncertain, choose soft-delete and revisit.
+- Public `GET` endpoints must filter sensitive fields server-side (no `gm-only` notes, no messages) — do not rely on the frontend.

--- a/tickets-rivalries/03-activity-feed-handler.md
+++ b/tickets-rivalries/03-activity-feed-handler.md
@@ -1,0 +1,41 @@
+# [RIV-03] Rivalry activity feed handler
+
+**Phase:** 2 — Backend handlers
+**Estimate:** M
+**Blocked by:** RIV-01, RIV-02 (needs the Rivalry repos and the matches/promos integrations from RIV-06 — see Notes)
+**Blocks:** RIV-08 (Hub uses this feed)
+**Reference:** [plan-rivalries.md § Phase 2, step 6 (`getRivalryActivity.ts`)](../plan-rivalries.md)
+
+## Goal
+Power the "Recent Rivalry Activity" feed shown on the Hub: a single chronologically-sorted, paginated stream that merges messages, promos, matches, and notes across the caller's visible rivalries.
+
+## Scope
+**In:** One read-only handler that does the cross-source merge. HTTP route. Tests.
+**Out:** Materializing a `RivalryActivity` derived table — defer until / unless this becomes a hot path. Frontend consumption (RIV-08).
+
+## Subtasks
+- [ ] `backend/functions/rivalries/getRivalryActivity.ts` — accept query params: `participantId?` (defaults to caller), `eventId?`, `limit` (default 25), `cursor?`.
+- [ ] Resolve the set of visible rivalries (filtered by participant + event + caller's role for visibility).
+- [ ] Fan out to messages / promos / matches / notes repos in parallel; cap each per-source pull at `limit * 2` to bound work.
+- [ ] Merge into a single `RivalryActivityItem[]` typed union with discriminator `kind: 'message' | 'promo' | 'match' | 'note'` and a normalized `occurredAt` field.
+- [ ] Sort descending by `occurredAt`, slice to `limit`, return with a `nextCursor` (encoded `occurredAt` of the tail item).
+- [ ] Filter out activity items the caller can't see (e.g., `gm-only` messages from the other wrestler).
+- [ ] Add an in-handler memoization step keyed on `(participantId, eventId, cursor)` with a 30-second TTL — cheap protection against rapid hub re-renders.
+- [ ] Wire `GET /rivalries/activity` in `backend/serverless.yml` (public read; auth optional — caller identity is derived from the JWT if present).
+- [ ] Vitest tests: empty case, mixed-source merge ordering, audience filtering (`gm-only` message hidden from opposing wrestler), pagination cursor round-trip.
+
+## Files Touched
+- `backend/functions/rivalries/getRivalryActivity.ts` (create)
+- `backend/functions/rivalries/__tests__/getRivalryActivity.test.ts` (create)
+- `backend/serverless.yml` (modify — one HTTP event)
+- `frontend/src/types/rivalry.ts` (modify — add `RivalryActivityItem` discriminated union)
+
+## Acceptance Criteria
+- Handler returns a stable order regardless of which source (messages vs matches vs promos) currently has the latest item.
+- Audience filter test passes: a `gm-only` message authored by Wrestler B does NOT appear in the activity feed when Wrestler A is the caller.
+- Cursor pagination: fetching page 2 with the returned `nextCursor` returns the next slice with no overlap and no gap.
+- Cold-start handler latency < 800ms with 5 visible rivalries each having 50 items per source (sanity check, not a hard SLA).
+
+## Notes / Risks
+- This ticket can technically land before RIV-06 if the matches/promos integrations aren't wired yet — the activity feed will just show messages and notes only until `rivalryId` is persisted on matches/promos. List both as upstream so reviewers know.
+- If the on-the-fly merge proves too slow at real data volumes, file a follow-up ticket for the materialized `RivalryActivity` derived table. Don't over-engineer here.

--- a/tickets-rivalries/04-messaging-backend.md
+++ b/tickets-rivalries/04-messaging-backend.md
@@ -1,0 +1,39 @@
+# [RIV-04] Rivalry messaging backend (post + list with audience filtering)
+
+**Phase:** 2 — Backend handlers
+**Estimate:** M
+**Blocked by:** RIV-01, RIV-06 (notification types)
+**Blocks:** RIV-12 (Messages tab)
+**Reference:** [plan-rivalries.md § Phase 2, step 9](../plan-rivalries.md)
+
+## Goal
+The first two-way thread primitive in the codebase, scoped to a single rivalry, with per-message audience control (`gm-only` vs `all-participants`).
+
+## Scope
+**In:** post + list message handlers, audience filtering on both write and read paths, notification dispatch, tests.
+**Out:** Frontend chat UI (RIV-12), polling/WebSocket transport, attachments.
+
+## Subtasks
+- [ ] `backend/functions/rivalries/messages/postMessage.ts` — body: `{ content, audience? }`. If `audience` omitted, default to the rivalry's `defaultMessageAudience`. Validate `req.user.userId` is in the rivalry's allowed participant set (the two wrestlers + assigned GMs). Reject otherwise (403).
+- [ ] On successful post, create `'rivalry_message'` notifications for every other participant **filtered by audience** — a `'gm-only'` message only notifies GMs (and the author themselves for sent-confirmation if the existing notification convention requires it), never the opposing wrestler.
+- [ ] `backend/functions/rivalries/messages/listMessages.ts` — paginated by `createdAt` descending. Gated on participant membership AND on per-message audience: a wrestler must not see `'gm-only'` messages authored by the opposing wrestler. GMs see everything.
+- [ ] Wire HTTP events: `GET /rivalries/{id}/messages`, `POST /rivalries/{id}/messages`. Both authenticated.
+- [ ] Vitest tests: post by participant (success), post by non-participant (403), `gm-only` message visibility (opposing wrestler can't see it, GMs can, author can), notification fan-out matches audience, pagination cursor round-trip.
+
+## Files Touched
+- `backend/functions/rivalries/messages/postMessage.ts` (create)
+- `backend/functions/rivalries/messages/listMessages.ts` (create)
+- `backend/functions/rivalries/messages/__tests__/*.test.ts` (create)
+- `backend/serverless.yml` (modify — 2 HTTP events)
+
+## Acceptance Criteria
+- Audience filter tests pass on both post (notification fan-out) and list (visibility).
+- A `gm-only` message authored by Wrestler A is visible to A and to all assigned GMs, invisible to Wrestler B.
+- An `all-participants` message is visible to both wrestlers and all GMs.
+- A non-participant calling either endpoint gets 403, not 404 (don't leak rivalry existence).
+- System messages (e.g., from `respondRivalry` in RIV-02) appear in the list with `isSystem: true` and `audience: 'all-participants'`.
+
+## Notes / Risks
+- Notification volume — a 4-participant rivalry produces 3 notifications per message. Per-recipient debouncing or server-side batching is a deferred follow-up.
+- No real-time transport — the frontend will poll. That's a frontend concern (RIV-12), but the list endpoint should be cheap enough that 15-30s polling is fine.
+- The `audience` field is also written by `respondRivalry`'s system message in RIV-02. Confirm both sides agree on the enum values before merging.

--- a/tickets-rivalries/05-notes-backend.md
+++ b/tickets-rivalries/05-notes-backend.md
@@ -1,0 +1,43 @@
+# [RIV-05] Rivalry notes backend (storyline + plans, role-based visibility)
+
+**Phase:** 2 — Backend handlers
+**Estimate:** S
+**Blocked by:** RIV-01
+**Blocks:** RIV-11 (Notes & Plans tab)
+**Reference:** [plan-rivalries.md § Phase 2, step 10](../plan-rivalries.md)
+
+## Goal
+Persist storyline notes and GM "plans" for a rivalry, with strict role-based visibility so GM plans never leak to wrestlers unless explicitly published.
+
+## Scope
+**In:** upsert + list note handlers with strict role/visibility enforcement, tests.
+**Out:** Frontend notes UI (RIV-11).
+
+## Subtasks
+- [ ] `backend/functions/rivalries/notes/upsertNote.ts` — body: `{ noteId?, noteType: 'storyline' | 'plan', content, visibility?, scheduledFor?, linkedMatchId?, linkedEventId? }`. If `noteId` provided, update; otherwise create. Enforce:
+  - GMs can write any `noteType` and any `visibility`.
+  - Wrestlers can only write `'storyline'` notes with visibility forced to `'gm-only'` (suggestions to the GM).
+  - Wrestler attempts to write `'plan'` notes → 403.
+- [ ] `backend/functions/rivalries/notes/listNotes.ts` — query params: `noteType?`. Filter by caller role:
+  - Wrestlers never see `'gm-only'` notes authored by other wrestlers or by GMs.
+  - Wrestlers never see `'plan'` notes unless visibility is `'participants'` or `'public'`.
+  - GMs see everything.
+- [ ] Validate `linkedMatchId` and `linkedEventId` exist (if provided) — light existence check, not full referential cascade.
+- [ ] Wire HTTP events: `GET /rivalries/{id}/notes`, `POST /rivalries/{id}/notes`. Both authenticated.
+- [ ] Vitest tests: GM creates plan with `linkedMatchId` (success), wrestler attempts plan (403), wrestler creates storyline as `'gm-only'` (success), wrestler list filters out other wrestler's `'gm-only'` notes, GM list returns everything.
+
+## Files Touched
+- `backend/functions/rivalries/notes/upsertNote.ts` (create)
+- `backend/functions/rivalries/notes/listNotes.ts` (create)
+- `backend/functions/rivalries/notes/__tests__/*.test.ts` (create)
+- `backend/serverless.yml` (modify — 2 HTTP events)
+
+## Acceptance Criteria
+- Default visibility for `'plan'` notes is `'gm-only'` — explicit in the handler, not relying on caller convention.
+- Wrestler-authored `'storyline'` notes always force visibility to `'gm-only'` regardless of what was passed.
+- List endpoint never returns notes the caller shouldn't see, even if the frontend requests them — server-side enforcement, not client-side filtering.
+- Tests cover both write-side rejection and read-side filtering for every role × visibility × noteType combination.
+
+## Notes / Risks
+- Plans can spoil future storyline beats. The default visibility for `'plan'` MUST be `'gm-only'` and MUST be enforced server-side. This is the highest leak risk in the feature.
+- `linkedMatchId`/`linkedEventId` are advisory pointers — if the linked match is later deleted, leave the note's reference stale rather than cascading. The Notes & Plans tab UI should handle the missing-link case gracefully (RIV-11).

--- a/tickets-rivalries/06-cross-feature-integration.md
+++ b/tickets-rivalries/06-cross-feature-integration.md
@@ -1,0 +1,42 @@
+# [RIV-06] Cross-feature integration (matches, promos, notifications)
+
+**Phase:** 2 — Backend handlers
+**Estimate:** S
+**Blocked by:** RIV-01
+**Blocks:** RIV-03 (activity feed reads matches/promos by `rivalryId`), RIV-04 (notifications)
+**Reference:** [plan-rivalries.md § Phase 2, steps 13-15](../plan-rivalries.md)
+
+## Goal
+Tag matches and promos with an optional `rivalryId` so the rivalry hub can authoritatively aggregate them. Add the new notification types the rivalry handlers will emit.
+
+## Scope
+**In:** `rivalryId` field on matches + promos (write + filter on read), new notification type enum values, tests.
+**Out:** Anything that requires the rivalry to exist as a foreign key (intentional — keep loosely coupled).
+
+## Subtasks
+- [ ] `backend/functions/matches/createMatch.ts` — accept optional `rivalryId`. If present, validate that both `participants` are in the rivalry's pair (look up rivalry via repo). Persist the field. (Existing test file: add a case for rivalryId-tagged match creation.)
+- [ ] `backend/functions/matches/getMatches.ts` — add `rivalryId` filter param. Direct field comparison is more efficient than the existing client-side participants array filter at lines 59-63 — use it as the precedent for the pattern.
+- [ ] `backend/functions/promos/createPromo.ts` — accept optional `rivalryId`. Persist on the promo record. No participant validation needed — promos can reference a rivalry the author is or isn't in.
+- [ ] `backend/lib/notifications.ts` — add new notification type enum values: `'rivalry_message'`, `'rivalry_request'`, `'rivalry_status_change'`. Export helper `createRivalryNotification(rivalryId, recipientUserId, type, message)` for handler reuse.
+- [ ] Update existing match/promo Vitest tests: `getMatches` `rivalryId` filter, `createMatch` rivalryId acceptance + participant validation, `createPromo` rivalryId acceptance.
+- [ ] Add the new notification types to any frontend type definition (likely `frontend/src/types/notification.ts` or similar).
+
+## Files Touched
+- `backend/functions/matches/createMatch.ts` (modify)
+- `backend/functions/matches/getMatches.ts` (modify)
+- `backend/functions/matches/__tests__/*.test.ts` (modify — add cases)
+- `backend/functions/promos/createPromo.ts` (modify)
+- `backend/functions/promos/__tests__/createPromo.test.ts` (modify — add case)
+- `backend/lib/notifications.ts` (modify — enum + helper)
+- `frontend/src/types/notification.ts` (modify — if it exists; otherwise grep for the type)
+
+## Acceptance Criteria
+- Existing match and promo tests still pass with no regressions.
+- `getMatches({ rivalryId })` returns only matches tagged with that rivalry.
+- `createMatch` with a `rivalryId` whose pair doesn't include the match's participants returns 400.
+- A match created without `rivalryId` is unaffected (backwards compat — no migration needed).
+- `createRivalryNotification` helper is exported and the new enum values are accepted everywhere `NotificationType` is consumed.
+
+## Notes / Risks
+- Backwards compat is the primary concern. Both `rivalryId` fields MUST be optional. Existing data with `rivalryId === undefined` must continue to render in normal listings.
+- Validation in `createMatch` should look up the rivalry once, not on every test of the participant list.

--- a/tickets-rivalries/07-frontend-api-service.md
+++ b/tickets-rivalries/07-frontend-api-service.md
@@ -1,0 +1,42 @@
+# [RIV-07] Frontend API service layer
+
+**Phase:** 3 — Frontend service layer
+**Estimate:** S
+**Blocked by:** RIV-02, RIV-03, RIV-04, RIV-05 (need the deployed API shape)
+**Blocks:** every frontend ticket from RIV-08 onward
+**Reference:** [plan-rivalries.md § Phase 3, step 17](../plan-rivalries.md)
+
+## Goal
+Add the `rivalriesApi` namespace to the frontend service module so all UI components consume the backend through a single typed surface.
+
+## Scope
+**In:** `rivalriesApi` namespace with all read/write methods, mirroring the existing `challengesApi` and `promosApi` style.
+**Out:** Any UI consumers (those land per-component).
+
+## Subtasks
+- [ ] Add `rivalriesApi` to `frontend/src/services/api.ts` with the following methods (mirror return-type and error-handling patterns of existing `challengesApi`):
+  - `list({ status?, participantId?, seasonId?, eventId?, page? })`
+  - `get(rivalryId)`
+  - `getActivity({ participantId?, eventId?, limit?, cursor? })`
+  - `create(input: CreateRivalryInput)`
+  - `respond(rivalryId, action: 'approve' | 'reject' | 'conclude', message?: string)`
+  - `update(rivalryId, patch)`
+  - `delete(rivalryId)`
+  - `messages.list(rivalryId, { cursor? })`
+  - `messages.post(rivalryId, content, audience?)`
+  - `notes.list(rivalryId, { noteType? })`
+  - `notes.upsert(rivalryId, note)`
+- [ ] Reuse the existing auth-header helper and base-URL config from `api.ts`.
+- [ ] Make sure all method signatures import from `frontend/src/types/rivalry.ts` (no inline types).
+
+## Files Touched
+- `frontend/src/services/api.ts` (modify — add namespace)
+
+## Acceptance Criteria
+- TS strict check passes against the namespace.
+- Each method's return type is the exact response shape from the corresponding handler.
+- A quick console smoke from the browser devtools (`await rivalriesApi.list({})`) returns either an array or a documented error shape.
+
+## Notes / Risks
+- Keep parameter naming consistent with the backend query params — drift here causes silent filter failures (the backend ignores unknown params).
+- Don't introduce a new HTTP client library; reuse whatever `api.ts` already uses (likely `fetch` + the existing auth helper).

--- a/tickets-rivalries/08-rivalries-hub-page.md
+++ b/tickets-rivalries/08-rivalries-hub-page.md
@@ -1,0 +1,45 @@
+# [RIV-08] Rivalries Hub page
+
+**Phase:** 4 — Frontend
+**Estimate:** L
+**Blocked by:** RIV-07
+**Blocks:** RIV-15 (routing wires this page in)
+**Reference:** [plan-rivalries.md § Phase 4, steps 18-19](../plan-rivalries.md); Stitch mockup `screens/23c257203a23450c855d1b0348adba65`
+
+## Goal
+Build the public Rivalries Hub: an Episode-scoped board of rivalry cards with three tabs (Active / My Rivalries / Legacy Archive), filter chips, and a "Recent Rivalry Activity" feed.
+
+## Scope
+**In:** `RivalryCard` component, `RivalryHub` page, Episode selector, three tabs, filter chips, activity feed integration, request-rivalry CTA (links to RIV-13's form).
+**Out:** Detail page (RIV-09), the request form itself (RIV-13).
+
+## Subtasks
+- [ ] `frontend/src/components/rivalries/RivalryCard.tsx` — props: `Rivalry` + resolved player avatars. Renders two wrestler portraits face-off, title, heat meter (1-5 gold flames mapped from heat enum), match count, last-activity timestamp, status pill. Reuse the existing player-avatar component from the challenges feature.
+- [ ] `frontend/src/components/rivalries/RivalryHub.tsx` — page layout per Stitch hub mockup. Includes:
+  - Page header with display-lg "RIVALRIES" + tagline + Episode selector dropdown (defaults to active Episode).
+  - Top-right "Request a Rivalry" gold CTA → navigates to `/rivalries/new`.
+  - Three tabs: "Active Rivalries" (status `active`), "My Rivalries" (logged-in wrestler's rivalries — any status), "Legacy Archive" (status `concluded`).
+  - Filter chip row: All / Heated / Brewing / Personal / Slow Burn — applies in addition to the tab filter.
+  - Grid of `RivalryCard`s (uses `rivalriesApi.list` with combined tab + filter params + selected `eventId`).
+  - "Recent Rivalry Activity" feed below the grid (uses `rivalriesApi.getActivity` — see RIV-03; if RIV-03 isn't merged yet, render empty-state placeholder).
+- [ ] Empty state for each tab (no rivalries yet, no rivalries match filter, no activity yet).
+- [ ] Loading skeletons for the grid and activity feed.
+- [ ] Vitest tests: tab switching updates the API filter, chip selection composes with tab filter, "Request a Rivalry" CTA navigates to `/rivalries/new`.
+
+## Files Touched
+- `frontend/src/components/rivalries/RivalryCard.tsx` (create)
+- `frontend/src/components/rivalries/RivalryHub.tsx` (create)
+- `frontend/src/components/rivalries/__tests__/RivalryHub.test.tsx` (create)
+- `frontend/src/components/rivalries/__tests__/RivalryCard.test.tsx` (create)
+
+## Acceptance Criteria
+- All three tabs render and call `rivalriesApi.list` with the correct `status` and `participantId` filters.
+- Episode selector reflects the active Episode by default; switching it refetches the grid.
+- Activity feed shows latest 25 mixed-source events; pagination "Load more" appends without duplication.
+- Visual fidelity to the Stitch hub mockup — no pure white anywhere, gold accents only on CTAs and active states, sharp 4px corners.
+- Lighthouse-style sanity: page TTI under 2s with seed data.
+
+## Notes / Risks
+- Episode selector — list comes from existing Events API. If only one Episode exists, hide the selector.
+- "My Rivalries" tab is hidden for unauthenticated visitors (or shows "Log in to see your rivalries").
+- The Stitch mockup's "EPISODE 01: GENESIS" header label should pull from the selected Event's name + episode number, not be hardcoded.

--- a/tickets-rivalries/09-rivalry-detail-shell-overview.md
+++ b/tickets-rivalries/09-rivalry-detail-shell-overview.md
@@ -1,0 +1,46 @@
+# [RIV-09] Rivalry Detail shell + Overview tab
+
+**Phase:** 4 — Frontend
+**Estimate:** L
+**Blocked by:** RIV-07
+**Blocks:** RIV-10, RIV-11, RIV-12 (other tabs plug into the shell)
+**Reference:** [plan-rivalries.md § Phase 4, steps 20-21](../plan-rivalries.md); Stitch mockup `screens/3e9ac9e3e3084994a0d597fe237f582a`
+
+## Goal
+The hub page for a single rivalry: cinematic hero header, stat strip, tab bar, and the default Overview tab content.
+
+## Scope
+**In:** `RivalryDetail.tsx` page shell with hero + stat strip + tab routing, `OverviewTab.tsx`, "Message GM" floating button.
+**Out:** Match History / Future Matches / Promos / Notes & Plans / Messages tabs (RIV-10, RIV-11, RIV-12).
+
+## Subtasks
+- [ ] `frontend/src/components/rivalries/RivalryDetail.tsx` — page layout:
+  - Hero header: two wrestler portraits face-off across full width with display-lg gold names + "vs" divider.
+  - Stat strip below hero: head-to-head record (e.g., "5W - 3L - 1D"), match count, heat meter, status pill, "Days to Next Event" countdown.
+  - Tab bar with 6 entries: Overview (default), Match History, Future Matches, Promos, Notes & Plans, Messages.
+  - URL-driven tab routing: `/rivalries/:rivalryId` defaults to overview; `/rivalries/:rivalryId/:tab` switches.
+  - Floating bottom-right "Message GM" gold button → navigates to `…/messages`.
+  - Loading skeleton for the hero strip while `rivalriesApi.get` fetches.
+  - 404 / not-authorized handling.
+- [ ] `frontend/src/components/rivalries/tabs/OverviewTab.tsx` — two-column layout per Stitch detail mockup:
+  - Left column: "Storyline Notes" card (collapsed view of recent notes, link to Notes & Plans tab) + "GM Plans" timeline (preview of next 3 entries, link to Notes & Plans tab; respects role-based visibility — wrestlers see only `participants`/`public` plans).
+  - Right column: "Next Match" card (scheduled match details with date, stipulation, championship at stake) + "Recent Promos" preview (3 most recent, deep-link to Promos tab) + "Last 5 Encounters" mini-leaderboard.
+  - Empty states for each section.
+- [ ] Vitest tests: tab routing reflects URL, "Message GM" button navigates to messages tab, OverviewTab respects note visibility for wrestler vs GM caller.
+
+## Files Touched
+- `frontend/src/components/rivalries/RivalryDetail.tsx` (create)
+- `frontend/src/components/rivalries/tabs/OverviewTab.tsx` (create)
+- `frontend/src/components/rivalries/__tests__/RivalryDetail.test.tsx` (create)
+- `frontend/src/components/rivalries/tabs/__tests__/OverviewTab.test.tsx` (create)
+
+## Acceptance Criteria
+- Tab bar's 6 entries are present even before RIV-10/11/12 land — those tabs render placeholder content until their tickets ship.
+- Deep-linking to `/rivalries/{id}/messages` opens the Messages tab placeholder, not the Overview tab.
+- Visual fidelity to the Stitch detail mockup — hero portraits dominate the viewport, "vs" divider in primary gold.
+- The "Days to Next Event" countdown comes from the hydrated payload's next-event field (RIV-02's `getRivalry`).
+
+## Notes / Risks
+- The hero portraits are heavy assets — lazy-load and use `decoding="async"`.
+- If both wrestlers don't have portraits uploaded, fall back to silhouette placeholders consistent with the existing player-avatar component.
+- This ticket is the structural shell — the content tabs are deliberately split so they can be parallelized after this lands.

--- a/tickets-rivalries/10-detail-tabs-matches-promos.md
+++ b/tickets-rivalries/10-detail-tabs-matches-promos.md
@@ -1,0 +1,40 @@
+# [RIV-10] Detail tabs: Match History, Future Matches, Promos
+
+**Phase:** 4 — Frontend
+**Estimate:** M
+**Blocked by:** RIV-09 (shell), RIV-06 (rivalryId on matches/promos)
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 4, step 20](../plan-rivalries.md)
+
+## Goal
+Three lighter content tabs on the Rivalry Detail page — pulling matches and promos already tagged with the rivalry's `rivalryId`.
+
+## Scope
+**In:** `MatchHistoryTab.tsx`, `FutureMatchesTab.tsx`, `PromosTab.tsx`, with deep-links to existing schedule/compose flows pre-filled with `rivalryId`.
+**Out:** New schedule or compose UIs — reuse existing flows. Notes & Plans (RIV-11). Messages (RIV-12).
+
+## Subtasks
+- [ ] `frontend/src/components/rivalries/tabs/MatchHistoryTab.tsx` — calls `matchesApi.list({ rivalryId, status: 'completed' })`. Renders a list of completed matches between the pair (reuse existing match list components if they accept a list prop; otherwise a simple list with date, stipulation, winner). Empty state.
+- [ ] `frontend/src/components/rivalries/tabs/FutureMatchesTab.tsx` — calls `matchesApi.list({ rivalryId, status: 'scheduled' })`. Renders scheduled matches. Admin-only "Schedule Match for this Rivalry" CTA → navigates to `ScheduleMatch.tsx` pre-filled with the pair + `rivalryId` via React Router state (analog of the challenge→schedule flow described in TO-DOS.md line 17). Empty state.
+- [ ] `frontend/src/components/rivalries/tabs/PromosTab.tsx` — calls `promosApi.list({ rivalryId })`. Renders promo cards with reactions (reuse `PromoCard`). "Cut a Promo" CTA → navigates to `PromoEditor` pre-filled with `rivalryId` and `targetPlayerId` (the opponent) via React Router state. Empty state.
+- [ ] Update `frontend/src/components/admin/ScheduleMatch.tsx` to accept and persist a `rivalryId` from React Router state (if not already wired by RIV-06's plan).
+- [ ] Update `frontend/src/components/promos/PromoEditor.tsx` to accept and persist a `rivalryId` from React Router state.
+- [ ] Vitest tests for each tab: list rendering, empty state, CTAs navigate with correct state.
+
+## Files Touched
+- `frontend/src/components/rivalries/tabs/MatchHistoryTab.tsx` (create)
+- `frontend/src/components/rivalries/tabs/FutureMatchesTab.tsx` (create)
+- `frontend/src/components/rivalries/tabs/PromosTab.tsx` (create)
+- `frontend/src/components/admin/ScheduleMatch.tsx` (modify — accept rivalryId from router state)
+- `frontend/src/components/promos/PromoEditor.tsx` (modify — accept rivalryId from router state)
+- `frontend/src/components/rivalries/tabs/__tests__/*.test.tsx` (create)
+
+## Acceptance Criteria
+- Each tab fetches only its own data, lazily on tab open.
+- Schedule-Match CTA from Future Matches tab pre-fills participants AND `rivalryId`; the resulting match appears in both this tab (after refresh) and the rivalry's Match History after the match is recorded.
+- Cut-a-Promo CTA from Promos tab pre-fills `rivalryId` and the opposing wrestler as the target.
+- Empty states are visually distinct from loading states (no infinite spinner if the list is genuinely empty).
+
+## Notes / Risks
+- The existing `ScheduleMatch.tsx` and `PromoEditor.tsx` modifications must be backwards-compatible — no rivalryId passed should still work as before.
+- If the schedule flow is being reworked by the [TO-DOS.md](../TO-DOS.md) "Challenge & Promo to Match Scheduling" entries (line 17), coordinate to add `rivalryId` to the same router-state shape they introduce, not a separate one.

--- a/tickets-rivalries/11-detail-tab-notes-plans.md
+++ b/tickets-rivalries/11-detail-tab-notes-plans.md
@@ -1,0 +1,38 @@
+# [RIV-11] Detail tab: Notes & Plans
+
+**Phase:** 4 — Frontend
+**Estimate:** M
+**Blocked by:** RIV-09 (shell), RIV-05 (notes backend)
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 4, step 20](../plan-rivalries.md); Stitch detail mockup "STORYLINE NOTES" + "GM EXECUTIVE PLANS" sections
+
+## Goal
+Two-column tab showing storyline notes (visible per role) and the GM-only plans timeline, with inline edit for GMs and deep-links from plan entries to their linked match or event.
+
+## Scope
+**In:** `NotesPlansTab.tsx` with role-based UI, inline create/edit for GMs, link rendering for `linkedMatchId` / `linkedEventId`.
+**Out:** Note backend (RIV-05).
+
+## Subtasks
+- [ ] `frontend/src/components/rivalries/tabs/NotesPlansTab.tsx` — two-column layout:
+  - Left column: "Storyline Notes" — list of notes filtered to `noteType: 'storyline'`. Visible to wrestlers and GMs. GMs see all visibilities; wrestlers see only `'participants'` and `'public'` plus their own `'gm-only'` notes (those they authored).
+  - Right column: "GM Executive Plans" timeline — list of `noteType: 'plan'` notes. For each entry render: a header (with `scheduledFor` date if set), the content, and if `linkedMatchId` or `linkedEventId` is present, a small clickable badge linking to the match detail page or event detail page. Default visibility for plans is `'gm-only'` (per RIV-05) — wrestlers may see no plans at all unless GMs explicitly publish them.
+- [ ] Inline-create form for GMs at the top of each column with: textarea, optional `scheduledFor` date picker, optional `linkedMatchId` / `linkedEventId` selectors (autocomplete from existing matches/events APIs), visibility selector.
+- [ ] Inline-edit affordance on each note (GMs only; wrestlers can edit their own `'storyline'` `'gm-only'` notes).
+- [ ] Graceful handling of stale links: if `linkedMatchId` or `linkedEventId` no longer resolves, render the badge with a strikethrough and tooltip "Match no longer exists" — do not 404 the page.
+- [ ] Wrestler-suggestion mode: a wrestler creating a `'storyline'` note sees a hint "GMs will be notified of your suggestion" (the visibility is server-forced to `'gm-only'`).
+- [ ] Vitest tests: GM sees all visibilities, wrestler does not see GM `'gm-only'` notes, plan badge resolves to correct match/event link, stale link renders gracefully.
+
+## Files Touched
+- `frontend/src/components/rivalries/tabs/NotesPlansTab.tsx` (create)
+- `frontend/src/components/rivalries/tabs/__tests__/NotesPlansTab.test.tsx` (create)
+
+## Acceptance Criteria
+- Wrestler caller never sees a `'plan'` note unless its visibility is `'participants'` or `'public'`.
+- Wrestler caller sees their own `'storyline'` `'gm-only'` notes (suggestions to the GM) but not other wrestlers' `'gm-only'` notes — confirms server filtering AND client UI alignment.
+- GM caller sees everything and can edit any note inline.
+- Linked-match / linked-event badges navigate to the right URLs when clicked.
+- The "Wrestler suggestion" hint is shown only when the caller is a wrestler creating a `'storyline'` note.
+
+## Notes / Risks
+- Plans visibility is the highest leak risk in the feature — if a wrestler ever sees a `'gm-only'` `'plan'` note that wasn't theirs, that's a P0 bug. RIV-05 enforces server-side; this ticket should reinforce by also filtering client-side as defense-in-depth (with a console.warn if the server returned data the client wouldn't show).

--- a/tickets-rivalries/12-detail-tab-messages.md
+++ b/tickets-rivalries/12-detail-tab-messages.md
@@ -1,0 +1,42 @@
+# [RIV-12] Detail tab: Messages (with audience toggle, polling, optimistic UI)
+
+**Phase:** 4 — Frontend
+**Estimate:** L
+**Blocked by:** RIV-09 (shell), RIV-04 (messaging backend)
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 4, step 20](../plan-rivalries.md); Stitch mockup `screens/617995aa3b1b47b99127ce0262e4d0d7`
+
+## Goal
+The two-way thread UI scoped to a single rivalry. Renders the conversation, supports the "Loop in Opponent" audience toggle, polls for new messages, and provides optimistic-send UX.
+
+## Scope
+**In:** `MessagesTab.tsx` (left rail + right thread), composer with audience toggle, polling refresh, optimistic-send rollback on failure.
+**Out:** Real-time WebSocket transport (deferred per CLAUDE.md "Known Limitations" #7), file attachments.
+
+## Subtasks
+- [ ] `frontend/src/components/rivalries/tabs/MessagesTab.tsx` — two-column layout per Stitch messages mockup:
+  - Left rail (~30%): "Participants" card listing the two wrestlers + assigned GMs with avatars, names, online-status placeholder dots. "Message Settings" card with toggles: "Push notifications", "Email alerts", "Loop in Opponent" (binds to rivalry's `defaultMessageAudience` — when off, default audience is `'gm-only'`; when on, default is `'all-participants'`). Toggle changes call `rivalriesApi.update(rivalryId, { defaultMessageAudience: ... })`.
+  - Right pane (~70%): chronological thread of message bubbles. Own messages right-aligned with subtle gold tint; others left-aligned with avatar. System messages (e.g., "GM scheduled a match…") rendered with a distinct styled row, no bubble.
+  - Composer at bottom: sunken textarea, attach + emoji icons (placeholder buttons OK for now, no actual attach handler), gold "Send" button. Below the input: character counter and the hint text "Messages are private between you and the GMs." (or "…and your opponent." when Loop in Opponent is on — bind to current audience).
+- [ ] Polling: fetch new messages every 15s when the tab is visible (use the Page Visibility API to pause when hidden). Debounce on server load: skip the next poll if a manual refresh or post just happened.
+- [ ] Optimistic send: append the new message to the thread immediately with a sending state, fire `rivalriesApi.messages.post`, swap to confirmed on success, mark as failed (with retry button) on error.
+- [ ] Per-message audience override: a small toggle on the composer to send a single message as `'gm-only'` even when the thread default is `'all-participants'` (and vice versa).
+- [ ] Auto-mark-as-read when the tab is opened.
+- [ ] Empty state ("No messages yet — say hi to your GM").
+- [ ] Vitest tests: optimistic-send rollback on failure, polling pauses when tab hidden, audience toggle updates default and persists, system messages render distinct from user messages.
+
+## Files Touched
+- `frontend/src/components/rivalries/tabs/MessagesTab.tsx` (create)
+- `frontend/src/components/rivalries/tabs/__tests__/MessagesTab.test.tsx` (create)
+
+## Acceptance Criteria
+- Polling works: a message posted by another participant appears within 15s without a page reload.
+- Optimistic send shows the message instantly; on a backend 500 the message flips to a "Failed — Retry" state without disappearing.
+- Toggling "Loop in Opponent" persists across page reloads (server-side via `rivalriesApi.update`).
+- A `'gm-only'` message is rendered with a small visual indicator (lock icon or muted color) so the sender knows it's not visible to the opponent.
+- Composer hint text reflects the current default audience.
+
+## Notes / Risks
+- Polling fan-out — every active Messages tab makes one request every 15s. With many concurrent users this could pressure the API. If load is a concern at scale, file a follow-up for a long-poll or SSE variant; do not block this ticket.
+- The optimistic-send UX is critical because polling latency is otherwise visible to the sender.
+- The "Loop in Opponent" rivalry-level toggle should be GM-controlled or both-wrestler-controlled, not solely the requester's. Confirm with product before merging if ambiguous.

--- a/tickets-rivalries/13-request-rivalry-form.md
+++ b/tickets-rivalries/13-request-rivalry-form.md
@@ -1,0 +1,47 @@
+# [RIV-13] Request a Rivalry form (2-step)
+
+**Phase:** 4 — Frontend
+**Estimate:** M
+**Blocked by:** RIV-07
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 4, step 22](../plan-rivalries.md); Stitch mockup `screens/f98b693dbcfc4d0e9689c2d9d1bcb9e0`
+
+## Goal
+Wrestler-facing two-step form to pitch a new rivalry to the GMs.
+
+## Scope
+**In:** `RequestRivalry.tsx` two-step form, opponent autocomplete, GM tagging, validation, submit-and-redirect flow.
+**Out:** Backend handler (RIV-02 already covers `createRivalry`).
+
+## Subtasks
+- [ ] `frontend/src/components/rivalries/RequestRivalry.tsx` — page layout per Stitch request mockup. Centered form on a `surface_container_high` card, max-width ~720px.
+- [ ] Two-step indicator at top: Step 1 "Who & Why" / Step 2 "Pitch & Plans".
+- [ ] **Step 1 fields:**
+  - "Your Wrestler" — read-only chip showing current logged-in wrestler portrait + name (resolves from auth context).
+  - "Opponent" — autocomplete dropdown calling players API, showing portrait + name + record per result. Filter out self from the suggestions.
+  - "Rivalry Title" — text input with placeholder "e.g. Bloodline Civil War", required, max 80 chars.
+  - "Proposed Heat Level" — radio chips: Slow Burn / Brewing / Heated / Personal.
+  - "Why this rivalry?" — large textarea, required, 50-1500 char counter.
+  - "Tag your GM" — chips with assigned-GMs avatars; one or more can be selected (passed as a hint, not an exclusive routing — see RIV-02 notes).
+  - "Continue to Step 2" gold button (disabled until required fields valid). "Cancel" outline button.
+- [ ] **Step 2 fields:**
+  - "Storyline Pitch" — larger rich-text-style textarea (just textarea is fine for v1; rich text deferred), 100-3000 chars.
+  - "Proposed Plans" — optional list of 1-5 plan-entry rows (text + optional `scheduledFor` date) — these are saved as initial `'plan'` notes (visibility `'gm-only'`) after the rivalry is created.
+  - "Submit Rivalry Request" gold button. "Back" button → returns to Step 1 preserving state.
+- [ ] On submit: call `rivalriesApi.create(input)`. On success, also create the proposed plan notes via `rivalriesApi.notes.upsert` (one per plan row). Navigate to `/rivalries/:newRivalryId`.
+- [ ] Validation: surface inline errors per field; do not allow Step 1 → 2 progression with invalid required fields.
+- [ ] Vitest tests: required-field validation blocks Step 1, opponent autocomplete excludes self, submit creates rivalry then notes then navigates, back button preserves Step 1 state.
+
+## Files Touched
+- `frontend/src/components/rivalries/RequestRivalry.tsx` (create)
+- `frontend/src/components/rivalries/__tests__/RequestRivalry.test.tsx` (create)
+
+## Acceptance Criteria
+- Form matches Stitch request mockup visually — gold accent only on the active step indicator and the primary CTA, sharp 4px corners, sunken input fills.
+- Submitting with required fields returns the user on the new rivalry's detail page within 1s on a typical connection.
+- A failed submit (e.g., duplicate-active 409 from RIV-02) shows an inline error without losing form state.
+- The plan-row creation runs sequentially after rivalry creation; if a plan-note write fails, it does not roll back the rivalry but does flag the failure to the user with a "Some plans failed to save — edit later in the rivalry detail" banner.
+
+## Notes / Risks
+- Keep Step 1 + Step 2 inside a single component with internal state — using React Router for the two steps adds complexity without payoff at this size.
+- The Step 2 plan-rows are a UX nicety; if scope-cutting, defer Step 2 entirely and let the user add plans from the Notes & Plans tab post-creation.

--- a/tickets-rivalries/14-admin-rivalries-panel.md
+++ b/tickets-rivalries/14-admin-rivalries-panel.md
@@ -1,0 +1,41 @@
+# [RIV-14] Admin Rivalries moderation panel
+
+**Phase:** 4 — Frontend
+**Estimate:** M
+**Blocked by:** RIV-02 (respond/update/delete handlers), RIV-07 (api client)
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 4, step 23](../plan-rivalries.md)
+
+## Goal
+GM-facing moderation table to triage rivalry requests and manage their lifecycle.
+
+## Scope
+**In:** `AdminRivalries.tsx` table with status filters, per-row actions (approve / reject / conclude / delete), bulk-clear, admin-tab registration.
+**Out:** Inline messaging — admins use the regular Messages tab on the detail page.
+
+## Subtasks
+- [ ] `frontend/src/components/admin/AdminRivalries.tsx` — table layout mirroring `frontend/src/components/admin/AdminChallenges.tsx`. Columns: created date, requester, opponent, title, heat, status, actions.
+- [ ] Status filter chips at top: All / Pending / Active / Concluded / Rejected / Cancelled.
+- [ ] Per-row actions:
+  - For `pending`: "Approve" + "Reject" (both open a small modal for an optional response message → call `rivalriesApi.respond`).
+  - For `active`: "Conclude" (modal for closure notes → `rivalriesApi.respond` with `action: 'conclude'`) + "Open" (deep-link to the detail page).
+  - For all rows: "Delete" (confirmation modal → `rivalriesApi.delete`).
+- [ ] Bulk-clear button: "Clear Resolved" — deletes all rivalries with status in `['concluded', 'rejected', 'cancelled']`. Confirmation modal showing count.
+- [ ] Pagination on the table (page size 25).
+- [ ] Register the new tab in `frontend/src/components/admin/AdminPanel.tsx`'s tab router under `/admin/rivalries`.
+- [ ] Vitest tests: each row action calls the correct API method with correct args, bulk-clear confirmation gates the destructive call, status filter chip composes with table data.
+
+## Files Touched
+- `frontend/src/components/admin/AdminRivalries.tsx` (create)
+- `frontend/src/components/admin/__tests__/AdminRivalries.test.tsx` (create)
+- `frontend/src/components/admin/AdminPanel.tsx` (modify — register tab)
+
+## Acceptance Criteria
+- All four lifecycle actions (approve, reject, conclude, delete) work end-to-end against a deployed devtest backend.
+- Bulk-clear requires explicit confirmation showing the exact count of rivalries that will be deleted.
+- Table refreshes after each action without a full page reload.
+- Visually consistent with `AdminChallenges.tsx` and `AdminPromos.tsx` — same row patterns, same chip styles.
+
+## Notes / Risks
+- Bulk-clear is destructive at scale (could delete thousands of historical rivalries). Confirmation copy must show the exact count and a "Type DELETE to confirm" pattern is overkill for v1 but worth considering if real production data accumulates.
+- Reject and Conclude both call `respond` with different action enums. Don't confuse the API surface.

--- a/tickets-rivalries/15-routing-nav-dashboard.md
+++ b/tickets-rivalries/15-routing-nav-dashboard.md
@@ -1,0 +1,43 @@
+# [RIV-15] Routing, nav, Dashboard surface
+
+**Phase:** 4 — Frontend
+**Estimate:** S
+**Blocked by:** RIV-08 (Hub), RIV-09 (Detail), RIV-13 (Request form), RIV-14 (Admin panel)
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 4, steps 24-26](../plan-rivalries.md)
+
+## Goal
+Wire the new pages into the app shell: routes, nav entries, and a "My Active Rivalries" card on the Dashboard.
+
+## Scope
+**In:** App.tsx route registrations, navConfig entries (wrestler + admin nav groups), Dashboard surface card.
+**Out:** Any new pages — those land in their own tickets.
+
+## Subtasks
+- [ ] `frontend/src/App.tsx` — register routes:
+  - `/rivalries` → `<FeatureRoute feature="rivalries"><RivalryHub /></FeatureRoute>`
+  - `/rivalries/new` → `<RequireAuth><RequestRivalry /></RequireAuth>`
+  - `/rivalries/:rivalryId` → `<RivalryDetail />`
+  - `/rivalries/:rivalryId/:tab` → `<RivalryDetail />` (same component, tab from URL)
+  - `/admin/rivalries` → `<AdminRoute><AdminRivalries /></AdminRoute>` (or however admin routes are wrapped today)
+- [ ] `frontend/src/config/navConfig.ts`:
+  - Add `rivalries` entry to the wrestler nav group, after `promos`. Use the appropriate icon and i18n key.
+  - Add `rivalries` entry to the admin `/admin/content` nav group, after `promos`.
+- [ ] `frontend/src/components/Dashboard.tsx` — add "My Active Rivalries" card for logged-in wrestlers. Shows top 2-3 active rivalries (call `rivalriesApi.list({ participantId: currentUserPlayerId, status: 'active', limit: 3 })`) with mini-`RivalryCard`s and a "View all" link to `/rivalries?tab=my`. Hide the card entirely for non-logged-in or non-wrestler users.
+- [ ] Vitest test: Dashboard card hidden for unauthenticated user, visible for wrestler with active rivalries, hidden for wrestler with no active rivalries.
+
+## Files Touched
+- `frontend/src/App.tsx` (modify — routes)
+- `frontend/src/config/navConfig.ts` (modify — nav entries)
+- `frontend/src/components/Dashboard.tsx` (modify — surface card)
+- `frontend/src/components/__tests__/Dashboard.test.tsx` (modify — add the card cases)
+
+## Acceptance Criteria
+- Direct navigation to every new route renders the right page without a 404.
+- Nav entry highlights when on the corresponding route.
+- Dashboard card uses the same visual idiom as the existing dashboard cards (no special styling for this surface).
+- Existing nav-config tests (if any) still pass; if they break on index-shifted assertions, update them to reflect the new entry.
+
+## Notes / Risks
+- `<FeatureRoute>` is the existing feature-flag wrapper — confirm `feature="rivalries"` corresponds to a feature flag the team will set, or default to enabled for now and document.
+- The Dashboard card should fail silently if the API call errors — never block the rest of the dashboard.

--- a/tickets-rivalries/16-localization.md
+++ b/tickets-rivalries/16-localization.md
@@ -1,0 +1,45 @@
+# [RIV-16] Localization (English + German)
+
+**Phase:** 5 — Polish
+**Estimate:** S
+**Blocked by:** can land in parallel with frontend tickets, but easiest after RIV-08 through RIV-14 settle their copy
+**Blocks:** none (the components fall back to keys if translations are missing — but ship before public release)
+**Reference:** [plan-rivalries.md § Phase 5, step 27](../plan-rivalries.md)
+
+## Goal
+Add the full `rivalries.*` translation namespace to both locale files so every visible string is localized in English and German.
+
+## Scope
+**In:** Every user-facing string in the new components, in both locales.
+**Out:** The wiki articles' translations (RIV-17).
+
+## Subtasks
+- [ ] Add the `rivalries.*` block to `frontend/src/i18n/locales/en.json` mirroring the depth of the existing `challenges.*` block. Required sub-namespaces:
+  - `rivalries.hub.*` — page title, tagline, tabs (active / myRivalries / legacyArchive), filterChipLabels, requestCta, episodeSelectorLabel, recentActivityHeading
+  - `rivalries.card.*` — heatLabels (slow-burn / brewing / heated / personal), statusLabels (pending / active / concluded / rejected / cancelled), matchCountLabel, lastActivityLabel
+  - `rivalries.detail.*` — heroVsLabel, daysToEvent, recordLabel, tabLabels (overview / matchHistory / futureMatches / promos / notesPlans / messages), messageGmCta
+  - `rivalries.overview.*` — storylineNotesHeading, gmPlansHeading, nextMatchHeading, recentPromosHeading, lastEncountersHeading, emptyStates.*
+  - `rivalries.notes.*` — storylineColumnHeading, plansColumnHeading, addStorylineCta, addPlanCta, scheduledForLabel, linkedMatchLabel, linkedEventLabel, wrestlerSuggestionHint, staleLink
+  - `rivalries.messages.*` — composerPlaceholder.gmOnly, composerPlaceholder.allParticipants, composerHint.gmOnly, composerHint.allParticipants, sendCta, retryCta, loopInOpponentLabel, pushNotificationsLabel, emailAlertsLabel, emptyState
+  - `rivalries.request.*` — pageTitle, pageSubtitle, stepLabels (whoAndWhy / pitchAndPlans), fields.* (yourWrestler, opponent, title, heat, why, tagGm, storylinePitch, plans), helpText.*, submitCta, backCta, cancelCta, validationErrors.*
+  - `rivalries.admin.*` — tabTitle, statusFilterLabels, actions (approve / reject / conclude / delete / clearResolved), confirmModals.* (rejectReason, concludeReason, deleteConfirm, bulkClearConfirm)
+  - `rivalries.status.*` — same enum keys as `card.statusLabels` but suitable for inline status pills
+  - `rivalries.heat.*` — same enum keys as `card.heatLabels` but suitable for chips
+  - `rivalries.dashboard.*` — myActiveRivalriesHeading, viewAllLink, emptyState
+- [ ] Add German translations for every key above to `frontend/src/i18n/locales/de.json`. Keep depth/structure identical.
+- [ ] Replace any hardcoded English strings in the new components (RIV-08 through RIV-14) with `t()` calls referencing the new keys. Grep the new files for literal strings.
+
+## Files Touched
+- `frontend/src/i18n/locales/en.json` (modify — add `rivalries.*`)
+- `frontend/src/i18n/locales/de.json` (modify — add `rivalries.*` translations)
+- All `frontend/src/components/rivalries/**/*.tsx` (modify — replace hardcoded strings with `t()` calls; many of these will already be using `t()` if the component-author followed convention)
+- `frontend/src/components/admin/AdminRivalries.tsx` (modify — same)
+
+## Acceptance Criteria
+- Switching language to German renders every visible string in the rivalry feature in German with no missing-key warnings in the console.
+- The `wiki.articles.rivalries` and `wiki.articles.adminRivalries` keys are present too (RIV-17 also touches these — coordinate ordering).
+- No hardcoded English string remains in any rivalry component (grep verifies).
+
+## Notes / Risks
+- German translations should mirror tone of existing `challenges.*` and `promos.*` blocks. If the original engineer doesn't speak German, defer to whoever did the existing translations.
+- Heat / status enum labels are referenced from multiple places (`card.*`, `status.*`, `heat.*` namespaces). Keep the actual displayed text consistent across them, even if the keys differ.

--- a/tickets-rivalries/17-wiki-articles.md
+++ b/tickets-rivalries/17-wiki-articles.md
@@ -1,0 +1,54 @@
+# [RIV-17] Wiki articles (English + German)
+
+**Phase:** 5 — Polish
+**Estimate:** S
+**Blocked by:** none (write any time after the feature scope is firm)
+**Blocks:** none
+**Reference:** [plan-rivalries.md § Phase 5, step 28](../plan-rivalries.md); CLAUDE.md "Help and Wiki" section
+
+## Goal
+Two static wiki articles — one user-facing, one GM-facing — covering how to use the rivalry feature.
+
+## Scope
+**In:** 4 markdown files (en + de × user + admin), 2 entries in `index.json`, 2 i18n title keys.
+**Out:** Any in-app onboarding or tour.
+
+## Subtasks
+- [ ] Write `frontend/public/wiki/rivalries.md` (English, user-facing). Cover:
+  - What is a rivalry vs a challenge — when to use which.
+  - How to request a rivalry (link to the request form).
+  - What "Heat Level" means and how to choose one.
+  - How GM messages work — default audience, "Loop in Opponent" toggle, how messages stay private.
+  - What happens after a request is submitted (GM review, approval, status meaning).
+  - How matches and promos get tagged to a rivalry.
+- [ ] Write `frontend/public/wiki/admin-rivalries.md` (English, GM-facing). Cover:
+  - How to triage pending requests (criteria for approval / rejection).
+  - How to write storyline notes vs GM plans, and the visibility model.
+  - How to schedule matches against a rivalry from the Future Matches tab.
+  - When to conclude a rivalry vs leave it active.
+  - Bulk-clear and cleanup workflow.
+- [ ] Translate both articles to German under `frontend/public/wiki/de/rivalries.md` and `frontend/public/wiki/de/admin-rivalries.md`. Keep section structure 1:1.
+- [ ] Append two entries to `frontend/public/wiki/index.json`:
+  - `{ "slug": "rivalries", "titleKey": "wiki.articles.rivalries", "file": "rivalries.md" }`
+  - `{ "slug": "admin-rivalries", "titleKey": "wiki.articles.adminRivalries", "file": "admin-rivalries.md", "adminOnly": true }`
+- [ ] Add `wiki.articles.rivalries` and `wiki.articles.adminRivalries` keys to both `en.json` and `de.json`.
+- [ ] Verify the articles render correctly in `/guide/wiki/rivalries` and `/guide/wiki/admin-rivalries` in both languages.
+- [ ] Verify the "Edit this page" link resolves to the correct GitHub URL (env vars `VITE_GITHUB_REPO` and optional `VITE_GITHUB_BRANCH` per CLAUDE.md).
+
+## Files Touched
+- `frontend/public/wiki/rivalries.md` (create)
+- `frontend/public/wiki/admin-rivalries.md` (create)
+- `frontend/public/wiki/de/rivalries.md` (create)
+- `frontend/public/wiki/de/admin-rivalries.md` (create)
+- `frontend/public/wiki/index.json` (modify)
+- `frontend/src/i18n/locales/en.json` (modify — wiki title keys)
+- `frontend/src/i18n/locales/de.json` (modify — wiki title keys)
+
+## Acceptance Criteria
+- Both articles render without any markdown rendering glitches in both locales.
+- The German fallback works: deleting `de/rivalries.md` temporarily falls back to the English version (per CLAUDE.md wiki spec).
+- Admin article shows up only when an admin is logged in (the `adminOnly: true` flag in `index.json` is respected).
+
+## Notes / Risks
+- Don't drift the article copy from the actual UI labels — if RIV-16 changes terminology, update the wiki too.
+- The GM-facing article must explicitly cover the visibility model for plans (`gm-only` default) so GMs don't accidentally publish spoilers.

--- a/tickets-rivalries/18-seed-data.md
+++ b/tickets-rivalries/18-seed-data.md
@@ -1,0 +1,36 @@
+# [RIV-18] Seed data for local development
+
+**Phase:** 5 — Polish
+**Estimate:** S
+**Blocked by:** RIV-01 (tables), RIV-02 (handlers — for cross-checks), RIV-04, RIV-05 (so seeded messages and notes resolve)
+**Blocks:** RIV-19 (E2E verification benefits from realistic data)
+**Reference:** [plan-rivalries.md § Phase 5, step 29](../plan-rivalries.md)
+
+## Goal
+Seed 2-3 example rivalries with full sub-data so devs running `npm run seed` get a meaningful rivalry feature experience locally.
+
+## Scope
+**In:** Modifications to the existing seed script to populate the new tables and tag existing matches/promos with `rivalryId`.
+**Out:** A separate seed-rivalries.ts module — wait for the modular seed-data refactor (TO-DOS.md line 7) and add a `seed-rivalries.ts` then.
+
+## Subtasks
+- [ ] Modify `backend/scripts/seed-data.ts` to add a Rivalries section that creates:
+  - **Rivalry 1 (active, heated):** Two top wrestlers from the existing seeded set. 8-10 messages mixed `gm-only` and `all-participants` (some authored by each wrestler, some by the GM). 3 storyline notes (mixed `gm-only` and `participants` visibility). 2 GM plans with `scheduledFor` dates, one with a `linkedMatchId` to a seeded scheduled match. Tag 3-4 existing seeded completed matches and 2 seeded promos with this `rivalryId`.
+  - **Rivalry 2 (concluded, slow-burn):** A historical rivalry between two other wrestlers. 5-6 messages. 2 storyline notes. No active plans (concluded). 5 tagged completed matches. 1 tagged promo.
+  - **Rivalry 3 (pending):** A fresh request, no GM response yet. No messages, no notes, no tagged matches/promos.
+- [ ] Ensure `defaultMessageAudience` is set to `'all-participants'` for Rivalry 1 (so the seed shows the multi-party thread experience) and `'gm-only'` for Rivalry 2.
+- [ ] Add a corresponding clear step to `backend/scripts/clear-data.ts` that empties the three new tables.
+- [ ] Document in the seed script header comment which existing seeded players and matches the rivalries reference (so devs know what to look for).
+
+## Files Touched
+- `backend/scripts/seed-data.ts` (modify — add Rivalries section)
+- `backend/scripts/clear-data.ts` (modify — clear new tables)
+
+## Acceptance Criteria
+- `cd backend && npm run seed` completes without errors and the three rivalries are visible at `http://localhost:3000/rivalries`.
+- Rivalry 1's detail page shows real matches in History, real promos in Promos, the seeded plans in Notes & Plans, and the seeded message thread in Messages.
+- `cd backend && npm run clear-data` empties all three rivalry tables without error.
+
+## Notes / Risks
+- Use the existing seeded player IDs explicitly (don't rely on order). Hardcode the IDs at the top of the seed script if not already done.
+- Keep the seed deterministic — same script run produces same rivalry IDs, helpful for QA scripts.

--- a/tickets-rivalries/19-end-to-end-verification.md
+++ b/tickets-rivalries/19-end-to-end-verification.md
@@ -1,0 +1,51 @@
+# [RIV-19] End-to-end verification & release readiness
+
+**Phase:** 6 — Tests & verification
+**Estimate:** M
+**Blocked by:** every other ticket
+**Blocks:** PROD deploy
+**Reference:** [plan-rivalries.md § Phase 6, steps 30-31; § Testing & Verification](../plan-rivalries.md)
+
+## Goal
+Final sweep: full lint/typecheck/test pass on both halves, manual end-to-end smoke against devtest, accessibility check, and sign-off on the visibility model that gates the highest-leak surfaces.
+
+## Scope
+**In:** Full test runs, manual smoke checklist, accessibility pass, visibility audit, deploy to devtest, prod readiness sign-off.
+**Out:** New feature work (file follow-ups instead).
+
+## Subtasks
+- [ ] Run `cd backend && npx tsc --project tsconfig.json --noEmit` — zero errors.
+- [ ] Run `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — zero errors.
+- [ ] Run `cd backend && npm run lint && npx vitest run` — zero failures.
+- [ ] Run `cd frontend && npm run lint && npx vitest run` — zero failures.
+- [ ] Deploy to devtest: `cd backend && npx serverless deploy --stage devtest --aws-profile league-szn` then `cd frontend && npm run build -- --mode devtest && aws s3 sync dist s3://dev.leagueszn.jpdxsolo.com --profile league-szn --delete`.
+- [ ] **Manual smoke against devtest** (per plan § Testing & Verification):
+  - [ ] Wrestler A logs in → Dashboard "My Active Rivalries" card shows seeded data → click through to seeded rivalry → Overview tab populated.
+  - [ ] Wrestler A clicks "Request a Rivalry" → completes both steps → submits → lands on new rivalry detail with status "pending".
+  - [ ] Admin logs in → `/admin/rivalries` shows the pending request → approves → wrestler A receives a notification → status flips to active → system message appears in Messages tab.
+  - [ ] Wrestler A posts a `'gm-only'` message → admin sees it on refresh → opposing Wrestler B confirms they CANNOT see it. Wrestler A posts an `'all-participants'` message → opposing Wrestler B sees it.
+  - [ ] Admin schedules a match from Future Matches tab → match created with `rivalryId` → appears in Future Matches → after recording result, appears in Match History.
+  - [ ] Admin tags a promo with `rivalryId` from the promo composer → appears in the rivalry's Promos tab.
+  - [ ] Switch language to German → all rivalry strings render translated. Switch back to English.
+- [ ] **Visibility audit** — for each of the following matrix cells, verify the wrong party CANNOT see the data via either UI or direct API call (use `curl` with their JWT):
+  - [ ] Wrestler B viewing Wrestler A's `'gm-only'` rivalry messages → 200 response excludes them.
+  - [ ] Wrestler B viewing GM's `'gm-only'` plan notes → 200 response excludes them.
+  - [ ] Unauthenticated viewing the rivalry detail page → no messages, no `'gm-only'` notes in the response.
+  - [ ] Non-participant attempting to POST a message → 403.
+- [ ] Accessibility pass: keyboard-only navigation through Hub → Detail → Messages tab → composer. Screen reader can read message thread chronologically with author attribution.
+- [ ] Performance sanity: Hub TTI under 2s with seed data; Detail page TTI under 2s; Messages tab polling does not produce visible jank.
+- [ ] File any follow-up tickets discovered during the smoke (e.g., bulk-message debouncing, real-time transport, in-place rich text editor).
+
+## Files Touched
+- None (verification only). Any bugs found get their own follow-up tickets or quick fixes in the relevant feature ticket.
+
+## Acceptance Criteria
+- All four lint/typecheck/test commands exit 0.
+- Every checkbox in the manual smoke and visibility-audit sections is checked off with a brief note in the PR description.
+- Sign-off recorded on the visibility model — explicit confirmation that no role × visibility × noteType combination leaks data.
+- DevOps green-light: devtest deploy succeeded, no CloudWatch errors during smoke, no DynamoDB throttling.
+
+## Notes / Risks
+- The visibility audit is the most important step — a leak here is the highest-impact bug class in this feature.
+- Performance numbers are sanity checks, not hard SLAs. If they regress significantly, file a follow-up rather than blocking release.
+- Don't promote to prod without completing the German-locale smoke; missing translation keys are easy to ship by accident.

--- a/tickets-rivalries/README.md
+++ b/tickets-rivalries/README.md
@@ -1,0 +1,62 @@
+# Rivalries Feature — Ticket Index
+
+Source plan: [`../plan-rivalries.md`](../plan-rivalries.md)
+Stitch mockups: project `10219259134533090941` (Hub, Detail, Messages, Request)
+
+19 tickets, grouped by phase. Each ticket has its own subtask list, files-touched table, acceptance criteria, and dependency links — pull whichever onto your Kanban board as cards.
+
+## Phase 1 — Foundation
+| ID | Title | Estimate | Blocked by |
+|----|-------|----------|------------|
+| [RIV-01](01-data-model-foundation.md) | Data model foundation (types + tables + repos + UnitOfWork) | M | — |
+
+## Phase 2 — Backend handlers
+| ID | Title | Estimate | Blocked by |
+|----|-------|----------|------------|
+| [RIV-02](02-core-crud-handlers.md) | Core CRUD handlers + dispatcher + serverless events | L | RIV-01 |
+| [RIV-03](03-activity-feed-handler.md) | Rivalry activity feed handler | M | RIV-01, RIV-02 |
+| [RIV-04](04-messaging-backend.md) | Messaging backend (post + list + audience filtering) | M | RIV-01, RIV-06 |
+| [RIV-05](05-notes-backend.md) | Notes backend (storyline + plans, role-based visibility) | S | RIV-01 |
+| [RIV-06](06-cross-feature-integration.md) | Cross-feature integration (matches + promos + notifications) | S | RIV-01 |
+
+## Phase 3 — Frontend service layer
+| ID | Title | Estimate | Blocked by |
+|----|-------|----------|------------|
+| [RIV-07](07-frontend-api-service.md) | Frontend API service layer (`rivalriesApi`) | S | RIV-02..05 |
+
+## Phase 4 — Frontend components
+| ID | Title | Estimate | Blocked by |
+|----|-------|----------|------------|
+| [RIV-08](08-rivalries-hub-page.md) | Rivalries Hub page (card + 3 tabs + filters + activity feed) | L | RIV-07 |
+| [RIV-09](09-rivalry-detail-shell-overview.md) | Rivalry Detail shell + Overview tab | L | RIV-07 |
+| [RIV-10](10-detail-tabs-matches-promos.md) | Detail tabs: Match History, Future Matches, Promos | M | RIV-09, RIV-06 |
+| [RIV-11](11-detail-tab-notes-plans.md) | Detail tab: Notes & Plans | M | RIV-09, RIV-05 |
+| [RIV-12](12-detail-tab-messages.md) | Detail tab: Messages (audience toggle + polling + optimistic UI) | L | RIV-09, RIV-04 |
+| [RIV-13](13-request-rivalry-form.md) | Request a Rivalry form (2-step) | M | RIV-07 |
+| [RIV-14](14-admin-rivalries-panel.md) | Admin Rivalries moderation panel | M | RIV-02, RIV-07 |
+| [RIV-15](15-routing-nav-dashboard.md) | Routing, nav, Dashboard surface | S | RIV-08, RIV-09, RIV-13, RIV-14 |
+
+## Phase 5 — Polish
+| ID | Title | Estimate | Blocked by |
+|----|-------|----------|------------|
+| [RIV-16](16-localization.md) | Localization (English + German) | S | RIV-08..14 (copy stable) |
+| [RIV-17](17-wiki-articles.md) | Wiki articles (English + German) | S | — |
+| [RIV-18](18-seed-data.md) | Seed data for local development | S | RIV-01, RIV-02, RIV-04, RIV-05 |
+
+## Phase 6 — Verification
+| ID | Title | Estimate | Blocked by |
+|----|-------|----------|------------|
+| [RIV-19](19-end-to-end-verification.md) | End-to-end verification & release readiness | M | every other ticket |
+
+## Suggested order for first 3 sprints
+
+**Sprint 1 (foundation can ship to devtest with no UI):** RIV-01 → RIV-02 → RIV-06 → RIV-05 → RIV-04 → RIV-03 → RIV-07. Backend complete + API client wired.
+
+**Sprint 2 (UI shell & primary flows):** RIV-08, RIV-09, RIV-13, RIV-14 in parallel. RIV-15 lands once those four are in.
+
+**Sprint 3 (depth + polish):** RIV-10, RIV-11, RIV-12 in parallel. RIV-16, RIV-17, RIV-18 in parallel. RIV-19 closes out.
+
+## Estimate legend
+- **S** — small (≤1 day of focused work)
+- **M** — medium (2-3 days)
+- **L** — large (3-5 days; consider sub-splitting on the board if it sits in-progress too long)


### PR DESCRIPTION
## Summary
- Backend `removeMember` now permits self-removal in addition to leader/admin removal. The leader is still blocked from leaving via this path and must disband.
- Frontend `MyStable` shows a **Leave Stable** action to non-leader members of an approved/active stable, with a confirmation dialog and the same feedback/refresh pattern as the existing Disband flow.
- Fixes a pre-existing bug in `stablesApi.removeMember` which was hitting a non-existent `DELETE /stables/{id}/members/{playerId}` endpoint instead of `POST /stables/{id}/remove-member` with `{ playerId }` body.

## Notes
- Existing auto-disband-on-1-member logic still applies: if a self-leave drops the stable to just the leader, the stable is auto-disbanded and the leader's `stableId` is cleared.
- Backend `tsc` passes clean. Frontend `tsc` shows the same pre-existing `MenuModeContext` casing errors that exist on `main` (none touch the changed files).

## Test plan
- [ ] As a non-leader member of an approved/active stable, click **Leave Stable**, confirm, and verify the stable disappears from "My Stable" and the player is no longer listed in members on the stable detail page.
- [ ] As the stable leader, verify **Leave Stable** is **not** rendered (only Disband / Invite remain).
- [ ] As a non-leader, leave a stable that has only 2 members (you + leader). Verify the stable auto-disbands and the leader's `stableId` is cleared.
- [ ] As a stable leader, verify removing a member from the manage UI still works end-to-end (regression check on the API client path fix).
- [ ] Verify a request to `POST /stables/{id}/remove-member` with the leader's `playerId` returns the "leader cannot leave" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)