### PR TITLE
Expand OpenAPI spec + add ManageLocations admin UI (LOC-02)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -39,6 +39,23 @@ tags:
   - name: Challenges
   - name: Promos
   - name: Statistics
+  - name: Dashboard
+  - name: Activity
+  - name: Rivalries
+  - name: Season Awards
+  - name: Companies
+  - name: Shows
+  - name: Locations
+  - name: Wrestlers
+  - name: Matchmaking
+  - name: Stables
+  - name: Tag Teams
+  - name: Videos
+  - name: Announcements
+  - name: Notifications
+  - name: Transfers
+  - name: Storyline Requests
+  - name: Overalls
 
 components:
   securitySchemes:
@@ -530,6 +547,228 @@ components:
       type: object
       description: Response shape varies by query param section (overall, headToHead, leaderboards, records, achievements, etc.)
       additionalProperties: true
+
+    Company:
+      type: object
+      properties:
+        companyId: { type: string }
+        name: { type: string }
+        abbreviation: { type: string }
+        imageUrl: { type: string }
+        description: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Show:
+      type: object
+      properties:
+        showId: { type: string }
+        name: { type: string }
+        companyId: { type: string }
+        description: { type: string }
+        schedule: { type: string }
+        dayOfWeek: { type: string }
+        ppvDate: { type: string }
+        imageUrl: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Location:
+      type: object
+      properties:
+        locationId: { type: string }
+        name: { type: string }
+        city: { type: string }
+        state: { type: string }
+        country: { type: string }
+        capacity: { type: integer }
+        latitude: { type: number }
+        longitude: { type: number }
+        imageUrl: { type: string }
+        notes: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Wrestler:
+      type: object
+      properties:
+        wrestlerId: { type: string }
+        promotion: { type: string, enum: [AAA, AEW, NJPW, ROH, TNA, WCW, WWE, OTHER] }
+        name: { type: string }
+        overallCap: { type: integer, minimum: 70, maximum: 93 }
+        isInUse: { type: boolean }
+        assignedPlayerId: { type: string }
+        assignedSlot: { type: string, enum: [primary, alternate] }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Stable:
+      type: object
+      properties:
+        stableId: { type: string }
+        name: { type: string }
+        leaderId: { type: string }
+        memberIds: { type: array, items: { type: string } }
+        imageUrl: { type: string }
+        status: { type: string, enum: [pending, approved, active, disbanded] }
+        wins: { type: integer }
+        losses: { type: integer }
+        draws: { type: integer }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        disbandedAt: { type: string, format: date-time }
+
+    StableInvitation:
+      type: object
+      properties:
+        invitationId: { type: string }
+        stableId: { type: string }
+        invitedPlayerId: { type: string }
+        invitedByPlayerId: { type: string }
+        status: { type: string, enum: [pending, accepted, declined, expired] }
+        message: { type: string }
+        expiresAt: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    TagTeam:
+      type: object
+      properties:
+        tagTeamId: { type: string }
+        name: { type: string }
+        player1Id: { type: string }
+        player2Id: { type: string }
+        imageUrl: { type: string }
+        status: { type: string, enum: [pending_partner, pending_admin, active, dissolved] }
+        wins: { type: integer }
+        losses: { type: integer }
+        draws: { type: integer }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        dissolvedAt: { type: string, format: date-time }
+
+    Video:
+      type: object
+      properties:
+        videoId: { type: string }
+        title: { type: string }
+        description: { type: string }
+        videoUrl: { type: string }
+        thumbnailUrl: { type: string }
+        category: { type: string, enum: [match, highlight, promo, other] }
+        tags: { type: array, items: { type: string } }
+        isPublished: { type: boolean }
+        uploadedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    Announcement:
+      type: object
+      properties:
+        announcementId: { type: string }
+        title: { type: string }
+        body: { type: string }
+        priority: { type: integer }
+        isActive: { type: boolean }
+        expiresAt: { type: string, format: date-time }
+        videoUrl: { type: string }
+        createdBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    Notification:
+      type: object
+      properties:
+        notificationId: { type: string }
+        userId: { type: string }
+        type: { type: string }
+        message: { type: string }
+        sourceId: { type: string }
+        sourceType: { type: string }
+        isRead: { type: boolean }
+        createdAt: { type: string, format: date-time }
+
+    TransferRequest:
+      type: object
+      properties:
+        requestId: { type: string }
+        playerId: { type: string }
+        fromDivisionId: { type: string }
+        toDivisionId: { type: string }
+        reason: { type: string }
+        status: { type: string, enum: [pending, approved, rejected] }
+        reviewNote: { type: string }
+        reviewedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    StorylineRequest:
+      type: object
+      properties:
+        requestId: { type: string }
+        requesterId: { type: string }
+        targetPlayerIds: { type: array, items: { type: string } }
+        requestType: { type: string, enum: [storyline, backstage_attack, rivalry] }
+        description: { type: string }
+        status: { type: string, enum: [pending, acknowledged, declined] }
+        gmNote: { type: string }
+        reviewedBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    OverallSubmission:
+      type: object
+      properties:
+        playerId: { type: string }
+        mainOverall: { type: integer, minimum: 60, maximum: 99 }
+        alternateOverall: { type: integer, minimum: 60, maximum: 99 }
+        submittedAt: { type: string, format: date-time }
+
+    SeasonAward:
+      type: object
+      properties:
+        awardId: { type: string }
+        seasonId: { type: string }
+        name: { type: string }
+        awardType: { type: string }
+        playerId: { type: string }
+        playerName: { type: string }
+        description: { type: string }
+        value: { type: string }
+        autoGenerated: { type: boolean }
+        createdAt: { type: string, format: date-time }
+
+    ContenderOverride:
+      type: object
+      properties:
+        championshipId: { type: string }
+        playerId: { type: string }
+        overrideType: { type: string, enum: [bump_to_top, send_to_bottom] }
+        reason: { type: string }
+        createdBy: { type: string }
+        createdAt: { type: string, format: date-time }
+        expiresAt: { type: string, format: date-time }
+        active: { type: boolean }
+        playerName: { type: string }
+        wrestlerName: { type: string }
+        playerImageUrl: { type: string }
+
+    MatchmakingInvitation:
+      type: object
+      properties:
+        invitationId: { type: string }
+        fromPlayerId: { type: string }
+        toPlayerId: { type: string }
+        matchFormat: { type: string }
+        stipulationId: { type: string }
+        status: { type: string, enum: [pending, accepted, declined] }
+        createdAt: { type: string, format: date-time }
+        expiresAt: { type: string, format: date-time }
+
+    DeleteUserInput:
+      type: object
+      required: [userId]
+      properties:
+        userId: { type: string }
 
 paths:
   /auth/setup:
