### PR TITLE
feat(matches): wrestler choice on slot claim (MSL-03)

### DIFF
--- a/backend/functions/matches/__tests__/adminUpdateSlot.test.ts
+++ b/backend/functions/matches/__tests__/adminUpdateSlot.test.ts
@@ -229,4 +229,103 @@ describe('adminUpdateSlot', () => {
     expect(b.status).toBe('completed');
     expect(b.slots[0].teamLabel).toBe('A');
   });
+
+  // ── MSL-03: wrestler choice + snapshot ─────────────────────────────────
+
+  it('force-assigns with silent main default when wrestlerChoice omitted', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(makeMatch());
+    mockPlayersFindById.mockResolvedValue({
+      playerId: 'p1',
+      currentWrestler: 'Stone Cold',
+      alternateWrestler: 'The Rock',
+    });
+    captureTx();
+
+    const r = await adminUpdateSlot(ev({ playerId: 'p1' }), ctx, cb);
+    expect(r!.statusCode).toBe(200);
+    const b = JSON.parse(r!.body);
+    expect(b.slots[0].wrestlerChoice).toBe('main');
+    expect(b.slots[0].wrestlerNameSnapshot).toBe('Stone Cold');
+  });
+
+  it('force-assigns with explicit wrestlerChoice="alternate"', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(makeMatch());
+    mockPlayersFindById.mockResolvedValue({
+      playerId: 'p1',
+      currentWrestler: 'Stone Cold',
+      alternateWrestler: 'The Rock',
+    });
+    captureTx();
+
+    const r = await adminUpdateSlot(
+      ev({ playerId: 'p1', wrestlerChoice: 'alternate' }),
+      ctx,
+      cb,
+    );
+    expect(r!.statusCode).toBe(200);
+    const b = JSON.parse(r!.body);
+    expect(b.slots[0].wrestlerChoice).toBe('alternate');
+    expect(b.slots[0].wrestlerNameSnapshot).toBe('The Rock');
+  });
+
+  it('clearing a slot wipes wrestlerChoice and wrestlerNameSnapshot', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(
+      makeMatch({
+        status: 'scheduled',
+        slots: [
+          {
+            slotId: 's1',
+            position: 1,
+            playerId: 'p1',
+            claimedAt: '2024-05-30T00:00:00Z',
+            wrestlerChoice: 'alternate',
+            wrestlerNameSnapshot: 'The Rock',
+          },
+          { slotId: 's2', position: 2, playerId: 'p2', claimedAt: '2024-05-30T00:00:00Z' },
+        ],
+        participants: ['p1', 'p2'],
+      }),
+    );
+    captureTx();
+
+    const r = await adminUpdateSlot(ev({ playerId: null }), ctx, cb);
+    expect(r!.statusCode).toBe(200);
+    const b = JSON.parse(r!.body);
+    expect(b.slots[0].playerId).toBeUndefined();
+    expect(b.slots[0].wrestlerChoice).toBeUndefined();
+    expect(b.slots[0].wrestlerNameSnapshot).toBeUndefined();
+  });
+
+  it('switching wrestlerChoice without changing playerId recomputes the snapshot', async () => {
+    mockMatchesFindByIdWithDate.mockResolvedValue(
+      makeMatch({
+        status: 'scheduled',
+        slots: [
+          {
+            slotId: 's1',
+            position: 1,
+            playerId: 'p1',
+            claimedAt: '2024-05-30T00:00:00Z',
+            wrestlerChoice: 'main',
+            wrestlerNameSnapshot: 'Stone Cold',
+          },
+          { slotId: 's2', position: 2, playerId: 'p2', claimedAt: '2024-05-30T00:00:00Z' },
+        ],
+        participants: ['p1', 'p2'],
+      }),
+    );
+    mockPlayersFindById.mockResolvedValue({
+      playerId: 'p1',
+      currentWrestler: 'Stone Cold',
+      alternateWrestler: 'The Rock',
+    });
+    captureTx();
+
+    const r = await adminUpdateSlot(ev({ wrestlerChoice: 'alternate' }), ctx, cb);
+    expect(r!.statusCode).toBe(200);
+    const b = JSON.parse(r!.body);
+    expect(b.slots[0].playerId).toBe('p1'); // unchanged
+    expect(b.slots[0].wrestlerChoice).toBe('alternate');
+    expect(b.slots[0].wrestlerNameSnapshot).toBe('The Rock');
+  });
 });

