### PR TITLE
fix(events): match-card header uses slot wrestlerNameSnapshot

### DIFF
--- a/backend/functions/events/__tests__/getEvent.test.ts
+++ b/backend/functions/events/__tests__/getEvent.test.ts
@@ -223,4 +223,92 @@ describe('getEvent', () => {
     expect(result!.statusCode).toBe(500);
     expect(JSON.parse(result!.body).message).toBe('Failed to fetch event');
   });
+
+  it('participants[].wrestlerName uses slot wrestlerNameSnapshot when present (MSL-03)', async () => {
+    // Regression: a player who claimed a slot with their alternate must show
+    // up as that alternate name in BOTH the slot row and the match-card
+    // header (which reads from participants[].wrestlerName). Previously the
+    // header always rendered the player's currentWrestler regardless.
+    const player = await repos.roster.players.create({
+      name: 'JPAdmin',
+      currentWrestler: 'Raquel Rodriguez',
+      alternateWrestler: 'Diamond Dallas Page',
+    });
+
+    const match = await repos.competition.matches.create({
+      matchId: 'm-snap',
+      date: '2024-01-01',
+      matchFormat: 'singles',
+      participants: [player.playerId],
+      slots: [
+        {
+          slotId: 's1',
+          position: 1,
+          playerId: player.playerId,
+          claimedAt: '2024-01-01T00:00:00Z',
+          wrestlerChoice: 'alternate',
+          wrestlerNameSnapshot: 'Diamond Dallas Page',
+        },
+      ],
+      slotsRequired: 2,
+      isChampionship: false,
+      status: 'open-signups',
+      createdAt: new Date().toISOString(),
+    });
+
+    const eventItem = await repos.leagueOps.events.create({
+      name: 'Raw', eventType: 'weekly', date: '2024-01-01',
+    });
+    await repos.leagueOps.events.update(eventItem.eventId, {
+      matchCards: [
+        { position: 1, matchId: match.matchId, designation: 'midcard' as const },
+      ],
+    });
+
+    const event = makeEvent({ pathParameters: { eventId: eventItem.eventId } });
+    const result = await getEvent(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    const md = body.enrichedMatches[0].matchData;
+    // The header / participants list shows the alternate, not the live main.
+    expect(md.participants[0].wrestlerName).toBe('Diamond Dallas Page');
+    // Slot row also shows the alternate (existing MSL-03 hydration).
+    expect(md.slots[0].wrestlerName).toBe('Diamond Dallas Page');
+  });
+
+  it('participants[].wrestlerName falls back to currentWrestler when no snapshot is set', async () => {
+    // Legacy path: a slot claimed before MSL-03 has no wrestlerNameSnapshot.
+    // The header should fall back to the player's currentWrestler.
+    const player = await repos.roster.players.create({
+      name: 'JPAdmin',
+      currentWrestler: 'Stone Cold',
+    });
+    const match = await repos.competition.matches.create({
+      matchId: 'm-legacy',
+      date: '2024-01-01',
+      matchFormat: 'singles',
+      participants: [player.playerId],
+      slots: [
+        { slotId: 's1', position: 1, playerId: player.playerId },
+      ],
+      slotsRequired: 2,
+      isChampionship: false,
+      status: 'open-signups',
+      createdAt: new Date().toISOString(),
+    });
+    const eventItem = await repos.leagueOps.events.create({
+      name: 'Raw', eventType: 'weekly', date: '2024-01-01',
+    });
+    await repos.leagueOps.events.update(eventItem.eventId, {
+      matchCards: [{ position: 1, matchId: match.matchId, designation: 'midcard' as const }],
+    });
+
+    const event = makeEvent({ pathParameters: { eventId: eventItem.eventId } });
+    const result = await getEvent(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.enrichedMatches[0].matchData.participants[0].wrestlerName).toBe('Stone Cold');
+  });
 });

--- a/backend/functions/events/getEvent.ts
+++ b/backend/functions/events/getEvent.ts
@@ -48,6 +48,22 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           };
         }
 
+        // Build a playerId → wrestlerNameSnapshot lookup from this match's
+        // slots so the participants list (used by the match-card header) shows
+        // the wrestler the player actually claimed with — not their live
+        // currentWrestler. Without this, a player who claimed with their
+        // alternate would still display as their main in the header even
+        // though the slot row below correctly shows the alternate.
+        const slots = match.slots as MatchSlot[] | undefined;
+        const slotSnapshotByPlayer = new Map<string, string>();
+        if (slots) {
+          for (const s of slots) {
+            if (s.playerId && s.wrestlerNameSnapshot && !slotSnapshotByPlayer.has(s.playerId)) {
+              slotSnapshotByPlayer.set(s.playerId, s.wrestlerNameSnapshot);
+            }
+          }
+        }
+
         // Fetch participant player data via repository. The same lookup also
         // feeds slot hydration below, since slot playerIds are a subset of
         // participants in slot-mode matches.
@@ -57,17 +73,17 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           const playerPromises = (match.participants as string[]).map(async (playerId: string) => {
             const player = await players.findById(playerId);
             if (player) playerLookup.set(playerId, player);
+            const snapshot = slotSnapshotByPlayer.get(playerId);
             return {
               playerId,
               playerName: player?.name || 'Unknown Player',
-              wrestlerName: player?.currentWrestler || 'Unknown Wrestler',
+              wrestlerName: snapshot ?? player?.currentWrestler ?? 'Unknown Wrestler',
             };
           });
           participantData.push(...(await Promise.all(playerPromises)));
         }
 
         // Slot hydration (pure read enrichment, no persistence).
-        const slots = match.slots as MatchSlot[] | undefined;
         const hydratedSlots = slots && slots.length > 0
           ? hydrateMatchSlots(slots, playerLookup)
           : undefined;


### PR DESCRIPTION
## Summary
Fixes a visible MSL-03 bug: a player who claimed a slot with their **alternate** wrestler (e.g. \`Diamond Dallas Page\`) saw the slot row correctly show the alternate, but the match-card header above the slots still showed their **main** (\`Raquel Rodriguez\`).

## Root cause
\`hydrateMatchSlots\` prefers \`wrestlerNameSnapshot\` for slot rows (the MSL-03 invariant), but the match header reads from \`matchData.participants[].wrestlerName\`, which [getEvent.ts](backend/functions/events/getEvent.ts) was populating from \`player.currentWrestler\` unconditionally — bypassing the snapshot.

## Fix
Build a \`playerId → wrestlerNameSnapshot\` lookup from this match's slots first, then prefer the snapshot over \`currentWrestler\` when hydrating participants. Falls back to \`currentWrestler\` when no snapshot exists, so:
- Legacy slots claimed before MSL-03 still display correctly.
- Non-slot matches (which never had snapshots) are unaffected.

## Test plan
- [x] \`cd backend && npx tsc --project tsconfig.json --noEmit\` — clean
- [x] \`cd backend && npx vitest run functions/events functions/matches\` — 203/203 (2 new MSL-03 regression cases)
- [ ] Manual smoke (after deploy): on a match where a player claimed with their alternate, header shows the alternate name (matches the slot row), not the main.

## Screenshots from the bug report
The slot list correctly read \`Diamond Dallas Page (JPAdmin)\` while the header above said \`Raquel Rodriguez (JPAdmin)\` — same player, two different wrestler names visible at once on the same card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)