### PR TITLE
feat(events): visually nest match slots inside their match card

### DIFF
--- a/frontend/src/components/events/EventDetail.css
+++ b/frontend/src/components/events/EventDetail.css
@@ -157,6 +157,14 @@
   gap: 0;
 }
 
+/* When slots follow a match card, drop the match-entry's bottom rounding so
+ * the slot section reads as a flush footer of the same card. */
+.match-entry-with-actions.has-slots .match-entry {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 14px;
+}
+
 .match-entry-actions {
   display: flex;
   gap: 8px;

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -412,9 +412,13 @@ export default function EventDetail() {
     const rawMatch = scheduledMatchesById.get(match.matchId);
 
     const slots = match.matchData?.slots;
+    const hasSlots = !!(slots && slots.length > 0);
 
     return (
-      <div key={match.matchId} className="match-entry-with-actions">
+      <div
+        key={match.matchId}
+        className={`match-entry-with-actions${hasSlots ? ' has-slots' : ''}`}
+      >
         <MatchEntry
           match={match}
           isCompleted={match.matchData?.status === 'completed'}

--- a/frontend/src/components/events/MatchSlots.css
+++ b/frontend/src/components/events/MatchSlots.css
@@ -1,23 +1,60 @@
+/*
+ * MatchSlots renders flush inside its parent match-entry card. We use tonal
+ * stacking (no borders) to keep the slots clearly grouped with their match
+ * even when many matches are stacked on the page.
+ */
 .match-slots {
-  margin-top: 12px;
-  padding: 10px 12px;
-  background: #1f1f1f;
-  border: 1px solid #333;
-  border-radius: 6px;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+
+/* Inner "nested well": the visible slot area uses a darker tone than the
+ * match-entry card behind it, with a subtle top divider, to read as a
+ * footer section of the same card. */
+.match-slots-inner {
+  padding: 10px 14px 12px 14px;
+  background: rgba(0, 0, 0, 0.28);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+/* Header row inside the slot section: small uppercase label + open-count. */
+.match-slots-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #c0a060;
+}
+
+.match-slots-header-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.match-slots-header-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: #fbbf24;
+  border-radius: 50%;
 }
 
 .match-slots-badge {
-  display: inline-block;
-  margin-bottom: 8px;
-  padding: 3px 10px;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 700;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #fbbf24;
-  background: rgba(251, 191, 36, 0.12);
-  border: 1px solid rgba(251, 191, 36, 0.4);
-  border-radius: 999px;
 }
 
 .match-slots-list {
@@ -26,7 +63,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .match-slot {

--- a/frontend/src/components/events/MatchSlots.tsx
+++ b/frontend/src/components/events/MatchSlots.tsx
@@ -85,33 +85,47 @@ export default function MatchSlots(props: MatchSlotsProps) {
     const rows = loadingCount ?? Math.max(slots.length, 2);
     return (
       <div className="match-slots" data-match-id={matchId} role="status" aria-busy="true">
-        <ol className="match-slots-list">
-          {Array.from({ length: rows }, (_, i) => (
-            <li key={i} className="match-slot match-slot-skeleton">
-              <span className="match-slot-position">·</span>
-              <span className="match-slot-content">
-                <span className="match-slot-skeleton-bar" />
-              </span>
-            </li>
-          ))}
-        </ol>
+        <div className="match-slots-inner">
+          <ol className="match-slots-list">
+            {Array.from({ length: rows }, (_, i) => (
+              <li key={i} className="match-slot match-slot-skeleton">
+                <span className="match-slot-position">·</span>
+                <span className="match-slot-content">
+                  <span className="match-slot-skeleton-bar" />
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
       </div>
     );
   }
 
+  const isOpenSignups = matchStatus === 'open-signups';
+  const headerLabel = isOpenSignups
+    ? t('matches.slots.openSpotsHeader', { defaultValue: 'Open spots' })
+    : t('matches.slots.spotsHeader', { defaultValue: 'Spots' });
+
   return (
     <div className="match-slots" data-match-id={matchId}>
-      {matchStatus === 'open-signups' && (
-        <div className="match-slots-badge" role="status">
-          {t('matches.slots.openCountBadge', {
-            open: openCount,
-            total: sortedSlots.length,
-            defaultValue: `${openCount} of ${sortedSlots.length} spots open`,
-          })}
+      <div className="match-slots-inner">
+        <div className="match-slots-header">
+          <span className="match-slots-header-label">
+            {isOpenSignups && <span className="match-slots-header-dot" aria-hidden="true" />}
+            {headerLabel}
+          </span>
+          {isOpenSignups && (
+            <span className="match-slots-badge" role="status">
+              {t('matches.slots.openCountBadge', {
+                open: openCount,
+                total: sortedSlots.length,
+                defaultValue: `${openCount} of ${sortedSlots.length} spots open`,
+              })}
+            </span>
+          )}
         </div>
-      )}
 
-      <ol className="match-slots-list">
+        <ol className="match-slots-list">
         {sortedSlots.map((slot) => {
           const filled = !!slot.playerId;
           const isMine = filled && slot.playerId === currentPlayerId;
@@ -202,7 +216,8 @@ export default function MatchSlots(props: MatchSlotsProps) {
             </li>
           );
         })}
-      </ol>
+        </ol>
+      </div>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -461,7 +461,9 @@
       "teamLabelPlaceholder": "Team (optional)",
       "signupModeToggle": "Match für Anmeldungen öffnen",
       "slotsRequiredLabel": "Anzahl der Plätze",
-      "editorLabel": "Plätze"
+      "editorLabel": "Plätze",
+      "openSpotsHeader": "Freie Plätze",
+      "spotsHeader": "Plätze"
     }
   },
   "matchSearch": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -461,7 +461,9 @@
       "teamLabelPlaceholder": "Team (optional)",
       "signupModeToggle": "Open match for signups",
       "slotsRequiredLabel": "Number of spots",
-      "editorLabel": "Slots"
+      "editorLabel": "Slots",
+      "openSpotsHeader": "Open spots",
+      "spotsHeader": "Spots"
     }
   },
   "matchSearch": {


### PR DESCRIPTION
## Summary
Stacked on top of `feat/match-slot-signups` (the MSL-01/02 branch). Targets that branch, not main.

Fixes a UX issue: with multiple matches on an Event Detail page, the slot list rendered as its own bordered card below each match, making it ambiguous which match a given slot list belonged to. Re-grounded so the slot section is a visually flush footer of the match card it describes — same card, no air gap, tonal-stacked "nested well" effect.

## What changed
- **`.match-entry-with-actions`** picks up a `has-slots` class on the wrapper when slots are present; that drops `match-entry`'s bottom border-radius so the slot section reads as a continuation of the same card.
- **`MatchSlots`** lost its own background, border, border-radius, and `margin-top`. The slot list now lives inside a new `.match-slots-inner` well that shifts to a darker tone over the match-entry surface, with a 1px top divider and bottom corners matching the parent card.
- **New header row** inside the slot section: small uppercase "Open spots" / "Spots" label with the open-count badge inline on its right (only on `open-signups` matches). Replaces the floating badge that used to sit above the list.
- **i18n** — added `matches.slots.openSpotsHeader` and `matches.slots.spotsHeader` in EN + DE.

Designed via the Stitch MCP using the project's existing "Prestige Brutalism" design system (dark + gold, tonal stacking instead of borders).

## Test plan
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `cd frontend && npx vitest run` — 445/445 pass (the 11 MatchSlots tests still hold; nothing about the public component contract changed)
- [ ] Manual: load an event with two slot-mode matches stacked, confirm each slot list visually belongs to the match card it sits inside; confirm legacy non-slot matches unaffected; confirm "Open spots · X of N open" reads at the top of the slot section instead of floating above

## Merge order
This PR merges into `feat/match-slot-signups`. After that branch goes to main, this lands too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)