### PR TITLE
fix(events): refresh admin data after slot mutations + winner highlight on slot rows

### DIFF
--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -130,6 +130,12 @@ export default function EventDetail() {
   // Non-optimistic: the per-slot button shows "Claiming…/Releasing…" while the
   // request is in flight, and we refetch the event on both success and failure.
   // The refetch on failure acts as the rollback (per MSL-02 spec).
+  // Slot mutations can flip a match's status between 'open-signups' and
+  // 'scheduled' (filling the last slot or releasing one), so we have to
+  // refresh BOTH eventData and the admin scheduledMatches list. Without the
+  // admin refresh, clicking Record Result on a freshly-scheduled match shows
+  // the inline "Match data is not available" error because scheduledMatches
+  // didn't include this match when it was last fetched.
   const handleClaimSlot = useCallback(async (
     matchId: string,
     slotId: string,
@@ -141,9 +147,9 @@ export default function EventDetail() {
     } catch (err) {
       setMatchActionError(err instanceof Error ? err.message : 'Failed to claim slot');
     } finally {
-      await loadEvent();
+      await Promise.all([loadEvent(), loadAdminData()]);
     }
-  }, [loadEvent]);
+  }, [loadEvent, loadAdminData]);
 
   const handleReleaseSlot = useCallback(async (matchId: string, slotId: string) => {
     setMatchActionError(null);
@@ -152,9 +158,9 @@ export default function EventDetail() {
     } catch (err) {
       setMatchActionError(err instanceof Error ? err.message : 'Failed to release slot');
     } finally {
-      await loadEvent();
+      await Promise.all([loadEvent(), loadAdminData()]);
     }
-  }, [loadEvent]);
+  }, [loadEvent, loadAdminData]);
 
   const handleLoginRequired = useCallback(() => {
     if (!eventId) return;
@@ -170,15 +176,22 @@ export default function EventDetail() {
   }, []);
 
   const handleSlotEditSave = useCallback(async (
-    patch: { playerId?: string | null; lockedByAdmin?: boolean; teamLabel?: string | null },
+    patch: {
+      playerId?: string | null;
+      lockedByAdmin?: boolean;
+      teamLabel?: string | null;
+      wrestlerChoice?: 'main' | 'alternate';
+    },
   ) => {
     if (!editingSlot) return;
     try {
       await matchesApi.adminUpdateSlot(editingSlot.matchId, editingSlot.slot.slotId, patch);
     } finally {
-      await loadEvent();
+      // adminUpdateSlot can also flip the match's status (filling the last
+      // slot, clearing one, etc.), so refresh admin data too.
+      await Promise.all([loadEvent(), loadAdminData()]);
     }
-  }, [editingSlot, loadEvent]);
+  }, [editingSlot, loadEvent, loadAdminData]);
 
   const handleStatusChange = async (newStatus: string) => {
     if (!eventData || !eventId || newStatus === eventData.status) return;
@@ -485,6 +498,8 @@ export default function EventDetail() {
             })}
             currentPlayerCurrentWrestler={currentWrestler}
             currentPlayerAlternateWrestler={alternateWrestler}