@@ -1516,5 +1755,1752 @@ paths:
             schema: { $ref: '#/components/schemas/BulkDeletePromosInput' }
       responses:
         '200': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Dashboard & Activity ──────────────────────────────────────────
+
+  /dashboard:
+    get:
+      tags: [Dashboard]
+      summary: Get dashboard overview
+      responses:
+        '200': { description: Dashboard data with current champions, upcoming events, recent results, season info, quick stats }
+
+  /activity:
+    get:
+      tags: [Activity]
+      summary: Get activity feed
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+        - name: cursor
+          in: query
+          schema: { type: string }
+          description: Pagination cursor (timestamp|id)
+        - name: type
+          in: query
+          schema: { type: string, enum: [match, championship, challenge, promo, tournament, season] }
+      responses:
+        '200':
+          description: Paginated activity items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items: { type: array, items: { type: object } }
+                  nextCursor: { type: string, nullable: true }
+
+  /rivalries:
+    get:
+      tags: [Rivalries]
+      summary: Get rivalry rankings
+      parameters:
+        - name: seasonId
+          in: query
+          schema: { type: string }
+      responses:
+        '200': { description: Top rivalries sorted by intensity }
+
+  # ── Season Awards ─────────────────────────────────────────────────
+
+  /seasons/{seasonId}/awards:
+    get:
+      tags: [Season Awards]
+      summary: Get season awards (auto + custom)
+      parameters:
+        - name: seasonId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Auto-generated and custom awards }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    post:
+      tags: [Season Awards]
+      summary: Create custom season award
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: seasonId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, playerId]
+              properties:
+                name: { type: string }
+                playerId: { type: string }
+                description: { type: string }
+      responses:
+        '201': { description: Award created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /seasons/{seasonId}/awards/{awardId}:
+    delete:
+      tags: [Season Awards]
+      summary: Delete custom season award
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: seasonId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: awardId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Admin Users (additional) ──────────────────────────────────────
+
+  /admin/users/delete:
+    post:
+      tags: [Users]
+      summary: Delete user
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/DeleteUserInput' }
+      responses:
+        '200': { description: User deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Player Statistics ─────────────────────────────────────────────
+
+  /players/{playerId}/statistics:
+    get:
+      tags: [Players]
+      summary: Get player statistics breakdown
+      parameters:
+        - name: playerId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: seasonId
+          in: query
+          schema: { type: string }
+      responses:
+        '200': { description: Player stats with overall and per-match-type breakdown }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Companies ─────────────────────────────────────────────────────
+
+  /companies:
+    get:
+      tags: [Companies]
+      summary: List companies
+      responses:
+        '200': { description: List of companies }
+    post:
+      tags: [Companies]
+      summary: Create company
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                abbreviation: { type: string }
+                imageUrl: { type: string }
+                description: { type: string }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /companies/{companyId}:
+    get:
+      tags: [Companies]
+      summary: Get company
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Company }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Companies]
+      summary: Update company
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                abbreviation: { type: string }
+                imageUrl: { type: string }
+                description: { type: string }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Companies]
+      summary: Delete company
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – players or shows assigned', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Shows ──────────────────────────────────────────────────────────
+
+  /shows:
+    get:
+      tags: [Shows]
+      summary: List shows
+      parameters:
+        - name: companyId
+          in: query
+          schema: { type: string }
+      responses:
+        '200': { description: List of shows }
+    post:
+      tags: [Shows]
+      summary: Create show
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, companyId]
+              properties:
+                name: { type: string }
+                companyId: { type: string }
+                description: { type: string }
+                schedule: { type: string }
+                dayOfWeek: { type: string }
+                ppvDate: { type: string }
+                imageUrl: { type: string }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /shows/{showId}:
+    get:
+      tags: [Shows]
+      summary: Get show
+      parameters:
+        - name: showId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Show }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Shows]
+      summary: Update show
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: showId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                companyId: { type: string }
+                description: { type: string }
+                schedule: { type: string }
+                dayOfWeek: { type: string }
+                ppvDate: { type: string }
+                imageUrl: { type: string }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Shows]
+      summary: Delete show
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: showId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – events reference this show', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Locations ──────────────────────────────────────────────────────
+
+  /locations:
+    get:
+      tags: [Locations]
+      summary: List locations
+      responses:
+        '200': { description: Locations sorted alphabetically }
+    post:
+      tags: [Locations]
+      summary: Create location
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                city: { type: string }
+                state: { type: string }
+                country: { type: string }
+                capacity: { type: integer }
+                latitude: { type: number }
+                longitude: { type: number }
+                imageUrl: { type: string }
+                notes: { type: string }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /locations/bulk:
+    post:
+      tags: [Locations]
+      summary: Bulk create locations
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [locations]
+              properties:
+                locations:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name: { type: string }
+                      city: { type: string }
+                      state: { type: string }
+                      country: { type: string }
+                      capacity: { type: integer }
+                      latitude: { type: number }
+                      longitude: { type: number }
+                      imageUrl: { type: string }
+                      notes: { type: string }
+      responses:
+        '200': { description: Array of created locations }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /locations/{locationId}:
+    get:
+      tags: [Locations]
+      summary: Get location
+      parameters:
+        - name: locationId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Location }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Locations]
+      summary: Update location
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: locationId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                city: { type: string }
+                state: { type: string }
+                country: { type: string }
+                capacity: { type: integer }
+                latitude: { type: number }
+                longitude: { type: number }
+                imageUrl: { type: string }
+                notes: { type: string }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Locations]
+      summary: Delete location
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: locationId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Wrestlers ──────────────────────────────────────────────────────
+
+  /wrestlers:
+    get:
+      tags: [Wrestlers]
+      summary: List wrestlers
+      parameters:
+        - name: promotion
+          in: query
+          schema: { type: string, enum: [AAA, AEW, NJPW, ROH, TNA, WCW, WWE, OTHER] }
+        - name: available
+          in: query
+          schema: { type: string, enum: ['true', 'false'] }
+      responses:
+        '200': { description: List of wrestlers }
+    post:
+      tags: [Wrestlers]
+      summary: Create wrestler
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [promotion, name, overallCap]
+              properties:
+                promotion: { type: string, enum: [AAA, AEW, NJPW, ROH, TNA, WCW, WWE, OTHER] }
+                name: { type: string, minLength: 1, maxLength: 128 }
+                overallCap: { type: integer, minimum: 70, maximum: 93 }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /wrestlers/{wrestlerId}:
+    get:
+      tags: [Wrestlers]
+      summary: Get wrestler
+      parameters:
+        - name: wrestlerId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Wrestler }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Wrestlers]
+      summary: Update wrestler
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: wrestlerId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                promotion: { type: string }
+                name: { type: string }
+                overallCap: { type: integer, minimum: 70, maximum: 93 }
+                isInUse: { type: boolean }
+                assignedPlayerId: { type: string, nullable: true }
+                assignedSlot: { type: string, enum: [primary, alternate], nullable: true }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Wrestlers]
+      summary: Delete wrestler
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: wrestlerId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – wrestler is in use', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /wrestlers/import:
+    post:
+      tags: [Wrestlers]
+      summary: Bulk import wrestlers
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wrestlers:
+                  type: array
+                  items:
+                    type: object
+                    required: [promotion, name, overallCap]
+                    properties:
+                      promotion: { type: string }
+                      name: { type: string }
+                      overallCap: { type: integer }
+      responses:
+        '200': { description: Import results }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Event Check-Ins ────────────────────────────────────────────────
+
+  /events/{eventId}/check-in:
+    post:
+      tags: [Events]
+      summary: Check in to event
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status: { type: string, enum: [available, tentative, unavailable] }
+      responses:
+        '200': { description: Check-in recorded }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Events]
+      summary: Delete my check-in
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /events/{eventId}/check-in/me:
+    get:
+      tags: [Events]
+      summary: Get my check-in for event
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: My check-in }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'No check-in found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /events/{eventId}/check-ins/summary:
+    get:
+      tags: [Events]
+      summary: Get check-in summary counts
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Check-in counts by status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  eventId: { type: string }
+                  available: { type: integer }
+                  tentative: { type: integer }
+                  unavailable: { type: integer }
+                  total: { type: integer }
+
+  /events/{eventId}/check-ins:
+    get:
+      tags: [Events]
+      summary: Get all check-ins grouped by status (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Check-ins grouped by available, tentative, unavailable, noResponse }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Match Slots ────────────────────────────────────────────────────
+
+  /matches/{matchId}/slots/{slotId}/claim:
+    post:
+      tags: [Matches]
+      summary: Claim a match slot
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: matchId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: slotId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                wrestlerChoice: { type: string, enum: [main, alternate] }
+      responses:
+        '200': { description: Updated match with claimed slot }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – slot taken or match not open', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Matches]
+      summary: Release a match slot
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: matchId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: slotId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Updated match with released slot }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matches/{matchId}/slots/{slotId}:
+    put:
+      tags: [Matches]
+      summary: Admin update slot
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: matchId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: slotId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                playerId: { type: string, nullable: true }
+                lockedByAdmin: { type: boolean }
+                teamLabel: { type: string, nullable: true }
+                wrestlerChoice: { type: string, enum: [main, alternate] }
+      responses:
+        '200': { description: Updated match }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Contender Overrides ────────────────────────────────────────────
+
+  /admin/contenders/overrides:
+    get:
+      tags: [Contenders]
+      summary: Get all active contender overrides
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: championshipId
+          in: query
+          schema: { type: string }
+      responses:
+        '200': { description: List of overrides with player info }
+    post:
+      tags: [Contenders]
+      summary: Set contender override
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [championshipId, playerId, overrideType, reason]
+              properties:
+                championshipId: { type: string }
+                playerId: { type: string }
+                overrideType: { type: string, enum: [bump_to_top, send_to_bottom] }
+                reason: { type: string }
+                expiresAt: { type: string, format: date-time }
+      responses:
+        '201': { description: Override created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/contenders/overrides/{championshipId}/{playerId}:
+    delete:
+      tags: [Contenders]
+      summary: Remove contender override
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: championshipId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: playerId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Override removed }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Matchmaking ────────────────────────────────────────────────────
+
+  /matchmaking/heartbeat:
+    post:
+      tags: [Matchmaking]
+      summary: Send presence heartbeat
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: Heartbeat acknowledged }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/presence:
+    delete:
+      tags: [Matchmaking]
+      summary: Leave presence (go offline)
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: Presence removed }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/queue:
+    get:
+      tags: [Matchmaking]
+      summary: Get active matchmaking queue
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: Queue entries with player info }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/queue/join:
+    post:
+      tags: [Matchmaking]
+      summary: Join matchmaking queue
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                matchFormat: { type: string }
+                stipulationId: { type: string }
+                expiresInMinutes: { type: integer, default: 15 }
+      responses:
+        '200': { description: Queued }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – no active presence', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/queue/leave:
+    post:
+      tags: [Matchmaking]
+      summary: Leave matchmaking queue
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: Left queue }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/online:
+    get:
+      tags: [Matchmaking]
+      summary: Get online players
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: List of online presence records }
+
+  /matchmaking/invite:
+    post:
+      tags: [Matchmaking]
+      summary: Create match invitation
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [targetPlayerId]
+              properties:
+                targetPlayerId: { type: string }
+                matchFormat: { type: string }
+                stipulationId: { type: string }
+      responses:
+        '201': { description: Invitation created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – duplicate or target offline', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/invitations:
+    get:
+      tags: [Matchmaking]
+      summary: Get my invitations (incoming + outgoing)
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200':
+          description: Invitations with player info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  incoming: { type: array, items: { $ref: '#/components/schemas/MatchmakingInvitation' } }
+                  outgoing: { type: array, items: { $ref: '#/components/schemas/MatchmakingInvitation' } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/invitations/{invitationId}/accept:
+    post:
+      tags: [Matchmaking]
+      summary: Accept match invitation
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: invitationId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Match created from invitation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  matchId: { type: string }
+                  invitation: { $ref: '#/components/schemas/MatchmakingInvitation' }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – expired or already responded', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /matchmaking/invitations/{invitationId}/decline:
+    post:
+      tags: [Matchmaking]
+      summary: Decline match invitation
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: invitationId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Declined }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Stables ────────────────────────────────────────────────────────
+
+  /stables:
+    get:
+      tags: [Stables]
+      summary: List stables
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string, enum: [pending, approved, active, disbanded] }
+      responses:
+        '200': { description: List of stables }
+    post:
+      tags: [Stables]
+      summary: Create stable
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                imageUrl: { type: string }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – already in a stable', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/standings:
+    get:
+      tags: [Stables]
+      summary: Get stable standings
+      responses:
+        '200': { description: Stables sorted by wins }
+
+  /stables/{stableId}:
+    get:
+      tags: [Stables]
+      summary: Get stable
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Stable }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Stables]
+      summary: Update stable
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/Stable' }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Stables]
+      summary: Delete stable (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/approve:
+    post:
+      tags: [Stables]
+      summary: Approve stable (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Approved }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/reject:
+    post:
+      tags: [Stables]
+      summary: Reject stable (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Rejected }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/disband:
+    post:
+      tags: [Stables]
+      summary: Disband stable (leader only)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Disbanded }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/reactivate:
+    post:
+      tags: [Stables]
+      summary: Reactivate disbanded stable (leader only)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Reactivated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/remove-member:
+    post:
+      tags: [Stables]
+      summary: Remove member from stable (leader only)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [playerId]
+              properties:
+                playerId: { type: string }
+      responses:
+        '200': { description: Member removed }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/invitations:
+    get:
+      tags: [Stables]
+      summary: Get stable invitations (leader only)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: List of invitations }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    post:
+      tags: [Stables]
+      summary: Invite player to stable (leader only)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [playerId]
+              properties:
+                playerId: { type: string }
+                message: { type: string }
+      responses:
+        '201': { description: Invitation sent }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – stable full or player already in stable', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /stables/{stableId}/invitations/{invitationId}/respond:
+    post:
+      tags: [Stables]
+      summary: Respond to stable invitation
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: stableId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: invitationId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action]
+              properties:
+                action: { type: string, enum: [accept, decline] }
+      responses:
+        '200': { description: Responded }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Tag Teams ──────────────────────────────────────────────────────
+
+  /tag-teams:
+    get:
+      tags: [Tag Teams]
+      summary: List tag teams
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string, enum: [pending_partner, pending_admin, active, dissolved] }
+      responses:
+        '200': { description: List of tag teams with player names }
+    post:
+      tags: [Tag Teams]
+      summary: Create tag team
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, partnerId]
+              properties:
+                name: { type: string }
+                partnerId: { type: string }
+                imageUrl: { type: string }
+      responses:
+        '201': { description: Created (pending partner approval) }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '409': { description: 'Conflict – already in a tag team', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /tag-teams/standings:
+    get:
+      tags: [Tag Teams]
+      summary: Get tag team standings
+      responses:
+        '200': { description: Tag teams sorted by wins }
+
+  /tag-teams/{tagTeamId}:
+    get:
+      tags: [Tag Teams]
+      summary: Get tag team
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Tag team }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Tag Teams]
+      summary: Update tag team
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TagTeam' }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Tag Teams]
+      summary: Delete tag team (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /tag-teams/{tagTeamId}/respond:
+    post:
+      tags: [Tag Teams]
+      summary: Respond to tag team invitation (partner)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action]
+              properties:
+                action: { type: string, enum: [accept, decline] }
+      responses:
+        '200': { description: Responded }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /tag-teams/{tagTeamId}/approve:
+    post:
+      tags: [Tag Teams]
+      summary: Approve tag team (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Approved }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /tag-teams/{tagTeamId}/reject:
+    post:
+      tags: [Tag Teams]
+      summary: Reject tag team (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Rejected }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /tag-teams/{tagTeamId}/dissolve:
+    post:
+      tags: [Tag Teams]
+      summary: Dissolve tag team (member)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: tagTeamId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Dissolved }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Videos ─────────────────────────────────────────────────────────
+
+  /videos:
+    get:
+      tags: [Videos]
+      summary: List published videos
+      parameters:
+        - name: category
+          in: query
+          schema: { type: string, enum: [match, highlight, promo, other] }
+      responses:
+        '200': { description: List of published videos }
+
+  /videos/{videoId}:
+    get:
+      tags: [Videos]
+      summary: Get video
+      parameters:
+        - name: videoId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Video }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/videos:
+    get:
+      tags: [Videos]
+      summary: List all videos (admin)
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: All videos including unpublished }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    post:
+      tags: [Videos]
+      summary: Create video
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title, videoUrl, category]
+              properties:
+                title: { type: string }
+                description: { type: string }
+                videoUrl: { type: string }
+                thumbnailUrl: { type: string }
+                category: { type: string, enum: [match, highlight, promo, other] }
+                tags: { type: array, items: { type: string } }
+                isPublished: { type: boolean }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/videos/{videoId}:
+    put:
+      tags: [Videos]
+      summary: Update video (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: videoId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                description: { type: string }
+                videoUrl: { type: string }
+                thumbnailUrl: { type: string }
+                category: { type: string, enum: [match, highlight, promo, other] }
+                tags: { type: array, items: { type: string } }
+                isPublished: { type: boolean }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Videos]
+      summary: Delete video (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: videoId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Announcements ──────────────────────────────────────────────────
+
+  /announcements/active:
+    get:
+      tags: [Announcements]
+      summary: Get active announcements
+      responses:
+        '200': { description: List of active announcements }
+
+  /admin/announcements:
+    get:
+      tags: [Announcements]
+      summary: List all announcements (admin)
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: All announcements }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    post:
+      tags: [Announcements]
+      summary: Create announcement
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title, body]
+              properties:
+                title: { type: string }
+                body: { type: string }
+                priority: { type: integer }
+                isActive: { type: boolean }
+                expiresAt: { type: string, format: date-time }
+                videoUrl: { type: string }
+      responses:
+        '201': { description: Created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/announcements/{announcementId}:
+    put:
+      tags: [Announcements]
+      summary: Update announcement
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: announcementId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                body: { type: string }
+                priority: { type: integer }
+                isActive: { type: boolean }
+                expiresAt: { type: string, format: date-time, nullable: true }
+      responses:
+        '200': { description: Updated }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    delete:
+      tags: [Announcements]
+      summary: Delete announcement
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: announcementId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Notifications ──────────────────────────────────────────────────
+
+  /notifications:
+    get:
+      tags: [Notifications]
+      summary: Get my notifications
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20 }
+        - name: cursor
+          in: query
+          schema: { type: string }
+      responses:
+        '200':
+          description: Paginated notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items: { type: array, items: { $ref: '#/components/schemas/Notification' } }
+                  nextCursor: { type: string }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /notifications/unread-count:
+    get:
+      tags: [Notifications]
+      summary: Get unread notification count
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200':
+          description: Unread count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count: { type: integer }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /notifications/{notificationId}/read:
+    put:
+      tags: [Notifications]
+      summary: Mark notification as read
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: notificationId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Marked read }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /notifications/mark-all-read:
+    put:
+      tags: [Notifications]
+      summary: Mark all notifications as read
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200':
+          description: Count of updated notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updated: { type: integer }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /notifications/{notificationId}:
+    delete:
+      tags: [Notifications]
+      summary: Delete notification
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: notificationId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Deleted }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /notifications/delete-read:
+    delete:
+      tags: [Notifications]
+      summary: Delete all read notifications
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200':
+          description: Count of deleted notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: integer }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Transfers ──────────────────────────────────────────────────────
+
+  /transfers:
+    post:
+      tags: [Transfers]
+      summary: Request division transfer
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toDivisionId, reason]
+              properties:
+                toDivisionId: { type: string }
+                reason: { type: string }
+      responses:
+        '200': { description: Transfer request created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /transfers/me:
+    get:
+      tags: [Transfers]
+      summary: Get my transfer requests
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: List of my transfer requests with division names }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/transfers:
+    get:
+      tags: [Transfers]
+      summary: List all transfer requests (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string, enum: [pending, approved, rejected] }
+      responses:
+        '200': { description: Transfer requests with player and division names }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/transfers/{requestId}:
+    put:
+      tags: [Transfers]
+      summary: Review transfer request (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: requestId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status: { type: string, enum: [approved, rejected] }
+                reviewNote: { type: string }
+      responses:
+        '200': { description: Transfer reviewed }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Storyline Requests ─────────────────────────────────────────────
+
+  /storyline-requests:
+    post:
+      tags: [Storyline Requests]
+      summary: Submit storyline request
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [requestType, targetPlayerIds, description]
+              properties:
+                requestType: { type: string, enum: [storyline, backstage_attack, rivalry] }
+                targetPlayerIds: { type: array, items: { type: string } }
+                description: { type: string, maxLength: 500 }
+      responses:
+        '200': { description: Request created }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /storyline-requests/me:
+    get:
+      tags: [Storyline Requests]
+      summary: Get my storyline requests
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: List of my storyline requests with target player names }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/storyline-requests:
+    get:
+      tags: [Storyline Requests]
+      summary: List all storyline requests (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: status
+          in: query
+          schema: { type: string, enum: [pending, acknowledged, declined] }
+      responses:
+        '200': { description: Storyline requests with requester and target names }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/storyline-requests/{requestId}:
+    put:
+      tags: [Storyline Requests]
+      summary: Review storyline request (admin)
+      security: [{ BearerAuth: [] }]
+      parameters:
+        - name: requestId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status: { type: string, enum: [acknowledged, declined] }
+                gmNote: { type: string }
+      responses:
+        '200': { description: Request reviewed }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'Not found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  # ── Overalls ───────────────────────────────────────────────────────
+
+  /players/me/overall:
+    get:
+      tags: [Overalls]
+      summary: Get my overall rating
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: My overall submission }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '404': { description: 'No submission found', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+    put:
+      tags: [Overalls]
+      summary: Submit my overall rating
+      security: [{ BearerAuth: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [mainOverall]
+              properties:
+                mainOverall: { type: integer, minimum: 60, maximum: 99 }
+                alternateOverall: { type: integer, minimum: 60, maximum: 99 }
+      responses:
+        '200': { description: Submitted }
+        '400': { description: 'Bad request', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+
+  /admin/overalls:
+    get:
+      tags: [Overalls]
+      summary: Get all overall submissions (admin)
+      security: [{ BearerAuth: [] }]
+      responses:
+        '200': { description: All player overall submissions with names }
         '401': { description: 'Unauthorized', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
         '403': { description: 'Forbidden', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }


### PR DESCRIPTION
## Summary
- Expands `backend/docs/openapi.yaml` to document Dashboard, Activity, Rivalries, Season Awards, Companies, Shows, Locations, Wrestlers, Matchmaking, Stables, Tag Teams, Videos, Announcements, Notifications, Transfers, Storyline Requests, and Overalls (tags, schemas, paths).
- Adds `ManageLocations` admin UI with `locationsApi` client, `/admin/locations` route + sidebar nav, EN+DE i18n keys, and Vitest coverage (LOC-02).

## Test plan
- [ ] `cd backend && npx tsc --project tsconfig.json --noEmit`
- [ ] `cd frontend && npx tsc --project tsconfig.app.json --noEmit`
- [ ] Open `backend/docs/openapi.yaml` in Swagger Editor / Redoc and confirm it lints clean
- [ ] `cd frontend && npm test -- ManageLocations`
- [ ] Manually exercise `/admin/locations` (create, edit, delete) in dev environment
- [ ] Verify EN and DE translations render on the locations page

🤖 Generated with [Claude Code](https://claude.com/claude-code)