### PR TITLE
fix(matches): drop updatedAt from slot-handler patches

### DIFF
--- a/backend/functions/matches/__tests__/claimSlot.test.ts
+++ b/backend/functions/matches/__tests__/claimSlot.test.ts
@@ -107,6 +107,11 @@ describe('claimSlot', () => {
       '2024-06-01T00:00:00Z',
       expect.objectContaining({ status: 'open-signups' }),
     );
+    // Regression: DynamoUnitOfWork.updateMatch appends updatedAt itself, so
+    // including it in the patch would set the same path twice and DynamoDB
+    // rejects the UpdateExpression.
+    const patch = (tx.updateMatch as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    expect(patch).not.toHaveProperty('updatedAt');
   });
 
   it('flips status to scheduled when claiming the last open slot', async () => {

--- a/backend/functions/matches/adminUpdateSlot.ts
+++ b/backend/functions/matches/adminUpdateSlot.ts
@@ -80,12 +80,13 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           ? 'open-signups'
           : 'scheduled';
 
+    // DynamoUnitOfWork.updateMatch appends updatedAt itself; passing it again
+    // here would set the same path twice and fail validation.
     await runInTransaction(async (tx) => {
       tx.updateMatch(matchId, match.date, {
         slots: updatedSlots,
         participants: updatedParticipants,
         status: newStatus,
-        updatedAt: now,
       });
     });
 

--- a/backend/functions/matches/claimSlot.ts
+++ b/backend/functions/matches/claimSlot.ts
@@ -107,12 +107,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       ? 'open-signups'
       : 'scheduled';
 
+    // Note: don't pass `updatedAt` in the patch — DynamoUnitOfWork.updateMatch
+    // appends it automatically and DynamoDB rejects an UpdateExpression that
+    // sets the same path twice with a ValidationException.
     await runInTransaction(async (tx) => {
       tx.updateMatch(matchId, match.date, {
         slots: updatedSlots,
         participants: updatedParticipants,
         status: newStatus,
-        updatedAt: now,
       });
     });
 

--- a/backend/functions/matches/releaseSlot.ts
+++ b/backend/functions/matches/releaseSlot.ts
@@ -87,12 +87,13 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const updatedParticipants = dedupeFilledPlayerIds(updatedSlots);
     const newStatus: MatchStatus = 'open-signups';
 
+    // DynamoUnitOfWork.updateMatch appends updatedAt itself; passing it again
+    // here would set the same path twice and fail validation.
     await runInTransaction(async (tx) => {
       tx.updateMatch(matchId, match.date, {
         slots: updatedSlots,
         participants: updatedParticipants,
         status: newStatus,
-        updatedAt: now,
       });
     });
 


### PR DESCRIPTION
## Summary
Targets `feat/match-slot-signups` (the branch PR #320 tracks). Re-files the fix that landed in PR #322 — that commit was made after #322 had already been merged, so the fix is sitting on a closed branch and never made it to `feat/match-slot-signups`.

## What & why
**Symptom:** clicking "Claim spot" on a match slot returned a 500 with the generic message "Failed to claim slot."

**Root cause:** `claimSlot`, `releaseSlot`, and `adminUpdateSlot` were all passing `updatedAt: now` inside the patch handed to `tx.updateMatch`. But [`DynamoUnitOfWork.updateMatch`](backend/lib/repositories/dynamo/DynamoUnitOfWork.ts#L329) appends `updatedAt` to the `UpdateExpression` itself, so the generated expression set the same path twice. DynamoDB rejects that with `ValidationException: Two document paths overlap`, the handler's catch block swallowed the throw and returned the 500.

The earlier "Event has already started" 409 on this same flow was masking the underlying issue — once that gate was lifted, the duplicate-path bug surfaced.

## Fix
- Removed `updatedAt` from the patch in all three slot handlers. The UoW continues to write it; the returned `updated` object still surfaces the same `now` value to the caller for read-after-write display, so no API contract changes.
- Added a regression assertion in `claimSlot.test.ts` that the patch passed to `tx.updateMatch` never contains `updatedAt`, so this can't slip back in silently.

## Test plan
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd backend && npx vitest run functions/matches` — 115 passed
- [ ] Deploy: `cd backend && npx serverless deploy --stage devtest --aws-profile league-szn`
- [ ] Manual smoke: Click "Claim spot" on an open slot in an upcoming event → claim succeeds, slot fills with your wrestler, badge updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)