--- a/backend/functions/matches/__tests__/claimSlot.test.ts
+++ b/backend/functions/matches/__tests__/claimSlot.test.ts
@@ -92,7 +92,12 @@ function captureTx(): FakeTx {
 describe('claimSlot', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPlayersFindByUserId.mockResolvedValue({ playerId: 'p-caller' });
+    // Default: caller has only a main wrestler (no alternate). Tests that need
+    // both override this resolution to add `alternateWrestler`.
+    mockPlayersFindByUserId.mockResolvedValue({
+      playerId: 'p-caller',
+      currentWrestler: 'Stone Cold',
+    });
   });
 
   it('claims an open slot and stays open-signups when other slots remain', async () => {
@@ -372,5 +377,77 @@ describe('claimSlot', () => {
     expect(mockEventsFindById).not.toHaveBeenCalled();
     expect(mockMatchesFindById).not.toHaveBeenCalled();
     expect(mockRunInTransaction).not.toHaveBeenCalled();
+  });
+
+  // ── MSL-03: wrestler choice + snapshot ─────────────────────────────────
+
+  it('defaults to main and snapshots currentWrestler when player has no alternate', async () => {
+    mockPlayersFindByUserId.mockResolvedValue({
+      playerId: 'p-caller',
+      currentWrestler: 'Stone Cold',
+      // alternateWrestler not set
+    });
+    mockMatchesFindByIdWithDate.mockResolvedValue(makeMatch());
+    const tx = captureTx();
+
+    const r = await claimSlot(ev(), ctx, cb);
+    expect(r!.statusCode).toBe(200);
+    const b = JSON.parse(r!.body);
+    expect(b.slots[0].wrestlerChoice).toBe('main');
+    expect(b.slots[0].wrestlerNameSnapshot).toBe('Stone Cold');
+    // Persisted patch carries the same fields
+    const patch = tx.updateMatch.mock.calls[0][2];
+    expect(patch.slots[0].wrestlerChoice).toBe('main');
+    expect(patch.slots[0].wrestlerNameSnapshot).toBe('Stone Cold');
+  });
+
+  it('honors body wrestlerChoice="alternate" and snapshots alternateWrestler', async () => {
+    mockPlayersFindByUserId.mockResolvedValue({
+      playerId: 'p-caller',
+      currentWrestler: 'Stone Cold',
+      alternateWrestler: 'The Rock',
+    });
+    mockMatchesFindByIdWithDate.mockResolvedValue(makeMatch());
+    captureTx();
+
+    const r = await claimSlot(
+      ev({ body: JSON.stringify({ wrestlerChoice: 'alternate' }) }),
+      ctx,
+      cb,
+    );
+    expect(r!.statusCode).toBe(200);
+    const b = JSON.parse(r!.body);
+    expect(b.slots[0].wrestlerChoice).toBe('alternate');
+    expect(b.slots[0].wrestlerNameSnapshot).toBe('The Rock');
+  });
+
+  it('rejects 400 when player has both and body is missing wrestlerChoice', async () => {
+    mockPlayersFindByUserId.mockResolvedValue({
+      playerId: 'p-caller',
+      currentWrestler: 'Stone Cold',
+      alternateWrestler: 'The Rock',
+    });
+    mockMatchesFindByIdWithDate.mockResolvedValue(makeMatch());
+
+    const r = await claimSlot(ev(), ctx, cb); // no body
+    expect(r!.statusCode).toBe(400);
+    expect(JSON.parse(r!.body).message).toContain('wrestlerChoice');
+    expect(mockRunInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects 400 when player has both and wrestlerChoice is invalid', async () => {
+    mockPlayersFindByUserId.mockResolvedValue({
+      playerId: 'p-caller',
+      currentWrestler: 'Stone Cold',
+      alternateWrestler: 'The Rock',
+    });
+    mockMatchesFindByIdWithDate.mockResolvedValue(makeMatch());
+
+    const r = await claimSlot(
+      ev({ body: JSON.stringify({ wrestlerChoice: 'maybe' }) }),
+      ctx,
+      cb,
+    );
+    expect(r!.statusCode).toBe(400);
   });
 });

--- a/backend/functions/matches/__tests__/hydrateSlots.test.ts
+++ b/backend/functions/matches/__tests__/hydrateSlots.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import type { MatchSlot, Player } from '../../../lib/repositories/types';
+import { hydrateMatchSlots, collectSlotPlayerIds } from '../hydrateSlots';
+
+const player = (over: Partial<Player> = {}): Player => ({
+  playerId: 'p1',
+  name: 'Doe',
+  currentWrestler: 'Stone Cold',
+  wins: 0,
+  losses: 0,
+  draws: 0,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  ...over,
+});
+
+describe('hydrateMatchSlots', () => {
+  it('falls back to player.currentWrestler when no snapshot is set (legacy slot)', () => {
+    const slots: MatchSlot[] = [
+      { slotId: 's1', position: 1, playerId: 'p1' },
+    ];
+    const lookup = new Map<string, Player>([['p1', player({ currentWrestler: 'Stone Cold' })]]);
+    const out = hydrateMatchSlots(slots, lookup);
+    expect(out[0].wrestlerName).toBe('Stone Cold');
+  });
+
+  it('prefers wrestlerNameSnapshot over the player\'s current wrestler', () => {
+    // MSL-03 snapshot rule: a player who later renamed their gimmick must NOT
+    // retroactively rewrite what was billed for past matches.
+    const slots: MatchSlot[] = [
+      {
+        slotId: 's1',
+        position: 1,
+        playerId: 'p1',
+        wrestlerChoice: 'alternate',
+        wrestlerNameSnapshot: 'The Rock',
+      },
+    ];
+    const lookup = new Map<string, Player>([
+      ['p1', player({ currentWrestler: 'Stone Cold', alternateWrestler: 'Some New Name' })],
+    ]);
+    const out = hydrateMatchSlots(slots, lookup);
+    expect(out[0].wrestlerName).toBe('The Rock');
+    expect(out[0].playerName).toBe('Doe');
+  });
+
+  it('returns "Unknown Wrestler" when neither snapshot nor player record is available', () => {
+    const slots: MatchSlot[] = [
+      { slotId: 's1', position: 1, playerId: 'p-missing' },
+    ];
+    const out = hydrateMatchSlots(slots, new Map());
+    expect(out[0].wrestlerName).toBe('Unknown Wrestler');
+    expect(out[0].playerName).toBe('Unknown Player');
+  });
+
+  it('leaves open (unfilled) slots untouched', () => {
+    const slots: MatchSlot[] = [
+      { slotId: 's1', position: 1 },
+    ];
+    const out = hydrateMatchSlots(slots, new Map());
+    expect(out[0].wrestlerName).toBeUndefined();
+    expect(out[0].playerName).toBeUndefined();
+  });
+});
+
+describe('collectSlotPlayerIds', () => {
+  it('returns unique playerIds from filled slots only', () => {
+    const slots: MatchSlot[] = [
+      { slotId: 's1', position: 1, playerId: 'p1' },
+      { slotId: 's2', position: 2 },
+      { slotId: 's3', position: 3, playerId: 'p1' }, // dup
+      { slotId: 's4', position: 4, playerId: 'p2' },
+    ];
+    expect(collectSlotPlayerIds(slots).sort()).toEqual(['p1', 'p2']);
+  });
+});

--- a/backend/functions/matches/adminUpdateSlot.ts
+++ b/backend/functions/matches/adminUpdateSlot.ts
@@ -17,6 +17,14 @@ interface AdminUpdateSlotBody {
   lockedByAdmin?: boolean;
   /** undefined = no change; null = clear; string = set. */
   teamLabel?: string | null;
+  /**
+   * MSL-03: which of the assigned player's wrestlers to use for this match.
+   * Silent default 'main' when assigning a new player and the body omits
+   * this — admins shouldn't be forced through a radio for every scripted
+   * booking. Honored when explicitly set, including switching the radio on
+   * an existing claimant without changing the player.
+   */
+  wrestlerChoice?: 'main' | 'alternate';
 }
 
 /**
@@ -57,16 +65,57 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const slotIndex = slots.findIndex((s) => s.slotId === slotId);
     if (slotIndex < 0) return notFound('Slot not found');
 
-    // Validate player exists when explicitly assigning. Null clears; undefined
-    // leaves the existing playerId untouched.
-    if (typeof body.playerId === 'string') {
-      const player = await players.findById(body.playerId);
-      if (!player) return notFound(`Player not found: ${body.playerId}`);
-    }
-
     const now = new Date().toISOString();
     const original = slots[slotIndex];
-    const updatedSlot = applySlotPatch(original, body, now);
+
+    // ── Wrestler-choice resolution (MSL-03) ─────────────────────────────
+    // - Clear (playerId: null): wipe playerId, claimedAt, wrestlerChoice,
+    //   wrestlerNameSnapshot — the slot becomes a fresh open spot.
+    // - Re-assign (playerId is a string): fetch that player; resolve choice
+    //   from the body or default silently to 'main'; snapshot the matching
+    //   wrestler name.
+    // - Switch radio only (playerId omitted, wrestlerChoice provided):
+    //   re-fetch the existing claimant's player to recompute the snapshot.
+    // - No relevant change: preserve original.
+    const isClearing = body.playerId === null;
+    const newPlayerId = typeof body.playerId === 'string' ? body.playerId : null;
+
+    let resolvedPlayerId: string | undefined = original.playerId;
+    let resolvedClaimedAt: string | undefined = original.claimedAt;
+    let resolvedChoice: 'main' | 'alternate' | undefined = original.wrestlerChoice;
+    let resolvedSnapshot: string | undefined = original.wrestlerNameSnapshot;
+
+    if (isClearing) {
+      resolvedPlayerId = undefined;
+      resolvedClaimedAt = undefined;
+      resolvedChoice = undefined;
+      resolvedSnapshot = undefined;
+    } else if (newPlayerId !== null) {
+      const player = await players.findById(newPlayerId);
+      if (!player) return notFound(`Player not found: ${newPlayerId}`);
+      resolvedPlayerId = newPlayerId;
+      resolvedClaimedAt = now;
+      resolvedChoice = body.wrestlerChoice === 'alternate' ? 'alternate' : 'main';
+      resolvedSnapshot =
+        resolvedChoice === 'alternate' && player.alternateWrestler
+          ? player.alternateWrestler
+          : player.currentWrestler;
+    } else if (body.wrestlerChoice && original.playerId) {
+      const player = await players.findById(original.playerId);
+      if (!player) return notFound(`Player not found: ${original.playerId}`);
+      resolvedChoice = body.wrestlerChoice === 'alternate' ? 'alternate' : 'main';
+      resolvedSnapshot =
+        resolvedChoice === 'alternate' && player.alternateWrestler
+          ? player.alternateWrestler
+          : player.currentWrestler;
+    }
+
+    const updatedSlot = buildUpdatedSlot(original, body, {
+      playerId: resolvedPlayerId,
+      claimedAt: resolvedClaimedAt,
+      wrestlerChoice: resolvedChoice,
+      wrestlerNameSnapshot: resolvedSnapshot,
+    });
 
     const updatedSlots: MatchSlot[] = slots.map((s, i) => (i === slotIndex ? updatedSlot : s));
     const updatedParticipants = dedupeFilledPlayerIds(updatedSlots);
@@ -105,26 +154,29 @@ export const handler: APIGatewayProxyHandler = async (event) => {
   }
 };
 
-function applySlotPatch(
+interface ResolvedWrestlerFields {
+  playerId: string | undefined;
+  claimedAt: string | undefined;
+  wrestlerChoice: 'main' | 'alternate' | undefined;
+  wrestlerNameSnapshot: string | undefined;
+}
+
+function buildUpdatedSlot(
   original: MatchSlot,
   body: AdminUpdateSlotBody,
-  now: string,
+  resolved: ResolvedWrestlerFields,
 ): MatchSlot {
   const next: MatchSlot = {
     slotId: original.slotId,
     position: original.position,
   };
 
-  // playerId / claimedAt
-  if (body.playerId === null) {
-    // explicit clear
-  } else if (typeof body.playerId === 'string') {
-    next.playerId = body.playerId;
-    next.claimedAt = now;
-  } else if (original.playerId) {
-    next.playerId = original.playerId;
-    if (original.claimedAt) next.claimedAt = original.claimedAt;
-  }
+  // Wrestler fields are pre-resolved (clear / reassign / radio-only / preserve)
+  // — only emit when there's a value, so we don't write `undefined` into Dynamo.
+  if (resolved.playerId) next.playerId = resolved.playerId;
+  if (resolved.claimedAt) next.claimedAt = resolved.claimedAt;
+  if (resolved.wrestlerChoice) next.wrestlerChoice = resolved.wrestlerChoice;
+  if (resolved.wrestlerNameSnapshot) next.wrestlerNameSnapshot = resolved.wrestlerNameSnapshot;
 
   // lockedByAdmin
   if (body.lockedByAdmin === true) {

--- a/backend/functions/matches/claimSlot.ts
+++ b/backend/functions/matches/claimSlot.ts
@@ -11,6 +11,24 @@ import {
 } from '../../lib/response';
 import { getAuthContext, requireRole } from '../../lib/auth';
 
+interface ClaimSlotBody {
+  wrestlerChoice?: 'main' | 'alternate';
+}
+
+/**
+ * Parse an optional JSON body. Empty / missing body → empty object (the body
+ * is optional for claimSlot — a player with no alternate doesn't need to
+ * choose a wrestler). Malformed JSON → null so the caller can 400.
+ */
+function parseOptionalBody(rawBody: string | null | undefined): ClaimSlotBody | null {
+  if (!rawBody) return {};
+  try {
+    return JSON.parse(rawBody) as ClaimSlotBody;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * POST /matches/{matchId}/slots/{slotId}/claim
  *
@@ -28,6 +46,11 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     if (!matchId) return badRequest('matchId is required');
     if (!slotId) return badRequest('slotId is required');
 
+    const body = parseOptionalBody(event.body);
+    if (body === null) {
+      return badRequest('Invalid JSON in request body');
+    }
+
     const { sub } = getAuthContext(event);
     const {
       competition: { matches },
@@ -41,6 +64,28 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return forbidden('No player profile is linked to this account');
     }
     const callerPlayerId = callerPlayer.playerId;
+
+    // MSL-03: resolve which wrestler the player is bringing.
+    // - If they have no alternate, default silently to 'main'.
+    // - If they have both, the body MUST specify a valid choice. The frontend
+    //   chooser exists precisely to avoid this 400; if it ever fires, the
+    //   chooser logic has a bug.
+    const hasAlternate = !!callerPlayer.alternateWrestler;
+    let wrestlerChoice: 'main' | 'alternate';
+    if (hasAlternate) {
+      if (body.wrestlerChoice !== 'main' && body.wrestlerChoice !== 'alternate') {
+        return badRequest(
+          'This player has both main and alternate wrestlers — specify wrestlerChoice ("main" or "alternate")',
+        );
+      }
+      wrestlerChoice = body.wrestlerChoice;
+    } else {
+      wrestlerChoice = 'main';
+    }
+    const wrestlerNameSnapshot =
+      wrestlerChoice === 'alternate' && callerPlayer.alternateWrestler
+        ? callerPlayer.alternateWrestler
+        : callerPlayer.currentWrestler;
 
     const match = await matches.findByIdWithDate(matchId);
     if (!match) return notFound('Match not found');
@@ -125,11 +170,21 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const now = new Date().toISOString();
     const updatedSlots: MatchSlot[] = slots.map((s, i) => {
       if (i !== slotIndex) return s;
-      return {
+      const next: MatchSlot = {
         ...s,
         playerId: callerPlayerId,
         claimedAt: now,
+        wrestlerChoice,
       };
+      // wrestlerNameSnapshot is optional — only persist when we actually have
+      // a non-empty string so we don't write `undefined` into Dynamo (the
+      // doc client isn't configured to strip undefined values).
+      if (wrestlerNameSnapshot) {
+        next.wrestlerNameSnapshot = wrestlerNameSnapshot;
+      } else {
+        delete next.wrestlerNameSnapshot;
+      }
+      return next;
     });
     const updatedParticipants = dedupeFilledPlayerIds(updatedSlots);
     const newStatus: MatchStatus = updatedSlots.some((s) => !s.playerId)

--- a/backend/functions/matches/hydrateSlots.ts
+++ b/backend/functions/matches/hydrateSlots.ts
@@ -3,7 +3,12 @@ import type { MatchSlot, Player } from '../../lib/repositories/types';
 export interface HydratedMatchSlot extends MatchSlot {
   /** Display name of the assigned player. Only set when the slot is filled. */
   playerName?: string;
-  /** The player's currentWrestler at fetch time. Only set when the slot is filled. */
+  /**
+   * Display name of the wrestler this player is bringing. Prefers
+   * `wrestlerNameSnapshot` (pinned at claim time, immune to later renames);
+   * falls back to the player's `currentWrestler` for legacy slots that
+   * predate MSL-03's snapshot field. Only set when the slot is filled.
+   */
   wrestlerName?: string;
 }
 
@@ -20,10 +25,16 @@ export function hydrateMatchSlots(
   return slots.map((slot) => {
     if (!slot.playerId) return { ...slot };
     const player = playerLookup.get(slot.playerId);
+    // Snapshot wins over the live currentWrestler so a player renaming their
+    // gimmick doesn't retroactively rewrite what was billed for past matches.
+    const wrestlerName =
+      slot.wrestlerNameSnapshot
+      ?? player?.currentWrestler
+      ?? 'Unknown Wrestler';
     return {
       ...slot,
       playerName: player?.name ?? 'Unknown Player',
-      wrestlerName: player?.currentWrestler ?? 'Unknown Wrestler',
+      wrestlerName,
     };
   });
 }

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -483,6 +483,21 @@ export interface MatchSlot {
   claimedAt?: string;
   lockedByAdmin?: boolean;
   teamLabel?: string;
+  /**
+   * Which wrestler the player is bringing to this match: their main
+   * (`currentWrestler`) or alternate (`alternateWrestler`). Set at claim
+   * time, or by an admin force-assign. Only meaningful when `playerId` is
+   * set.
+   */
+  wrestlerChoice?: 'main' | 'alternate';
+  /**
+   * Denormalized display name of the chosen wrestler at the moment the slot
+   * was claimed/assigned. Pinned so a later rename of the player's wrestler
+   * fields doesn't retroactively change what was billed for this match.
+   * Hydration falls back to `player.currentWrestler` when this is unset
+   * (legacy slots predating MSL-03).
+   */
+  wrestlerNameSnapshot?: string;
 }
 
 export interface Match {

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -58,7 +58,14 @@ export default function EventDetail() {
   const { eventId } = useParams<{ eventId: string }>();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { isAdminOrModerator, isAuthenticated, isWrestler, playerId } = useAuth();
+  const {
+    isAdminOrModerator,
+    isAuthenticated,
+    isWrestler,
+    playerId,
+    currentWrestler,
+    alternateWrestler,
+  } = useAuth();
   const [eventData, setEventData] = useState<EventWithMatches | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -123,10 +130,14 @@ export default function EventDetail() {
   // Non-optimistic: the per-slot button shows "Claiming…/Releasing…" while the
   // request is in flight, and we refetch the event on both success and failure.
   // The refetch on failure acts as the rollback (per MSL-02 spec).
-  const handleClaimSlot = useCallback(async (matchId: string, slotId: string) => {
+  const handleClaimSlot = useCallback(async (
+    matchId: string,
+    slotId: string,
+    options?: { wrestlerChoice?: 'main' | 'alternate' },
+  ) => {
     setMatchActionError(null);
     try {
-      await matchesApi.claimSlot(matchId, slotId);
+      await matchesApi.claimSlot(matchId, slotId, options);
     } catch (err) {
       setMatchActionError(err instanceof Error ? err.message : 'Failed to claim slot');
     } finally {
@@ -460,7 +471,7 @@ export default function EventDetail() {
             currentPlayerId={playerId ?? undefined}
             isAdmin={isAdminOrModerator}
             isAuthenticated={isAuthenticated}
-            onClaim={(slotId) => handleClaimSlot(match.matchId, slotId)}
+            onClaim={(slotId, options) => handleClaimSlot(match.matchId, slotId, options)}
             onRelease={(slotId) => handleReleaseSlot(match.matchId, slotId)}
             onLoginRequired={handleLoginRequired}
             onAdminEdit={isAdminOrModerator
@@ -472,6 +483,8 @@ export default function EventDetail() {
             disableClaimReason={t('matches.slots.alreadyBookedTooltip', {
               defaultValue: 'You already have a slot in another match on this event',
             })}
+            currentPlayerCurrentWrestler={currentWrestler}
+            currentPlayerAlternateWrestler={alternateWrestler}
           />
         )}
         {isRecording && rawMatch && (

--- a/frontend/src/components/events/MatchSlots.css
+++ b/frontend/src/components/events/MatchSlots.css
@@ -256,3 +256,76 @@
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+
+/* MSL-03 wrestler chooser */
+.wrestler-chooser-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.wrestler-chooser {
+  background: #1f1f1f;
+  color: #eaeaea;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 22px 24px;
+  min-width: 320px;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+}
+
+.wrestler-chooser h3 {
+  margin: 0 0 16px 0;
+  font-size: 1.05rem;
+}
+
+.wrestler-chooser-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.wrestler-chooser-option:hover {
+  background: #333;
+}
+
+.wrestler-chooser-actions {
+  margin-top: 18px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.wrestler-chooser-actions button {
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid #555;
+  background: #333;
+  color: #eaeaea;
+}
+
+.wrestler-chooser-confirm {
+  background: #2563eb !important;
+  border-color: #2563eb !important;
+  color: white !important;
+}
+
+.wrestler-chooser-confirm:hover {
+  background: #1d4ed8 !important;
+}

--- a/frontend/src/components/events/MatchSlots.tsx
+++ b/frontend/src/components/events/MatchSlots.tsx
@@ -14,8 +14,15 @@ export interface MatchSlotsProps {
   isAdmin?: boolean;
   /** True when a JWT is available. False = guest; clicking Claim triggers `onLoginRequired`. */
   isAuthenticated?: boolean;
-  /** Called when an authenticated wrestler clicks Claim on an open slot. */
-  onClaim: (slotId: string) => Promise<void>;
+  /**
+   * Called when an authenticated wrestler clicks Claim on an open slot. The
+   * second arg carries the player's wrestler choice when MSL-03's chooser
+   * was used; otherwise undefined and the backend defaults to 'main'.
+   */
+  onClaim: (
+    slotId: string,
+    options?: { wrestlerChoice?: 'main' | 'alternate' },
+  ) => Promise<void>;
   /** Called when the slot's current claimant clicks Release, or admin releases. */
   onRelease: (slotId: string) => Promise<void>;
   /** Optional admin hook — opens whatever slot-edit dialog the parent provides. */
@@ -34,6 +41,14 @@ export interface MatchSlotsProps {
   claimDisabled?: boolean;
   /** Tooltip / hint shown on the disabled Claim button. */
   disableClaimReason?: string;
+  /**
+   * The signed-in player's main wrestler name. When BOTH this and
+   * `currentPlayerAlternateWrestler` are set, clicking Claim opens the
+   * MSL-03 chooser instead of submitting immediately.
+   */
+  currentPlayerCurrentWrestler?: string | null;
+  /** The signed-in player's alternate wrestler name (if any). */
+  currentPlayerAlternateWrestler?: string | null;
 }
 
 /**
@@ -57,9 +72,14 @@ export default function MatchSlots(props: MatchSlotsProps) {
     loadingCount,
     claimDisabled = false,
     disableClaimReason,
+    currentPlayerCurrentWrestler,
+    currentPlayerAlternateWrestler,
   } = props;
   const { t } = useTranslation();
   const [busySlotId, setBusySlotId] = useState<string | null>(null);
+  // MSL-03: when the player has both wrestlers, the Claim button opens this
+  // chooser. The slotId being chosen for is what closes the modal.
+  const [chooserSlotId, setChooserSlotId] = useState<string | null>(null);
 
   const sortedSlots = useMemo(
     () => [...slots].sort((a, b) => a.position - b.position),
@@ -84,7 +104,20 @@ export default function MatchSlots(props: MatchSlotsProps) {
       onLoginRequired?.();
       return;
     }
+    // MSL-03: open the chooser when the player has both a main and alt set.
+    // No alternate → claim immediately and let the backend default to 'main'.
+    if (currentPlayerCurrentWrestler && currentPlayerAlternateWrestler) {
+      setChooserSlotId(slotId);
+      return;
+    }
     void runWithBusy(slotId, () => onClaim(slotId));
+  };
+
+  const handleChooserConfirm = (choice: 'main' | 'alternate') => {
+    const slotId = chooserSlotId;
+    if (!slotId) return;
+    setChooserSlotId(null);
+    void runWithBusy(slotId, () => onClaim(slotId, { wrestlerChoice: choice }));
   };
 
   const handleRelease = (slotId: string) => {
@@ -228,6 +261,87 @@ export default function MatchSlots(props: MatchSlotsProps) {
           );
         })}
         </ol>
+      </div>
+
+      {/* MSL-03 wrestler chooser */}
+      {chooserSlotId && currentPlayerCurrentWrestler && currentPlayerAlternateWrestler && (
+        <WrestlerChooserDialog
+          mainName={currentPlayerCurrentWrestler}
+          alternateName={currentPlayerAlternateWrestler}
+          onConfirm={handleChooserConfirm}
+          onCancel={() => setChooserSlotId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface WrestlerChooserDialogProps {
+  mainName: string;
+  alternateName: string;
+  onConfirm: (choice: 'main' | 'alternate') => void;
+  onCancel: () => void;
+}
+
+function WrestlerChooserDialog({
+  mainName,
+  alternateName,
+  onConfirm,
+  onCancel,
+}: WrestlerChooserDialogProps) {
+  const { t } = useTranslation();
+  const [choice, setChoice] = useState<'main' | 'alternate'>('main');
+
+  return (
+    <div
+      className="wrestler-chooser-overlay"
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="wrestler-chooser">
+        <h3>{t('matches.slots.chooseWrestler', { defaultValue: 'Choose your wrestler' })}</h3>
+        <label className="wrestler-chooser-option">
+          <input
+            type="radio"
+            name="wrestler-chooser"
+            value="main"
+            checked={choice === 'main'}
+            onChange={() => setChoice('main')}
+          />
+          <span>
+            {t('matches.slots.useMain', { name: mainName, defaultValue: `Use main: ${mainName}` })}
+          </span>
+        </label>
+        <label className="wrestler-chooser-option">
+          <input
+            type="radio"
+            name="wrestler-chooser"
+            value="alternate"
+            checked={choice === 'alternate'}
+            onChange={() => setChoice('alternate')}
+          />
+          <span>
+            {t('matches.slots.useAlternate', {
+              name: alternateName,
+              defaultValue: `Use alternate: ${alternateName}`,
+            })}
+          </span>
+        </label>
+        <div className="wrestler-chooser-actions">
+          <button type="button" className="wrestler-chooser-cancel" onClick={onCancel}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </button>
+          <button
+            type="button"
+            className="wrestler-chooser-confirm"
+            onClick={() => onConfirm(choice)}
+          >
+            {t('matches.slots.confirmChoice', { defaultValue: 'Confirm' })}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/events/SlotEditDialog.css
+++ b/frontend/src/components/events/SlotEditDialog.css
@@ -105,3 +105,14 @@
 .slot-edit-dialog-save:hover:not(:disabled) {
   background: #1d4ed8 !important;
 }
+
+.slot-edit-dialog-wrestler-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.slot-edit-dialog-wrestler-options .slot-edit-dialog-checkbox {
+  flex-direction: row;
+  align-items: center;
+}

--- a/frontend/src/components/events/SlotEditDialog.tsx
+++ b/frontend/src/components/events/SlotEditDialog.tsx
@@ -16,6 +16,7 @@ export interface SlotEditDialogProps {
     playerId?: string | null;
     lockedByAdmin?: boolean;
     teamLabel?: string | null;
+    wrestlerChoice?: 'main' | 'alternate';
   }) => Promise<void>;
   onClose: () => void;
 }
@@ -25,6 +26,7 @@ export default function SlotEditDialog({ slot, players, onSave, onClose }: SlotE
   const [playerId, setPlayerId] = useState<string>('');
   const [locked, setLocked] = useState(false);
   const [teamLabel, setTeamLabel] = useState<string>('');
+  const [wrestlerChoice, setWrestlerChoice] = useState<'main' | 'alternate'>('main');
   const [saving, setSaving] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
@@ -34,17 +36,30 @@ export default function SlotEditDialog({ slot, players, onSave, onClose }: SlotE
     setPlayerId(slot.playerId ?? '');
     setLocked(!!slot.lockedByAdmin);
     setTeamLabel(slot.teamLabel ?? '');
+    setWrestlerChoice(slot.wrestlerChoice ?? 'main');
     setErrorMsg(null);
   }, [slot]);
 
   if (!slot) return null;
 
+  // Show the Wrestler radio only when the picked player has an alternate set.
+  const pickedPlayer = playerId
+    ? players.find((p) => p.playerId === playerId)
+    : undefined;
+  const showWrestlerRadio = !!pickedPlayer?.alternateWrestler;
+
   const buildPatch = (): {
     playerId?: string | null;
     lockedByAdmin?: boolean;
     teamLabel?: string | null;
+    wrestlerChoice?: 'main' | 'alternate';
   } => {
-    const patch: { playerId?: string | null; lockedByAdmin?: boolean; teamLabel?: string | null } = {};
+    const patch: {
+      playerId?: string | null;
+      lockedByAdmin?: boolean;
+      teamLabel?: string | null;
+      wrestlerChoice?: 'main' | 'alternate';
+    } = {};
     const trimmedLabel = teamLabel.trim();
     const originalLabel = slot.teamLabel ?? '';
 
@@ -57,6 +72,16 @@ export default function SlotEditDialog({ slot, players, onSave, onClose }: SlotE
     }
     if (trimmedLabel !== originalLabel) {
       patch.teamLabel = trimmedLabel === '' ? null : trimmedLabel;
+    }
+    // wrestlerChoice: include when re-assigning (so backend can default to
+    // 'main' or honor 'alternate'), or when explicitly switching the radio
+    // on an existing claimant. Hidden + omitted when the player has no alt.
+    if (showWrestlerRadio) {
+      const reassigning = patch.playerId !== undefined && patch.playerId !== null;
+      const choiceChanged = wrestlerChoice !== (slot.wrestlerChoice ?? 'main');
+      if (reassigning || choiceChanged) {
+        patch.wrestlerChoice = wrestlerChoice;
+      }
     }
     return patch;
   };
@@ -124,6 +149,44 @@ export default function SlotEditDialog({ slot, players, onSave, onClose }: SlotE
             ))}
           </select>
         </div>
+
+        {showWrestlerRadio && pickedPlayer && (
+          <div className="slot-edit-dialog-row">
+            <label>
+              {t('matches.slots.editWrestlerLabel', { defaultValue: 'Wrestler' })}
+            </label>
+            <div className="slot-edit-dialog-wrestler-options">
+              <label className="slot-edit-dialog-checkbox">
+                <input
+                  type="radio"
+                  name="slot-edit-wrestler-choice"
+                  value="main"
+                  checked={wrestlerChoice === 'main'}
+                  disabled={saving}
+                  onChange={() => setWrestlerChoice('main')}
+                />
+                {t('matches.slots.useMain', {
+                  name: pickedPlayer.currentWrestler,
+                  defaultValue: `Use main: ${pickedPlayer.currentWrestler}`,
+                })}
+              </label>
+              <label className="slot-edit-dialog-checkbox">
+                <input
+                  type="radio"
+                  name="slot-edit-wrestler-choice"
+                  value="alternate"
+                  checked={wrestlerChoice === 'alternate'}
+                  disabled={saving}
+                  onChange={() => setWrestlerChoice('alternate')}
+                />
+                {t('matches.slots.useAlternate', {
+                  name: pickedPlayer.alternateWrestler,
+                  defaultValue: `Use alternate: ${pickedPlayer.alternateWrestler}`,
+                })}
+              </label>
+            </div>
+          </div>
+        )}
 
         <div className="slot-edit-dialog-row">
           <label className="slot-edit-dialog-checkbox">

--- a/frontend/src/components/events/__tests__/MatchSlots.test.tsx
+++ b/frontend/src/components/events/__tests__/MatchSlots.test.tsx
@@ -214,4 +214,65 @@ describe('MatchSlots', () => {
     });
     expect(screen.getByRole('button', { name: 'Release' })).not.toBeDisabled();
   });
+
+  // ── MSL-03: wrestler chooser ────────────────────────────────────────────
+
+  it('claims directly without a chooser when the player has no alternate', async () => {
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderSlots({
+      slots: [open()],
+      isAuthenticated: true,
+      onClaim,
+      currentPlayerCurrentWrestler: 'Stone Cold',
+      currentPlayerAlternateWrestler: null,
+    });
+    await user.click(screen.getByRole('button', { name: 'Claim spot' }));
+    await waitFor(() => expect(onClaim).toHaveBeenCalled());
+    // Called with just the slotId (no chooser, so no options arg).
+    expect(onClaim.mock.calls[0][0]).toBe('s2');
+    expect(onClaim.mock.calls[0][1]).toBeUndefined();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the chooser when the player has both wrestlers and submits the choice', async () => {
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderSlots({
+      slots: [open()],
+      isAuthenticated: true,
+      onClaim,
+      currentPlayerCurrentWrestler: 'Stone Cold',
+      currentPlayerAlternateWrestler: 'The Rock',
+    });
+    await user.click(screen.getByRole('button', { name: 'Claim spot' }));
+
+    // Chooser is open, default selection is 'main'
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(onClaim).not.toHaveBeenCalled();
+
+    // Pick alternate, confirm
+    await user.click(screen.getByRole('radio', { name: /Use alternate/i }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() =>
+      expect(onClaim).toHaveBeenCalledWith('s2', { wrestlerChoice: 'alternate' }),
+    );
+  });
+
+  it('cancel on the chooser does not call onClaim', async () => {
+    const onClaim = vi.fn();
+    const user = userEvent.setup();
+    renderSlots({
+      slots: [open()],
+      isAuthenticated: true,
+      onClaim,
+      currentPlayerCurrentWrestler: 'Stone Cold',
+      currentPlayerAlternateWrestler: 'The Rock',
+    });
+    await user.click(screen.getByRole('button', { name: 'Claim spot' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClaim).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,6 +8,10 @@ interface AuthState {
   groups: UserRole[];
   email: string | null;
   playerId: string | null;
+  /** The signed-in player's main wrestler name. Used by the slot-claim chooser. */
+  currentWrestler: string | null;
+  /** The signed-in player's alternate wrestler name (if set). */
+  alternateWrestler: string | null;
 }
 
 interface AuthContextType extends AuthState {
@@ -33,6 +37,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     groups: cognitoAuth.getUserGroups(),
     email: null,
     playerId: null,
+    currentWrestler: null,
+    alternateWrestler: null,
   });
 
   // Initialize auth state on mount
@@ -54,6 +60,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               groups,
               email: `${(player.name as string).toLowerCase().replace(/\s/g, '.')}@dev.local`,
               playerId: player.playerId,
+              currentWrestler: null,
+              alternateWrestler: null,
             });
             return;
           } catch {
@@ -75,11 +83,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
           // Fetch player profile if user is in the Wrestler group
           let playerId: string | null = null;
+          let currentWrestler: string | null = null;
+          let alternateWrestler: string | null = null;
           if (groups.includes('Wrestler')) {
             try {
               const profile = await profileApi.getMyProfile();
               if (!mounted) return;
               playerId = profile.playerId;
+              currentWrestler = profile.currentWrestler ?? null;
+              alternateWrestler = profile.alternateWrestler ?? null;
             } catch {
               // Profile may not exist yet
             }
@@ -92,6 +104,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             groups,
             email: user.signInDetails?.loginId || user.username || null,
             playerId,
+            currentWrestler,
+            alternateWrestler,
           });
         } else {
           setState({
@@ -100,6 +114,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             groups: [],
             email: null,
             playerId: null,
+            currentWrestler: null,
+            alternateWrestler: null,
           });
         }
       } catch {
@@ -110,6 +126,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           groups: [],
           email: null,
           playerId: null,
+          currentWrestler: null,
+          alternateWrestler: null,
         });
       }
     };
@@ -125,10 +143,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Fetch player profile if user is in the Wrestler group
     let playerId: string | null = null;
+    let currentWrestler: string | null = null;
+    let alternateWrestler: string | null = null;
     if (result.groups.includes('Wrestler')) {
       try {
         const profile = await profileApi.getMyProfile();
         playerId = profile.playerId;
+        currentWrestler = profile.currentWrestler ?? null;
+        alternateWrestler = profile.alternateWrestler ?? null;
       } catch {
         // Profile may not exist yet
       }
@@ -140,6 +162,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       groups: result.groups,
       email,
       playerId,
+      currentWrestler,
+      alternateWrestler,
     });
   }, []);
 
@@ -160,13 +184,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       groups: [],
       email: null,
       playerId: null,
+      currentWrestler: null,
+      alternateWrestler: null,
     });
   }, []);
 
   const refreshProfile = useCallback(async () => {
     try {
       const profile = await profileApi.getMyProfile();
-      setState(prev => ({ ...prev, playerId: profile.playerId }));
+      setState(prev => ({
+        ...prev,
+        playerId: profile.playerId,
+        currentWrestler: profile.currentWrestler ?? null,
+        alternateWrestler: profile.alternateWrestler ?? null,
+      }));
     } catch {
       // Profile may not exist
     }
@@ -190,6 +221,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       groups,
       email: `${player.name.toLowerCase().replace(/\s/g, '.')}@dev.local`,
       playerId: player.playerId,
+      currentWrestler: null,
+      alternateWrestler: null,
     });
   }, []);
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -465,7 +465,12 @@
       "openSpotsHeader": "Freie Plätze",
       "spotsHeader": "Plätze",
       "alreadyBookedOnEvent": "Du hast bereits einen Platz in einem anderen Match dieser Veranstaltung — gib ihn erst frei",
-      "alreadyBookedTooltip": "Du hast bereits einen Platz in einem anderen Match dieser Veranstaltung"
+      "alreadyBookedTooltip": "Du hast bereits einen Platz in einem anderen Match dieser Veranstaltung",
+      "chooseWrestler": "Wähle deinen Wrestler",
+      "useMain": "Hauptwrestler verwenden: {{name}}",
+      "useAlternate": "Alternativen verwenden: {{name}}",
+      "confirmChoice": "Bestätigen",
+      "editWrestlerLabel": "Wrestler"
     }
   },
   "matchSearch": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -465,7 +465,12 @@
       "openSpotsHeader": "Open spots",
       "spotsHeader": "Spots",
       "alreadyBookedOnEvent": "You already have a slot in another match on this event — release that one first",
