### PR TITLE
feat(matches): one slot per event card (MSL-04)

### DIFF
--- a/backend/functions/matches/__tests__/claimSlot.test.ts
+++ b/backend/functions/matches/__tests__/claimSlot.test.ts
@@ -5,11 +5,13 @@ import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
 
 const {
   mockMatchesFindByIdWithDate,
+  mockMatchesFindById,
   mockPlayersFindByUserId,
   mockEventsFindById,
   mockRunInTransaction,
 } = vi.hoisted(() => ({
   mockMatchesFindByIdWithDate: vi.fn(),
+  mockMatchesFindById: vi.fn(),
   mockPlayersFindByUserId: vi.fn(),
   mockEventsFindById: vi.fn(),
   mockRunInTransaction: vi.fn(),
@@ -18,7 +20,10 @@ const {
 vi.mock('../../../lib/repositories', () => ({
   getRepositories: () => ({
     competition: {
-      matches: { findByIdWithDate: mockMatchesFindByIdWithDate },
+      matches: {
+        findByIdWithDate: mockMatchesFindByIdWithDate,
+        findById: mockMatchesFindById,
+      },
     },
     leagueOps: {
       events: { findById: mockEventsFindById },
@@ -262,5 +267,110 @@ describe('claimSlot', () => {
 
     const r = await claimSlot(ev(), ctx, cb);
     expect(r!.statusCode).toBe(409);
+  });
+
+  // ── MSL-04: one slot per event card ────────────────────────────────────
+
+  it('rejects a claim when caller already occupies a slot on another match of the same event', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(
+      makeMatch({ eventId: 'e1', matchId: 'm-target' }),
+    );
+    mockEventsFindById.mockResolvedValue({
+      eventId: 'e1',
+      status: 'upcoming',
+      date: '2999-01-01T00:00:00Z',
+      matchCards: [
+        { matchId: 'm-target', position: 1, designation: 'midcard' },
+        { matchId: 'm-other', position: 2, designation: 'midcard' },
+      ],
+    });
+    mockMatchesFindById.mockImplementation(async (id: string) => {
+      if (id === 'm-other') {
+        return {
+          matchId: 'm-other',
+          slots: [
+            { slotId: 'o1', position: 1, playerId: 'p-caller', claimedAt: '2024-05-30T00:00:00Z' },
+            { slotId: 'o2', position: 2 },
+          ],
+        };
+      }
+      return null;
+    });
+    captureTx();
+
+    const r = await claimSlot(
+      ev({ pathParameters: { matchId: 'm-target', slotId: 's1' } }),
+      ctx,
+      cb,
+    );
+    expect(r!.statusCode).toBe(409);
+    expect(JSON.parse(r!.body).message).toContain('another match');
+    expect(mockRunInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('allows a claim when caller occupies a slot on a different event', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(
+      makeMatch({ eventId: 'e1' }),
+    );
+    mockEventsFindById.mockResolvedValue({
+      eventId: 'e1',
+      status: 'upcoming',
+      date: '2999-01-01T00:00:00Z',
+      matchCards: [
+        // Only this match — no siblings on this event card.
+        { matchId: 'm1', position: 1, designation: 'midcard' },
+      ],
+    });
+    captureTx();
+
+    const r = await claimSlot(ev(), ctx, cb);
+    expect(r!.statusCode).toBe(200);
+    expect(mockMatchesFindById).not.toHaveBeenCalled();
+  });
+
+  it('allows a claim when sibling matches have no slots (legacy match in same event)', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(
+      makeMatch({ eventId: 'e1', matchId: 'm-target' }),
+    );
+    mockEventsFindById.mockResolvedValue({
+      eventId: 'e1',
+      status: 'upcoming',
+      date: '2999-01-01T00:00:00Z',
+      matchCards: [
+        { matchId: 'm-target', position: 1, designation: 'midcard' },
+        { matchId: 'm-legacy', position: 2, designation: 'midcard' },
+      ],
+    });
+    mockMatchesFindById.mockResolvedValue({
+      matchId: 'm-legacy',
+      slots: undefined, // legacy non-slot match
+    });
+    captureTx();
+
+    const r = await claimSlot(
+      ev({ pathParameters: { matchId: 'm-target', slotId: 's1' } }),
+      ctx,
+      cb,
+    );
+    expect(r!.statusCode).toBe(200);
+  });
+
+  it('idempotent re-claim short-circuits before the cross-match check (no event load)', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(
+      makeMatch({
+        eventId: 'e1',
+        slots: [
+          { slotId: 's1', position: 1, playerId: 'p-caller', claimedAt: '2024-05-30T00:00:00Z' },
+          { slotId: 's2', position: 2 },
+        ],
+        participants: ['p-caller'],
+      }),
+    );
+
+    const r = await claimSlot(ev(), ctx, cb);
+    expect(r!.statusCode).toBe(200);
+    expect(mockEventsFindById).not.toHaveBeenCalled();
+    expect(mockMatchesFindById).not.toHaveBeenCalled();
+    expect(mockRunInTransaction).not.toHaveBeenCalled();
   });
 });

--- a/backend/functions/matches/claimSlot.ts
+++ b/backend/functions/matches/claimSlot.ts
@@ -79,15 +79,44 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return conflict('You already occupy another slot in this match');
     }
 
-    // Event-level gate: trust the admin-controlled status. We do NOT reject
-    // based on `event.date` being in the past — date-only strings parse as
-    // midnight UTC, so a same-day event would be falsely blocked anywhere
-    // east of UTC after midnight local time. The admin advances status to
+    // Event-level checks: load the event once (if any) and use it for both
+    // the status gate and the one-claim-per-event-card rule (MSL-04).
+    const linkedEvent = match.eventId
+      ? await eventsRepo.findById(match.eventId)
+      : null;
+
+    // Trust the admin-controlled status. We do NOT reject based on
+    // `event.date` being in the past — date-only strings parse as midnight
+    // UTC, so a same-day event would be falsely blocked anywhere east of
+    // UTC after midnight local time. The admin advances status to
     // 'in-progress' / 'completed' to lock signups; that's authoritative.
-    if (match.eventId) {
-      const linkedEvent = await eventsRepo.findById(match.eventId);
-      if (linkedEvent && (linkedEvent.status === 'completed' || linkedEvent.status === 'cancelled')) {
-        return conflict('Event is no longer accepting signups');
+    if (linkedEvent && (linkedEvent.status === 'completed' || linkedEvent.status === 'cancelled')) {
+      return conflict('Event is no longer accepting signups');
+    }
+
+    // MSL-04: a wrestler may hold at most one slot across the entire event
+    // card. Walk every other match on this event and reject if the caller
+    // already occupies a slot anywhere. Admin force-assign via
+    // adminUpdateSlot bypasses this — that path is intentional for cameos
+    // and run-ins.
+    if (linkedEvent && linkedEvent.matchCards && linkedEvent.matchCards.length > 0) {
+      const otherMatchIds = linkedEvent.matchCards
+        .map((c) => c.matchId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0 && id !== matchId);
+
+      if (otherMatchIds.length > 0) {
+        const siblings = await Promise.all(
+          otherMatchIds.map((id) => matches.findById(id)),
+        );
+        const alreadyBooked = siblings.some((sib) => {
+          if (!sib || !sib.slots) return false;
+          return sib.slots.some((s) => s.playerId === callerPlayerId);
+        });
+        if (alreadyBooked) {
+          return conflict(
+            'You already have a slot in another match on this event — release that one first',
+          );
+        }
       }
     }
 

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -377,6 +377,18 @@ export default function EventDetail() {
     (m) => m.designation !== 'pre-show'
   );
 
+  // MSL-04: a wrestler can only hold one slot across the whole event card.
+  // If the viewing user already occupies a slot in any match on this event,
+  // we record that matchId so we can disable the Claim button on every
+  // OTHER match. The user's own match keeps Claim enabled (idempotent
+  // re-claim is a no-op, and matters for the rare case where they want to
+  // move within the same match — though MSL-01 already prevents that).
+  const userOccupiedMatchId: string | null = playerId
+    ? (enrichedMatches.find((m) =>
+        m.matchData?.slots?.some((s) => s.playerId === playerId),
+      )?.matchId ?? null)
+    : null;
+
   const renderStarRating = (rating: number) => {
     const full = Math.floor(rating);
     const half = rating % 1 >= 0.5;
@@ -454,6 +466,12 @@ export default function EventDetail() {
             onAdminEdit={isAdminOrModerator
               ? (slot) => handleAdminEditSlot(match.matchId, slot)
               : undefined}
+            claimDisabled={
+              !!userOccupiedMatchId && userOccupiedMatchId !== match.matchId
+            }
+            disableClaimReason={t('matches.slots.alreadyBookedTooltip', {
+              defaultValue: 'You already have a slot in another match on this event',
+            })}
           />
         )}
         {isRecording && rawMatch && (

--- a/frontend/src/components/events/MatchSlots.tsx
+++ b/frontend/src/components/events/MatchSlots.tsx
@@ -26,6 +26,14 @@ export interface MatchSlotsProps {
   loading?: boolean;
   /** Number of skeleton rows when loading. Defaults to slots.length or 2. */
   loadingCount?: number;
+  /**
+   * When true, disable the Claim button for every slot in this match
+   * (MSL-04: one slot per event card). Release on the user's own slot is
+   * unaffected — they need to be able to give up their existing claim.
+   */
+  claimDisabled?: boolean;
+  /** Tooltip / hint shown on the disabled Claim button. */
+  disableClaimReason?: string;
 }
 
 /**
@@ -47,6 +55,8 @@ export default function MatchSlots(props: MatchSlotsProps) {
     onLoginRequired,
     loading = false,
     loadingCount,
+    claimDisabled = false,
+    disableClaimReason,
   } = props;
   const { t } = useTranslation();
   const [busySlotId, setBusySlotId] = useState<string | null>(null);
@@ -183,7 +193,8 @@ export default function MatchSlots(props: MatchSlotsProps) {
                   <button
                     type="button"
                     className="match-slot-btn match-slot-claim"
-                    disabled={busy}
+                    disabled={busy || claimDisabled}
+                    title={claimDisabled ? disableClaimReason : undefined}
                     onClick={() => handleClaim(slot.slotId)}
                   >
                     {busy

--- a/frontend/src/components/events/__tests__/MatchSlots.test.tsx
+++ b/frontend/src/components/events/__tests__/MatchSlots.test.tsx
@@ -179,4 +179,39 @@ describe('MatchSlots', () => {
       's-third',
     ]);
   });
+
+  // ── MSL-04: one slot per event card ────────────────────────────────────
+
+  it('disables Claim and exposes the reason as a tooltip when claimDisabled is true', async () => {
+    const onClaim = vi.fn();
+    const user = userEvent.setup();
+    renderSlots({
+      slots: [open()],
+      isAuthenticated: true,
+      onClaim,
+      claimDisabled: true,
+      disableClaimReason: 'You already have a slot in another match on this event',
+    });
+    const btn = screen.getByRole('button', { name: 'Claim spot' });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute(
+      'title',
+      'You already have a slot in another match on this event',
+    );
+    await user.click(btn);
+    expect(onClaim).not.toHaveBeenCalled();
+  });
+
+  it('still allows Release on the user\'s own slot even when claimDisabled is true', () => {
+    renderSlots({
+      slots: [
+        filled({ slotId: 's-mine', playerId: 'me', playerName: 'Me', wrestlerName: 'X' }),
+      ],
+      currentPlayerId: 'me',
+      isAuthenticated: true,
+      claimDisabled: true,
+      disableClaimReason: 'unused',
+    });
+    expect(screen.getByRole('button', { name: 'Release' })).not.toBeDisabled();
+  });
 });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -463,7 +463,9 @@
       "slotsRequiredLabel": "Anzahl der Plätze",
       "editorLabel": "Plätze",
       "openSpotsHeader": "Freie Plätze",
-      "spotsHeader": "Plätze"
+      "spotsHeader": "Plätze",
+      "alreadyBookedOnEvent": "Du hast bereits einen Platz in einem anderen Match dieser Veranstaltung — gib ihn erst frei",
+      "alreadyBookedTooltip": "Du hast bereits einen Platz in einem anderen Match dieser Veranstaltung"
     }
   },
   "matchSearch": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -463,7 +463,9 @@
       "slotsRequiredLabel": "Number of spots",
       "editorLabel": "Slots",
       "openSpotsHeader": "Open spots",
-      "spotsHeader": "Spots"
+      "spotsHeader": "Spots",
+      "alreadyBookedOnEvent": "You already have a slot in another match on this event — release that one first",
+      "alreadyBookedTooltip": "You already have a slot in another match on this event"
     }
   },
   "matchSearch": {


### PR DESCRIPTION
## Summary
Targets `feat/match-slot-signups`, not main.

Implements **MSL-04**: a wrestler can hold at most one claimed slot across an event's match card. Trying to claim a second slot on a different match in the same event fails with a clear 409. Releasing then re-claiming elsewhere works as today. Admins are unaffected — `adminUpdateSlot` was never gated by self-claim rules and stays that way (still useful for cameos / run-ins).

## Why
- **Overbooking.** Until now a wrestler could claim Match 2 *and* Match 5 of the same show; the schedule double-counts them.
- **Fairness.** Without a per-event cap, the first 3 people online could fill 3 slots each and lock out the rest of the roster. The cap makes the signup queue self-balancing — once a popular wrestler claims their match, the rest of the card stays open.

## Subtasks (one commit each)
- `0ef18cc` — backend `claimSlot` cross-match check
- `995e0a2` — frontend disabled-state in `MatchSlots` + `EventDetail`
- `510d082` — i18n EN + DE (`matches.slots.alreadyBookedOnEvent`, `alreadyBookedTooltip`)
- `6da22a3` — Vitest coverage (4 backend, 2 frontend)

## How
**Backend** ([claimSlot.ts](backend/functions/matches/claimSlot.ts)) — after the existing in-match dup check, load the event once (we needed it for the status gate anyway), then walk every other matchCard entry, fetch them in parallel, and reject 409 if the caller occupies any slot on any of them. Standalone matches and matches whose event has empty matchCards are unaffected.

**Frontend** ([EventDetail.tsx](frontend/src/components/events/EventDetail.tsx)) — scan the event's `enrichedMatches` once per render to find which match the viewer occupies a slot in, if any. For every OTHER match, pass `claimDisabled={true}` and a `disableClaimReason` tooltip into `MatchSlots`. The Claim button on those slots renders disabled with a hint, pre-empting the backend round-trip in the common case. The user's own match keeps Claim enabled (idempotent re-claim is fine), and Release is always available so the user can give up their existing claim before booking elsewhere.

## Test plan
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `cd backend && npx vitest run functions/matches` — 119 passed (4 new MSL-04 backend cases)
- [x] `cd frontend && npx vitest run` — 447 passed (2 new MSL-04 MatchSlots cases)
- [ ] Manual smoke (after deploy):
  - On an event with two slot-mode matches, claim a slot on Match 1 → Match 2's open slots show disabled `Claim spot` with the tooltip.
  - Direct API attempt against Match 2 returns 409 with the friendly message; the existing error region surfaces it.
  - Release on Match 1 → Match 2's Claim re-enables; click and it goes through.
  - Different event entirely → same wrestler can claim freely (no cross-event interference).
  - Admin force-assigning the same wrestler to multiple slots on the same event still succeeds.
  - Standalone matches (no eventId) unaffected.

## Out of scope (deliberate)
- Cross-event constraints (calendar-level overlapping events) — separate feature.
- Tag-team / multi-team modeling where two players share one "slot" — out per MSL-01.
- One-click "swap match" affordance — two clicks (Release → Claim) is fine for v1; auto-swap would silently destroy the user's first claim if they didn't realize.
- Prompt-on-claim flow ("Move your claim from Match 2 to Match 5?") — hard reject keeps users in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)