+            winnerPlayerIds={match.matchData.winners}
+            loserPlayerIds={match.matchData.losers}
           />
         )}
         {isRecording && rawMatch && (

--- a/frontend/src/components/events/MatchSlots.css
+++ b/frontend/src/components/events/MatchSlots.css
@@ -329,3 +329,36 @@
 .wrestler-chooser-confirm:hover {
   background: #1d4ed8 !important;
 }
+
+/* Winner / loser slot highlights — match the header's `.participant.winner`
+ * styling so a completed match's SPOTS list visually matches the header. */
+.match-slot.winner {
+  background: rgba(74, 222, 128, 0.15);
+  border-color: #4ade80;
+  border-style: solid;
+}
+
+.match-slot.winner .match-slot-link {
+  color: #4ade80;
+}
+
+.match-slot.winner .match-slot-wrestler {
+  font-weight: 700;
+}
+
+.match-slot-winner-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 7px;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #052e0c;
+  background: #4ade80;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.match-slot.loser {
+  opacity: 0.55;
+}

--- a/frontend/src/components/events/MatchSlots.tsx
+++ b/frontend/src/components/events/MatchSlots.tsx
@@ -49,6 +49,14 @@ export interface MatchSlotsProps {
   currentPlayerCurrentWrestler?: string | null;
   /** The signed-in player's alternate wrestler name (if any). */
   currentPlayerAlternateWrestler?: string | null;
+  /**
+   * playerIds of the match's winners. When the match is completed, slot rows
+   * for these players render with the winner highlight so the SPOTS list
+   * matches the winner styling on the match-card header.
+   */
+  winnerPlayerIds?: string[];
+  /** playerIds of the match's losers. Rendered with a subdued treatment. */
+  loserPlayerIds?: string[];
 }
 
 /**
@@ -74,6 +82,8 @@ export default function MatchSlots(props: MatchSlotsProps) {
     disableClaimReason,
     currentPlayerCurrentWrestler,
     currentPlayerAlternateWrestler,
+    winnerPlayerIds,
+    loserPlayerIds,
   } = props;
   const { t } = useTranslation();
   const [busySlotId, setBusySlotId] = useState<string | null>(null);
@@ -177,11 +187,21 @@ export default function MatchSlots(props: MatchSlotsProps) {
           const showRelease = isMine && !slot.lockedByAdmin
             && matchStatus !== 'completed' && matchStatus !== 'cancelled';
 
+          const isWinner = filled
+            && !!slot.playerId
+            && !!winnerPlayerIds?.includes(slot.playerId);
+          const isLoser = filled
+            && !!slot.playerId
+            && !isWinner
+            && !!loserPlayerIds?.includes(slot.playerId);
+
           const rowClass = [
             'match-slot',
             filled ? 'filled' : 'open',
             isMine ? 'mine' : '',
             slot.lockedByAdmin ? 'locked' : '',
+            isWinner ? 'winner' : '',
+            isLoser ? 'loser' : '',
           ].filter(Boolean).join(' ');
 
           return (
@@ -200,6 +220,9 @@ export default function MatchSlots(props: MatchSlotsProps) {
                     <span className="match-slot-wrestler">{slot.wrestlerName ?? slot.playerId}</span>
                     {slot.playerName && (
                       <span className="match-slot-player"> ({slot.playerName})</span>
+                    )}
+                    {isWinner && (
+                      <span className="match-slot-winner-badge" aria-label="Winner">W</span>
                     )}
                   </Link>
                 ) : (

--- a/frontend/src/components/events/__tests__/MatchSlots.test.tsx
+++ b/frontend/src/components/events/__tests__/MatchSlots.test.tsx
@@ -275,4 +275,41 @@ describe('MatchSlots', () => {
     expect(onClaim).not.toHaveBeenCalled();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  // ── Winner / loser highlight on the slot rows ───────────────────────────
+
+  it('marks the winner\'s slot with the winner class + W badge', () => {
+    renderSlots({
+      slots: [
+        filled({ slotId: 's-loser', position: 1, playerId: 'p-loser', wrestlerName: 'Loser' }),
+        filled({ slotId: 's-winner', position: 2, playerId: 'p-winner', wrestlerName: 'Winner' }),
+      ],
+      matchStatus: 'completed',
+      winnerPlayerIds: ['p-winner'],
+      loserPlayerIds: ['p-loser'],
+    });
+
+    const winnerRow = document.querySelector('.match-slot[data-slot-id="s-winner"]');
+    const loserRow = document.querySelector('.match-slot[data-slot-id="s-loser"]');
+    expect(winnerRow?.classList.contains('winner')).toBe(true);
+    expect(winnerRow?.classList.contains('loser')).toBe(false);
+    expect(loserRow?.classList.contains('loser')).toBe(true);
+    expect(winnerRow?.querySelector('.match-slot-winner-badge')).not.toBeNull();
+    expect(loserRow?.querySelector('.match-slot-winner-badge')).toBeNull();
+  });
+
+  it('does not mark a winner when winnerPlayerIds is omitted', () => {
+    renderSlots({
+      slots: [
+        filled({ slotId: 's-a', playerId: 'pa' }),
+        filled({ slotId: 's-b', position: 2, playerId: 'pb' }),
+      ],
+      matchStatus: 'scheduled',
+    });
+    const rows = document.querySelectorAll('.match-slot');
+    rows.forEach((row) => {
+      expect(row.classList.contains('winner')).toBe(false);
+      expect(row.classList.contains('loser')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Two fixes addressing user-reported issues from the same Event Detail screenshot.

### #1 — "couldn't record results after filling last slot" (transient)
**Symptom:** filling the last slot on a match flips the match status to \`scheduled\`, the Record Result button correctly becomes available, but clicking it shows the inline \`"Match data is not available. Try refreshing the page."\` error. A manual page refresh resolves it.

**Root cause:** \`handleClaimSlot\`, \`handleReleaseSlot\`, and \`handleSlotEditSave\` only called \`loadEvent()\` after the mutation. The Record Result button gate (\`match.matchData?.status === 'scheduled'\`) reads from event data — fresh after the event refetch — but the inline \`MatchResultForm\` reads its match from \`scheduledMatches\`, which is loaded by \`loadAdminData()\` and was **never refreshed by the slot handlers**. So the freshly-scheduled match wasn't in \`scheduledMatchesById\` until the next admin-data load.

**Fix:** each slot-mutation handler now refetches both \`eventData\` and the admin \`scheduledMatches\` list in parallel.

### #2 — winner highlight not reflected in SPOTS list
**Symptom:** match header shows \`David Finlay (Test) W\` highlighted green as the winner, but in the SPOTS section below, David Finlay's slot has no winner indicator. The only highlighted slot was the viewer's own (\`.mine\` class), which is unrelated.

**Fix:** \`MatchSlots\` accepts \`winnerPlayerIds\` + \`loserPlayerIds\` props. The winner row gets the same green styling as the header (\`rgba(74, 222, 128, 0.15)\` background + \`#4ade80\` border + bold green text) plus a small \`W\` badge next to the wrestler name. Loser rows drop to 55% opacity. \`EventDetail\` forwards \`match.matchData.winners\` / \`.losers\`.

## Test plan
- [x] \`cd frontend && npx tsc --project tsconfig.app.json --noEmit\` — clean
- [x] \`cd frontend && npx vitest run\` — 452/452 (2 new MatchSlots cases)
- [ ] Manual smoke after deploy:
  - **#1**: claim the last open slot on an in-flight match → status flips to scheduled → click Record Result → inline form opens immediately (no \`Match data is not available\` error).
  - **#2**: on a completed slot-mode match, the winner's slot row in SPOTS shows the same green highlight as the header, with a small \`W\` badge; loser rows are dimmed.

## Backend
No backend changes — both fixes are frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)