### PR TITLE
feat(tag-teams): TTP-01 editable per-team wrestler personas

### DIFF
--- a/backend/functions/tagTeams/__tests__/getTagTeam.test.ts
+++ b/backend/functions/tagTeams/__tests__/getTagTeam.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+const {
+  mockTagTeamsFindById,
+  mockTagTeamsListByStatus,
+  mockPlayersFindById,
+  mockMatchesListCompleted,
+} = vi.hoisted(() => ({
+  mockTagTeamsFindById: vi.fn(),
+  mockTagTeamsListByStatus: vi.fn(),
+  mockPlayersFindById: vi.fn(),
+  mockMatchesListCompleted: vi.fn(),
+}));
+
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    roster: {
+      tagTeams: {
+        findById: mockTagTeamsFindById,
+        listByStatus: mockTagTeamsListByStatus,
+      },
+      players: {
+        findById: mockPlayersFindById,
+      },
+    },
+    competition: {
+      matches: {
+        listCompleted: mockMatchesListCompleted,
+      },
+    },
+  }),
+}));
+
+import { handler as getTagTeam } from '../getTagTeam';
+
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(tagTeamId = 'tt1'): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '/',
+    pathParameters: { tagTeamId },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {} as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+const player1 = {
+  playerId: 'p1',
+  name: 'Adam',
+  currentWrestler: 'Edge (solo)',
+  imageUrl: undefined,
+  psnId: undefined,
+};
+
+const player2 = {
+  playerId: 'p2',
+  name: 'Jay',
+  currentWrestler: 'Christian (solo)',
+  imageUrl: undefined,
+  psnId: undefined,
+};
+
+describe('getTagTeam — TTP-01 wrestler-name fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTagTeamsListByStatus.mockResolvedValue([]);
+    mockMatchesListCompleted.mockResolvedValue([]);
+    mockPlayersFindById.mockImplementation(async (id: string) => {
+      if (id === 'p1') return player1;
+      if (id === 'p2') return player2;
+      return null;
+    });
+  });
+
+  it('uses tagTeam.playerNWrestlerName when the override is set', async () => {
+    mockTagTeamsFindById.mockResolvedValue({
+      tagTeamId: 'tt1',
+      name: 'The Brood',
+      player1Id: 'p1',
+      player2Id: 'p2',
+      player1WrestlerName: 'Brood Edge',
+      player2WrestlerName: 'Brood Christian',
+      status: 'active',
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      createdAt: '',
+      updatedAt: '',
+    });
+
+    const result = await getTagTeam(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.player1.wrestlerName).toBe('Brood Edge');
+    expect(body.player2.wrestlerName).toBe('Brood Christian');
+  });
+
+  it('falls back to the player solo currentWrestler when the override is unset', async () => {
+    mockTagTeamsFindById.mockResolvedValue({
+      tagTeamId: 'tt1',
+      name: 'The Brood',
+      player1Id: 'p1',
+      player2Id: 'p2',
+      status: 'active',
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      createdAt: '',
+      updatedAt: '',
+    });
+
+    const result = await getTagTeam(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.player1.wrestlerName).toBe('Edge (solo)');
+    expect(body.player2.wrestlerName).toBe('Christian (solo)');
+  });
+
+  it('falls back to currentWrestler when the override is an empty string', async () => {
+    mockTagTeamsFindById.mockResolvedValue({
+      tagTeamId: 'tt1',
+      name: 'The Brood',
+      player1Id: 'p1',
+      player2Id: 'p2',
+      player1WrestlerName: '',
+      player2WrestlerName: '',
+      status: 'active',
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      createdAt: '',
+      updatedAt: '',
+    });
+
+    const result = await getTagTeam(makeEvent(), ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.player1.wrestlerName).toBe('Edge (solo)');
+    expect(body.player2.wrestlerName).toBe('Christian (solo)');
+  });
+});