-      "alreadyBookedTooltip": "You already have a slot in another match on this event"
+      "alreadyBookedTooltip": "You already have a slot in another match on this event",
+      "chooseWrestler": "Choose your wrestler",
+      "useMain": "Use main: {{name}}",
+      "useAlternate": "Use alternate: {{name}}",
+      "confirmChoice": "Confirm",
+      "editWrestlerLabel": "Wrestler"
     }
   },
   "matchSearch": {

--- a/frontend/src/services/api/matches.api.ts
+++ b/frontend/src/services/api/matches.api.ts
@@ -50,9 +50,18 @@ export const matchesApi = {
     });
   },
 
-  claimSlot: async (matchId: string, slotId: string): Promise<Match> => {
+  claimSlot: async (
+    matchId: string,
+    slotId: string,
+    options?: { wrestlerChoice?: 'main' | 'alternate' },
+  ): Promise<Match> => {
     return fetchWithAuth(`${API_BASE_URL}/matches/${matchId}/slots/${slotId}/claim`, {
       method: 'POST',
+      // Body is optional — players with no alternate omit it; players with
+      // both must include the choice (the chooser modal pre-supplies it).
+      ...(options?.wrestlerChoice
+        ? { body: JSON.stringify({ wrestlerChoice: options.wrestlerChoice }) }
+        : {}),
     });
   },
 
@@ -65,7 +74,12 @@ export const matchesApi = {
   adminUpdateSlot: async (
     matchId: string,
     slotId: string,
-    patch: { playerId?: string | null; lockedByAdmin?: boolean; teamLabel?: string | null },
+    patch: {
+      playerId?: string | null;
+      lockedByAdmin?: boolean;
+      teamLabel?: string | null;
+      wrestlerChoice?: 'main' | 'alternate';
+    },
   ): Promise<Match> => {
     return fetchWithAuth(`${API_BASE_URL}/matches/${matchId}/slots/${slotId}`, {
       method: 'PUT',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,10 @@ export interface MatchSlot {
   claimedAt?: string;
   lockedByAdmin?: boolean;
   teamLabel?: string;
+  /** Which wrestler the player is bringing: main (`currentWrestler`) or alternate. */
+  wrestlerChoice?: 'main' | 'alternate';
+  /** Display name of the chosen wrestler, pinned at claim time. */
+  wrestlerNameSnapshot?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements **MSL-03**. When a player has both a main and an alternate wrestler set on their profile, claiming a slot now opens a chooser asking which character they're bringing to that match. The choice is persisted on the slot and the chosen name is **snapshotted** at claim time, so a later profile rename doesn't retroactively rewrite history.

Players with only a main wrestler still claim with one click — no chooser, no body.

## Subtasks (one commit each)
- `70d723e` — types: `wrestlerChoice` + `wrestlerNameSnapshot` on `MatchSlot` (backend + frontend mirror)
- `8c79dd3` — backend `claimSlot` resolves choice from body + snapshots the name
- `4bbec28` — backend `adminUpdateSlot` accepts `wrestlerChoice` (silent 'main' default; clear wipes both fields; radio-only switch recomputes snapshot)
- `6e45e9c` — slot hydration prefers `wrestlerNameSnapshot` over the live currentWrestler
- `4293654` — frontend `matchesApi.claimSlot` accepts optional `wrestlerChoice`
- `9f1c773` — frontend MatchSlots wrestler chooser modal + AuthContext exposes the player's wrestler names
- `e5a765c` — admin SlotEditDialog gains a Wrestler radio (hidden when player has no alt)
- `2a710e4` — i18n EN + DE for the chooser + admin radio
- `fcd598c` — Vitest coverage (4 backend claim, 4 backend admin, 5 hydration, 3 frontend chooser)

## Behavior
**Player flow.** A wrestler with only a main wrestler clicks Claim and the slot fills with `Stone Cold (jpdev)`. A wrestler with both characters clicks Claim, the chooser opens with two radios prefilled, picks one, confirms, and the slot fills with their chosen name. Reload preserves it (snapshot wins). Releasing + re-claiming gets a fresh chooser and a fresh snapshot — that's deliberate.

**Snapshot rule.** Once claimed, `wrestlerNameSnapshot` is pinned. If the player later renames `currentWrestler` or `alternateWrestler` on their profile, the slot still shows the original name. This is the right behavior — a wrestler renaming their gimmick mid-week shouldn't rewrite what was billed for last Sunday's PPV.

**Admin flow.** Admin force-assign via `adminUpdateSlot` is unchanged in spirit — `wrestlerChoice` is **silently** defaulted to 'main' when omitted so scripted bookings don't get slowed down by a radio prompt. The SlotEditDialog now shows a Wrestler radio when the picked player has an alternate, hidden otherwise. The radio also recomputes the snapshot when an admin flips it without changing the player.

**Hydration fallback.** `wrestlerName = wrestlerNameSnapshot ?? player.currentWrestler` — falls back gracefully for slots claimed before this ticket lands. The fallback could be removed after a one-time backfill, but that's out of scope.

## Test plan
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `cd backend && npx vitest run functions/matches functions/events` — 201 passed (16 new MSL-03)
- [x] `cd frontend && npx vitest run` — 450 passed (3 new MSL-03 chooser cases)
- [ ] Manual smoke (after deploy):
  - Wrestler with only main → click Claim → slot fills with `Stone Cold (jpdev)` immediately, no modal.
  - Wrestler with both → click Claim → chooser opens with both names; pick alternate, confirm → slot shows `The Rock (jpdev)`.
  - Reload → display persists.
  - Player edits their `alternateWrestler` to a new name → existing claim still shows the original name.
  - Release + re-claim → chooser re-opens; pick the other character; new snapshot replaces.
  - Admin force-assigns a player with an alternate, leaves the radio at 'Main' default → slot persists with `'main'` and the player's currentWrestler snapshot.
  - Admin picks 'Alternate' on the radio → snapshot is the alternate name.

## Out of scope (deliberate)
- Letting players change their wrestler choice on a slot they've already claimed. Release + re-claim is the path.
- Cascading updates if the player later renames currentWrestler / alternateWrestler — the snapshot intentionally pins.
- Tracking per-match wrestler choice for legacy non-slot matches — those keep using the live currentWrestler at display time.
- `wrestlerIdSnapshot` (FK) — string snapshot is enough for display. Add the FK if future analytics needs to dedupe across renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)