--- a/backend/functions/tagTeams/__tests__/updateTagTeam.test.ts
+++ b/backend/functions/tagTeams/__tests__/updateTagTeam.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+const {
+  mockTagTeamsFindById,
+  mockTagTeamsUpdate,
+  mockPlayersFindByUserId,
+} = vi.hoisted(() => ({
+  mockTagTeamsFindById: vi.fn(),
+  mockTagTeamsUpdate: vi.fn(),
+  mockPlayersFindByUserId: vi.fn(),
+}));
+
+vi.mock('../../../lib/repositories', () => ({
+  getRepositories: () => ({
+    roster: {
+      tagTeams: {
+        findById: mockTagTeamsFindById,
+        update: mockTagTeamsUpdate,
+      },
+      players: {
+        findByUserId: mockPlayersFindByUserId,
+      },
+    },
+  }),
+}));
+
+import { handler as updateTagTeam } from '../updateTagTeam';
+
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(
+  groups: string,
+  sub: string,
+  body: unknown,
+  pathParameters: Record<string, string> | null = { tagTeamId: 'tt1' },
+): APIGatewayProxyEvent {
+  return {
+    body: body === undefined ? null : JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'PUT',
+    isBase64Encoded: false,
+    path: '/',
+    pathParameters,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: {
+        groups,
+        username: 'tester',
+        email: 'tester@test.com',
+        principalId: sub,
+      },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+const baseTagTeam = {
+  tagTeamId: 'tt1',
+  name: 'The Brood',
+  player1Id: 'p1',
+  player2Id: 'p2',
+  status: 'active' as const,
+  wins: 0,
+  losses: 0,
+  draws: 0,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('updateTagTeam — TTP-01 wrestler persona fields', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('persists player1WrestlerName and player2WrestlerName when caller is a member', async () => {
+    mockTagTeamsFindById.mockResolvedValue(baseTagTeam);
+    mockPlayersFindByUserId.mockResolvedValue({ playerId: 'p1' });
+    mockTagTeamsUpdate.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...baseTagTeam,
+      ...patch,
+    }));
+
+    const event = makeEvent('Wrestler', 'user-sub-1', {
+      name: 'The Brood',
+      player1WrestlerName: 'Edge',
+      player2WrestlerName: 'Christian',
+    });
+
+    const result = await updateTagTeam(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    expect(mockTagTeamsUpdate).toHaveBeenCalledTimes(1);
+    const [, patch] = mockTagTeamsUpdate.mock.calls[0];
+    expect(patch.player1WrestlerName).toBe('Edge');
+    expect(patch.player2WrestlerName).toBe('Christian');
+    expect(patch.name).toBe('The Brood');
+  });
+
+  it('trims whitespace from wrestler-name overrides before persisting', async () => {
+    mockTagTeamsFindById.mockResolvedValue(baseTagTeam);
+    mockPlayersFindByUserId.mockResolvedValue({ playerId: 'p2' });
+    mockTagTeamsUpdate.mockResolvedValue(baseTagTeam);
+
+    const event = makeEvent('Wrestler', 'user-sub-2', {
+      player1WrestlerName: '  Edge  ',
+      player2WrestlerName: '  Christian  ',
+    });
+
+    const result = await updateTagTeam(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const [, patch] = mockTagTeamsUpdate.mock.calls[0];
+    expect(patch.player1WrestlerName).toBe('Edge');
+    expect(patch.player2WrestlerName).toBe('Christian');
+  });
+
+  it('omits the wrestler-name fields when submitted empty so the existing override is preserved', async () => {
+    mockTagTeamsFindById.mockResolvedValue(baseTagTeam);
+    mockPlayersFindByUserId.mockResolvedValue({ playerId: 'p1' });
+    mockTagTeamsUpdate.mockResolvedValue(baseTagTeam);
+
+    const event = makeEvent('Wrestler', 'user-sub-1', {
+      name: 'New Name',
+      player1WrestlerName: '',
+      player2WrestlerName: '   ',
+    });
+
+    const result = await updateTagTeam(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const [, patch] = mockTagTeamsUpdate.mock.calls[0];
+    expect(patch.name).toBe('New Name');
+    expect(patch).not.toHaveProperty('player1WrestlerName');
+    expect(patch).not.toHaveProperty('player2WrestlerName');
+  });
+
+  it('returns 403 when caller is neither a tag-team member nor an admin', async () => {
+    mockTagTeamsFindById.mockResolvedValue(baseTagTeam);
+    mockPlayersFindByUserId.mockResolvedValue({ playerId: 'outsider' });
+
+    const event = makeEvent('Wrestler', 'user-sub-3', {
+      player1WrestlerName: 'Should Fail',
+    });
+
+    const result = await updateTagTeam(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(403);
+    expect(mockTagTeamsUpdate).not.toHaveBeenCalled();
+  });
+
+  it('allows an admin who is not a member to set the override', async () => {
+    mockTagTeamsFindById.mockResolvedValue(baseTagTeam);
+    mockTagTeamsUpdate.mockResolvedValue(baseTagTeam);
+
+    const event = makeEvent('Admin', 'admin-sub', {
+      player1WrestlerName: 'Stone Cold',
+    });
+
+    const result = await updateTagTeam(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    expect(mockPlayersFindByUserId).not.toHaveBeenCalled();
+    const [, patch] = mockTagTeamsUpdate.mock.calls[0];
+    expect(patch.player1WrestlerName).toBe('Stone Cold');
+  });
+
+  it('returns 400 when the body has no recognised fields to update', async () => {
+    mockTagTeamsFindById.mockResolvedValue(baseTagTeam);
+    mockPlayersFindByUserId.mockResolvedValue({ playerId: 'p1' });
+
+    const event = makeEvent('Wrestler', 'user-sub-1', {
+      player1WrestlerName: '',
+      player2WrestlerName: '',
+    });
+
+    const result = await updateTagTeam(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(mockTagTeamsUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/backend/functions/tagTeams/getTagTeam.ts
+++ b/backend/functions/tagTeams/getTagTeam.ts
@@ -155,7 +155,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       ? {
           playerId: player1.playerId,
           playerName: player1.name,
-          wrestlerName: player1.currentWrestler,
+          wrestlerName: tagTeam.player1WrestlerName || player1.currentWrestler,
           imageUrl: player1.imageUrl,
           psnId: player1.psnId,
         }
@@ -165,7 +165,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       ? {
           playerId: player2.playerId,
           playerName: player2.name,
-          wrestlerName: player2.currentWrestler,
+          wrestlerName: tagTeam.player2WrestlerName || player2.currentWrestler,
           imageUrl: player2.imageUrl,
           psnId: player2.psnId,
         }

--- a/backend/functions/tagTeams/updateTagTeam.ts
+++ b/backend/functions/tagTeams/updateTagTeam.ts
@@ -7,6 +7,8 @@ import { parseBody } from '../../lib/parseBody';
 interface UpdateTagTeamBody {
   name?: string;
   imageUrl?: string;
+  player1WrestlerName?: string;
+  player2WrestlerName?: string;
 }
 
 export const handler: APIGatewayProxyHandler = async (event) => {
@@ -23,7 +25,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     const { data: body, error: parseError } = parseBody<UpdateTagTeamBody>(event);
     if (parseError) return parseError;
-    const { name, imageUrl } = body;
+    const { name, imageUrl, player1WrestlerName, player2WrestlerName } = body;
 
     const { roster: { tagTeams: tagTeamsRepo, players: playersRepo } } = getRepositories();
 
@@ -51,6 +53,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const updateFields: Record<string, unknown> = {};
     if (name !== undefined) updateFields.name = name;
     if (imageUrl !== undefined) updateFields.imageUrl = imageUrl;
+    // Empty/whitespace input is treated as "leave unchanged" — read-side
+    // falls back to player.currentWrestler when the override is unset.
+    if (player1WrestlerName !== undefined && player1WrestlerName.trim() !== '') {
+      updateFields.player1WrestlerName = player1WrestlerName.trim();
+    }
+    if (player2WrestlerName !== undefined && player2WrestlerName.trim() !== '') {
+      updateFields.player2WrestlerName = player2WrestlerName.trim();
+    }
 
     if (Object.keys(updateFields).length === 0) {
       return badRequest('No fields to update');

--- a/backend/lib/repositories/RosterRepository.ts
+++ b/backend/lib/repositories/RosterRepository.ts
@@ -62,6 +62,8 @@ export interface TagTeamCreateInput {
 
 export interface TagTeamPatch {
   name?: string;
+  player1WrestlerName?: string;
+  player2WrestlerName?: string;
   imageUrl?: string;
   status?: TagTeamStatus;
   wins?: number;

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -176,6 +176,8 @@ export interface TagTeam {
   name: string;
   player1Id: string;
   player2Id: string;
+  player1WrestlerName?: string;
+  player2WrestlerName?: string;
   imageUrl?: string;
   status: TagTeamStatus;
   wins: number;

--- a/frontend/src/components/tagTeams/MyTagTeam.css
+++ b/frontend/src/components/tagTeams/MyTagTeam.css
@@ -420,6 +420,77 @@
   color: #fbbf24;
 }
 
+/* Edit team identity (TTP-01) */
+.my-tag-team__identity {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.my-tag-team__identity h4 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+.my-tag-team__identity-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.my-tag-team__identity-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.my-tag-team__identity-field span {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.my-tag-team__identity-field input {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.my-tag-team__identity-field input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.my-tag-team__identity .btn-primary {
+  align-self: flex-start;
+  padding: 0.6rem 1.4rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--color-primary);
+  color: #000;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.my-tag-team__identity .btn-primary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.my-tag-team__identity .btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Actions */
 .my-tag-team__actions {
   display: flex;

--- a/frontend/src/components/tagTeams/MyTagTeam.tsx
+++ b/frontend/src/components/tagTeams/MyTagTeam.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type FormEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
@@ -25,6 +25,12 @@ export default function MyTagTeam() {
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [dissolving, setDissolving] = useState(false);
+
+  // Edit-identity form state (TTP-01)
+  const [identityName, setIdentityName] = useState('');
+  const [identityMyWrestler, setIdentityMyWrestler] = useState('');
+  const [identityPartnerWrestler, setIdentityPartnerWrestler] = useState('');
+  const [savingIdentity, setSavingIdentity] = useState(false);
 
   const loadData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -82,6 +88,24 @@ export default function MyTagTeam() {
     return () => controller.abort();
   }, [isAuthenticated, loadData]);
 
+  // Seed the edit-identity form whenever the tag team or current player changes.
+  useEffect(() => {
+    if (!tagTeam || !profile) {
+      setIdentityName('');
+      setIdentityMyWrestler('');
+      setIdentityPartnerWrestler('');
+      return;
+    }
+    const isPlayer1 = tagTeam.player1.playerId === profile.playerId;
+    const myOverride = isPlayer1 ? tagTeam.player1WrestlerName : tagTeam.player2WrestlerName;
+    const partnerOverride = isPlayer1 ? tagTeam.player2WrestlerName : tagTeam.player1WrestlerName;
+    const myFallback = isPlayer1 ? tagTeam.player1.wrestlerName : tagTeam.player2.wrestlerName;
+    const partnerFallback = isPlayer1 ? tagTeam.player2.wrestlerName : tagTeam.player1.wrestlerName;
+    setIdentityName(tagTeam.name ?? '');
+    setIdentityMyWrestler(myOverride ?? myFallback ?? '');
+    setIdentityPartnerWrestler(partnerOverride ?? partnerFallback ?? '');
+  }, [tagTeam, profile]);
+
   const handleRespond = useCallback(async (tagTeamId: string, action: 'accept' | 'decline') => {
     try {
       await tagTeamsApi.respond(tagTeamId, action);
@@ -126,6 +150,32 @@ export default function MyTagTeam() {
   const handleCreated = useCallback(() => {
     loadData();
   }, [loadData]);
+
+  const handleSaveIdentity = useCallback(async (event: FormEvent) => {
+    event.preventDefault();
+    if (!tagTeam || !profile) return;
+    const isPlayer1 = tagTeam.player1.playerId === profile.playerId;
+    const myField = isPlayer1 ? 'player1WrestlerName' : 'player2WrestlerName';
+    const partnerField = isPlayer1 ? 'player2WrestlerName' : 'player1WrestlerName';
+
+    setSavingIdentity(true);
+    try {
+      await tagTeamsApi.update(tagTeam.tagTeamId, {
+        name: identityName,
+        [myField]: identityMyWrestler,
+        [partnerField]: identityPartnerWrestler,
+      });
+      setActionFeedback(t('tagTeams.my.identitySaved', 'Tag team identity saved.'));
+      await loadData();
+    } catch (err) {
+      setActionFeedback(
+        `Error: ${err instanceof Error ? err.message : t('common.error', 'Failed')}`
+      );
+    } finally {
+      setSavingIdentity(false);
+      setTimeout(() => setActionFeedback(null), 3000);
+    }
+  }, [tagTeam, profile, identityName, identityMyWrestler, identityPartnerWrestler, t, loadData]);
 
   if (!isAuthenticated) {
     return (
@@ -353,6 +403,54 @@ export default function MyTagTeam() {
                 )}
               </div>
             </div>
+          )}
+
+          {/* Edit team identity (TTP-01) */}
+          {tagTeam.status === 'active' && (
+            <form
+              className="my-tag-team__identity"
+              onSubmit={handleSaveIdentity}
+            >
+              <h4>{t('tagTeams.my.editIdentity', 'Edit Team Identity')}</h4>
+              <div className="my-tag-team__identity-fields">
+                <label className="my-tag-team__identity-field">
+                  <span>{t('tagTeams.my.teamName', 'Tag Team Name')}</span>
+                  <input
+                    type="text"
+                    value={identityName}
+                    onChange={(e) => setIdentityName(e.target.value)}
+                    disabled={savingIdentity}
+                  />
+                </label>
+                <label className="my-tag-team__identity-field">
+                  <span>{t('tagTeams.my.yourWrestler', 'Your wrestler in this team')}</span>
+                  <input
+                    type="text"
+                    value={identityMyWrestler}
+                    onChange={(e) => setIdentityMyWrestler(e.target.value)}
+                    disabled={savingIdentity}
+                  />
+                </label>
+                <label className="my-tag-team__identity-field">
+                  <span>{t('tagTeams.my.partnerWrestler', "Partner's wrestler in this team")}</span>
+                  <input
+                    type="text"
+                    value={identityPartnerWrestler}
+                    onChange={(e) => setIdentityPartnerWrestler(e.target.value)}
+                    disabled={savingIdentity}
+                  />
+                </label>
+              </div>
+              <button
+                type="submit"
+                className="btn-primary"
+                disabled={savingIdentity}
+              >
+                {savingIdentity
+                  ? t('common.saving', 'Saving...')
+                  : t('tagTeams.my.saveIdentity', 'Save')}
+              </button>
+            </form>
           )}
 
           {/* Actions */}

--- a/frontend/src/components/tagTeams/__tests__/MyTagTeam.test.tsx
+++ b/frontend/src/components/tagTeams/__tests__/MyTagTeam.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+
+const {
+  mockGetMyProfile,
+  mockTagTeamsGetById,
+  mockTagTeamsGetAll,
+  mockTagTeamsUpdate,
+  mockUseAuth,
+} = vi.hoisted(() => ({
+  mockGetMyProfile: vi.fn(),
+  mockTagTeamsGetById: vi.fn(),
+  mockTagTeamsGetAll: vi.fn(),
+  mockTagTeamsUpdate: vi.fn(),
+  mockUseAuth: vi.fn(),
+}));
+
+vi.mock('../../../services/api', () => ({
+  profileApi: {
+    getMyProfile: mockGetMyProfile,
+  },
+  tagTeamsApi: {
+    getById: mockTagTeamsGetById,
+    getAll: mockTagTeamsGetAll,
+    update: mockTagTeamsUpdate,
+  },
+}));
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: mockUseAuth,
+}));
+
+const stableT = (_key: string, fallback?: string) => fallback ?? _key;
+const stableUseTranslation = { t: stableT };
+vi.mock('react-i18next', () => ({
+  useTranslation: () => stableUseTranslation,
+}));
+
+vi.mock('../MyTagTeam.css', () => ({}));
+vi.mock('../CreateTagTeamModal', () => ({
+  default: () => null,
+}));
+
+import MyTagTeam from '../MyTagTeam';
+
+const profile = {
+  playerId: 'p1',
+  name: 'Adam',
+  currentWrestler: 'Edge (solo)',
+  wins: 0,
+  losses: 0,
+  draws: 0,
+  tagTeamId: 'tt1',
+  createdAt: '',
+  updatedAt: '',
+};
+
+const tagTeamDetail = {
+  tagTeamId: 'tt1',
+  name: 'The Brood',
+  player1Id: 'p1',
+  player2Id: 'p2',
+  player1WrestlerName: undefined,
+  player2WrestlerName: undefined,
+  status: 'active',
+  wins: 0,
+  losses: 0,
+  draws: 0,
+  createdAt: '',
+  updatedAt: '',
+  player1: {
+    playerId: 'p1',
+    playerName: 'Adam',
+    wrestlerName: 'Edge (solo)',
+  },
+  player2: {
+    playerId: 'p2',
+    playerName: 'Jay',
+    wrestlerName: 'Christian (solo)',
+  },
+  standings: {
+    winPercentage: 0,
+    recentForm: [],
+    currentStreak: { type: 'W', count: 0 },
+  },
+  headToHead: [],
+  matchTypeRecords: [],
+  recentMatches: [],
+};
+
+function renderMyTagTeam() {
+  return render(
+    <BrowserRouter>
+      <MyTagTeam />
+    </BrowserRouter>
+  );
+}
+
+describe('MyTagTeam — TTP-01 edit-identity form', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockGetMyProfile.mockResolvedValue(profile);
+    mockTagTeamsGetById.mockResolvedValue(tagTeamDetail);
+    mockTagTeamsGetAll.mockResolvedValue([]);
+    mockTagTeamsUpdate.mockResolvedValue(tagTeamDetail);
+  });
+
+  it('submits the edit form with name + both wrestler-name fields', async () => {
+    const user = userEvent.setup();
+    renderMyTagTeam();
+
+    // Wait for the form to render once data has loaded
+    const teamNameInput = await screen.findByLabelText('Tag Team Name');
+    const myWrestlerInput = screen.getByLabelText('Your wrestler in this team');
+    const partnerWrestlerInput = screen.getByLabelText("Partner's wrestler in this team");
+
+    // Fields are seeded from the loaded detail (override falls back to currentWrestler)
+    expect(teamNameInput).toHaveValue('The Brood');
+    expect(myWrestlerInput).toHaveValue('Edge (solo)');
+    expect(partnerWrestlerInput).toHaveValue('Christian (solo)');
+
+    await user.clear(myWrestlerInput);
+    await user.type(myWrestlerInput, 'Brood Edge');
+    await user.clear(partnerWrestlerInput);
+    await user.type(partnerWrestlerInput, 'Brood Christian');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockTagTeamsUpdate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockTagTeamsUpdate).toHaveBeenCalledWith('tt1', {
+      name: 'The Brood',
+      player1WrestlerName: 'Brood Edge',
+      player2WrestlerName: 'Brood Christian',
+    });
+  });
+});

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1361,7 +1361,15 @@
     "form": "Form",
     "streak": "Serie",
     "status": "Status",
-    "rank": "Rang"
+    "rank": "Rang",
+    "my": {
+      "editIdentity": "Team-Identität bearbeiten",
+      "teamName": "Tag-Team-Name",
+      "yourWrestler": "Dein Wrestler in diesem Team",
+      "partnerWrestler": "Wrestler deines Partners in diesem Team",
+      "saveIdentity": "Speichern",
+      "identitySaved": "Tag-Team-Identität gespeichert."
+    }
   },
   "contenders": {
     "title": "Herausforderer-Rangliste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1362,7 +1362,15 @@
     "form": "Form",
     "streak": "Streak",
     "status": "Status",
-    "rank": "Rank"
+    "rank": "Rank",
+    "my": {
+      "editIdentity": "Edit Team Identity",
+      "teamName": "Tag Team Name",
+      "yourWrestler": "Your wrestler in this team",
+      "partnerWrestler": "Partner's wrestler in this team",
+      "saveIdentity": "Save",
+      "identitySaved": "Tag team identity saved."
+    }
   },
   "contenders": {
     "title": "Contender Rankings",

--- a/frontend/src/services/api/tagTeams.api.ts
+++ b/frontend/src/services/api/tagTeams.api.ts
@@ -29,7 +29,15 @@ export const tagTeamsApi = {
     });
   },
 
-  update: async (tagTeamId: string, data: Partial<{ name: string; imageUrl: string }>): Promise<TagTeam> => {
+  update: async (
+    tagTeamId: string,
+    data: Partial<{
+      name: string;
+      imageUrl: string;
+      player1WrestlerName: string;
+      player2WrestlerName: string;
+    }>
+  ): Promise<TagTeam> => {
     return fetchWithAuth(`${API_BASE_URL}/tag-teams/${tagTeamId}`, {
       method: 'PUT',
       body: JSON.stringify(data),

--- a/frontend/src/types/tagTeam.ts
+++ b/frontend/src/types/tagTeam.ts
@@ -9,6 +9,8 @@ export interface TagTeam {
   name: string;
   player1Id: string;
   player2Id: string;
+  player1WrestlerName?: string;
+  player2WrestlerName?: string;
   imageUrl?: string;
   status: TagTeamStatus;
   wins: number;


### PR DESCRIPTION
## Summary
- Adds two optional persisted fields on the TagTeam aggregate: `player1WrestlerName` and `player2WrestlerName`. They flow through the existing `PUT /tag-teams/{id}` endpoint and are surfaced by `getTagTeam` as `player.wrestlerName`, falling back to `player.currentWrestler` (today's behavior) when the override is unset or empty.
- Introduces an inline "Edit Team Identity" form on `MyTagTeam.tsx` (visible only while `tagTeam.status === 'active'`). Three free-text inputs — Tag Team Name, your wrestler in this team, partner's wrestler in this team — submit the existing update endpoint. No uniqueness validation, no wrestler-record FK; v1 is intentionally minimal.
- Empty/whitespace-only input is treated as "leave unchanged" on the backend so the existing override (or the read-side fallback to `currentWrestler`) is preserved. Read-side uses `||` so any empty string that does land in storage still falls back gracefully.
- Adds EN+DE i18n keys (`tagTeams.my.editIdentity`, `teamName`, `yourWrestler`, `partnerWrestler`, `saveIdentity`, `identitySaved`).

## Test plan
- [x] `cd backend && npx vitest run functions/tagTeams` — 9 tests pass (updateTagTeam: persists overrides, trims whitespace, omits empty, 403 for non-members, admin allowed, 400 when nothing to update; getTagTeam: returns override when set, falls back when unset, falls back when empty string).
- [x] `cd frontend && npx vitest run src/components/tagTeams` — MyTagTeam form-submit test asserts the exact `tagTeamsApi.update` payload.
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean.
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean.
- [ ] Manual: as a wrestler in an active tag team, edit the team name + both per-team wrestler names on the My Tag Team page; reload — values persist; both members see the new wrestler names on TagTeamDetail.
- [ ] Manual regression: tag teams with no override still display the members' solo `currentWrestler` exactly as today.
- [ ] Manual: a non-member, non-admin caller hitting `PUT /tag-teams/{id}` with the new fields gets 403.

## Notes
- No data migration needed — the new fields are optional; existing teams just keep falling back to `currentWrestler`.
- Out of scope per the ticket: wrestler uniqueness validation, wrestler-table FK linkage, admin-panel surface in `ManageTagTeams`, per-team wrestler images, overall ratings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)