### PR TITLE
feat(factions): faction leader can remove members (FAC-02)

### DIFF
--- a/backend/functions/stables/__tests__/removeMember.test.ts
+++ b/backend/functions/stables/__tests__/removeMember.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { handler as removeMember } from '../removeMember';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+const LEADER_SUB = 'leader-sub';
+const MEMBER1_SUB = 'member1-sub';
+const MEMBER2_SUB = 'member2-sub';
+const OTHER_SUB = 'other-sub';
+const ADMIN_SUB = 'admin-sub';
+
+function makeEvent(stableId: string, body: unknown, groups: string, sub: string): APIGatewayProxyEvent {
+  return {
+    body: JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/remove-member`,
+    pathParameters: { stableId },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: { groups, username: 'tester', email: 'test@test.com', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seed() {
+  const leader = await repos.roster.players.create({ name: 'Leader', currentWrestler: 'Rock' });
+  await repos.roster.players.update(leader.playerId, { userId: LEADER_SUB });
+  const member1 = await repos.roster.players.create({ name: 'Member1', currentWrestler: 'Cena' });
+  await repos.roster.players.update(member1.playerId, { userId: MEMBER1_SUB });
+  const member2 = await repos.roster.players.create({ name: 'Member2', currentWrestler: 'Edge' });
+  await repos.roster.players.update(member2.playerId, { userId: MEMBER2_SUB });
+  const other = await repos.roster.players.create({ name: 'Other', currentWrestler: 'Orton' });
+  await repos.roster.players.update(other.playerId, { userId: OTHER_SUB });
+
+  return { leader, member1, member2, other };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+describe('removeMember (FAC-02)', () => {
+  it('lets the leader remove a member', async () => {
+    const { leader, member1, member2 } = await seed();
+    const stable = await repos.roster.stables.create({
+      name: 'NWO',
+      leaderId: leader.playerId,
+      memberIds: [leader.playerId, member1.playerId, member2.playerId],
+      status: 'active',
+    });
+    await repos.roster.players.update(member1.playerId, { stableId: stable.stableId });
+
+    const event = makeEvent(stable.stableId, { playerId: member1.playerId }, 'Wrestler', LEADER_SUB);
+    const result = await removeMember(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.removedPlayerId).toBe(member1.playerId);
+    expect(body.remainingMembers).toBe(2);
+
+    const updated = await repos.roster.stables.findById(stable.stableId);
+    expect(updated?.memberIds).toEqual([leader.playerId, member2.playerId]);
+    expect(updated?.status).toBe('active');
+
+    const updatedPlayer = await repos.roster.players.findById(member1.playerId);
+    expect(updatedPlayer?.stableId).toBeNull();
+  });
+
+  it('lets a super admin remove a member they are not part of', async () => {
+    const { leader, member1, member2 } = await seed();
+    const stable = await repos.roster.stables.create({
+      name: 'NWO',
+      leaderId: leader.playerId,
+      memberIds: [leader.playerId, member1.playerId, member2.playerId],
+      status: 'active',
+    });
+
+    // Admin caller has no player profile; the handler should still allow the call.
+    const event = makeEvent(stable.stableId, { playerId: member1.playerId }, 'Admin', ADMIN_SUB);
+    const result = await removeMember(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const updated = await repos.roster.stables.findById(stable.stableId);
+    expect(updated?.memberIds).toEqual([leader.playerId, member2.playerId]);
+  });
+
+  it('lets a member remove themselves', async () => {
+    const { leader, member1, member2 } = await seed();
+    const stable = await repos.roster.stables.create({
+      name: 'NWO',
+      leaderId: leader.playerId,
+      memberIds: [leader.playerId, member1.playerId, member2.playerId],
+      status: 'active',
+    });
+
+    const event = makeEvent(stable.stableId, { playerId: member1.playerId }, 'Wrestler', MEMBER1_SUB);
+    const result = await removeMember(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+  });
+
+  it('returns 403 when a non-leader, non-admin, non-self caller tries to remove someone else', async () => {
+    const { leader, member1, member2 } = await seed();
+    const stable = await repos.roster.stables.create({
+      name: 'NWO',
+      leaderId: leader.playerId,
+      memberIds: [leader.playerId, member1.playerId, member2.playerId],
+      status: 'active',
+    });
+
+    // The "other" player is not a member of the stable and is not an admin or leader.
+    const event = makeEvent(stable.stableId, { playerId: member1.playerId }, 'Wrestler', OTHER_SUB);
+    const result = await removeMember(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(403);
+    const updated = await repos.roster.stables.findById(stable.stableId);
+    expect(updated?.memberIds).toEqual([leader.playerId, member1.playerId, member2.playerId]);
+  });
+
+  it('auto-disbands the faction when removing the last non-leader member', async () => {
+    const { leader, member1 } = await seed();
+    const stable = await repos.roster.stables.create({
+      name: 'Solo',
+      leaderId: leader.playerId,
+      memberIds: [leader.playerId, member1.playerId],
+      status: 'active',
+    });
+    await repos.roster.players.update(leader.playerId, { stableId: stable.stableId });
+    await repos.roster.players.update(member1.playerId, { stableId: stable.stableId });
+
+    const event = makeEvent(stable.stableId, { playerId: member1.playerId }, 'Wrestler', LEADER_SUB);
+    const result = await removeMember(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.status).toBe('disbanded');
+
+    const updated = await repos.roster.stables.findById(stable.stableId);
+    expect(updated?.status).toBe('disbanded');
+    expect(updated?.memberIds).toEqual([leader.playerId]);
+    expect(updated?.disbandedAt).toBeDefined();
+
+    const ejected = await repos.roster.players.findById(member1.playerId);
+    expect(ejected?.stableId).toBeNull();
+    const orphanedLeader = await repos.roster.players.findById(leader.playerId);
+    expect(orphanedLeader?.stableId).toBeNull();
+  });
+});

--- a/backend/functions/stables/removeMember.ts
+++ b/backend/functions/stables/removeMember.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
-import { success, badRequest, notFound, serverError } from '../../lib/response';
+import { success, badRequest, forbidden, notFound, serverError } from '../../lib/response';
 import { getAuthContext, hasRole, isSuperAdmin } from '../../lib/auth';
 import { parseBody } from '../../lib/parseBody';
 
@@ -12,7 +12,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
   try {
     const auth = getAuthContext(event);
     if (!hasRole(auth, 'Wrestler')) {
-      return badRequest('Insufficient permissions');
+      return forbidden('Insufficient permissions');
     }
 
     const stableId = event.pathParameters?.stableId;
@@ -42,7 +42,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       const isLeader = callerPlayer?.playerId === stable.leaderId;
       const isSelfRemoval = callerPlayer?.playerId === playerId;
       if (!callerPlayer || (!isLeader && !isSelfRemoval)) {
-        return badRequest('Only the stable leader, an admin, or the member themselves can remove a member');
+        return forbidden('Only the stable leader, an admin, or the member themselves can remove a member');
       }
     }
 
@@ -51,9 +51,15 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('The leader cannot leave the stable. Disband it instead.');
     }
 
-    // Verify player is a member
+    // Idempotent: if the player is already not a member (e.g. a concurrent
+    // remove already completed), report success without mutating anything.
     if (!stable.memberIds.includes(playerId)) {
-      return badRequest('Player is not a member of this stable');
+      return success({
+        message: 'Player is not a member of this stable',
+        stableId,
+        removedPlayerId: playerId,
+        remainingMembers: stable.memberIds.length,
+      });
     }
 
     const updatedMemberIds = stable.memberIds.filter((id) => id !== playerId);

--- a/frontend/src/components/factions/MyFaction.css
+++ b/frontend/src/components/factions/MyFaction.css
@@ -406,6 +406,167 @@
   cursor: not-allowed;
 }
 
+/* Manage Members (leader-only) */
+.my-faction__manage-members {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.my-faction__manage-members h4 {
+  margin: 0 0 1rem;
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+.my-faction__manage-members-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.my-faction__manage-member-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background-color: var(--color-bg);
+  border-radius: 6px;
+  flex-wrap: wrap;
+}
+
+.my-faction__manage-member-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.my-faction__manage-member-name {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.my-faction__manage-member-wrestler {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.my-faction__manage-member-row .btn-danger {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+  border-radius: 4px;
+  background: rgba(220, 53, 69, 0.15);
+  color: var(--color-danger-alt);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.my-faction__manage-member-row .btn-danger:hover:not(:disabled) {
+  background: rgba(220, 53, 69, 0.25);
+}
+
+.my-faction__manage-member-row .btn-danger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.my-faction__manage-member-error {
+  flex-basis: 100%;
+  font-size: 0.8rem;
+  color: var(--color-danger-alt);
+}
+
+/* Confirmation modal */
+.my-faction__modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.my-faction__modal {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 440px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.my-faction__modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text);
+}
+
+.my-faction__modal-body {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.my-faction__modal-warning {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  background-color: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.my-faction__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.my-faction__modal-actions .btn-secondary,
+.my-faction__modal-actions .btn-danger {
+  padding: 0.55rem 1.1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  transition: background-color 0.2s;
+}
+
+.my-faction__modal-actions .btn-secondary:hover:not(:disabled) {
+  background-color: var(--color-border);
+}
+
+.my-faction__modal-actions .btn-danger {
+  background-color: rgba(220, 53, 69, 0.15);
+  border-color: rgba(220, 53, 69, 0.3);
+  color: var(--color-danger-alt);
+}
+
+.my-faction__modal-actions .btn-danger:hover:not(:disabled) {
+  background-color: rgba(220, 53, 69, 0.25);
+}
+
+.my-faction__modal-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Sent invitations */
 .my-faction__sent-invitations {
   background-color: var(--color-surface);

--- a/frontend/src/components/factions/MyFaction.tsx
+++ b/frontend/src/components/factions/MyFaction.tsx
@@ -27,6 +27,9 @@ export default function MyFaction() {
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [disbanding, setDisbanding] = useState(false);
   const [leaving, setLeaving] = useState(false);
+  const [memberToRemove, setMemberToRemove] = useState<{ playerId: string; playerName: string } | null>(null);
+  const [removingMember, setRemovingMember] = useState(false);
+  const [removeMemberErrors, setRemoveMemberErrors] = useState<Record<string, string>>({});
 
   const loadData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -135,6 +138,41 @@ export default function MyFaction() {
       setTimeout(() => setActionFeedback(null), 3000);
     }
   }, [faction, profile, t]);
+
+  const handleConfirmRemoveMember = useCallback(async () => {
+    if (!faction || !memberToRemove) return;
+    const { playerId, playerName } = memberToRemove;
+    setRemovingMember(true);
+    setRemoveMemberErrors((prev) => {
+      const { [playerId]: _omit, ...rest } = prev;
+      return rest;
+    });
+    try {
+      const result = await factionsApi.removeMember(faction.stableId, playerId) as unknown as {
+        status?: string;
+      };
+      const wasDisbanded = result?.status === 'disbanded';
+      setMemberToRemove(null);
+      if (wasDisbanded) {
+        setActionFeedback(
+          t('factions.my.removeMemberDisbanded', 'Faction disbanded — only the leader remained.')
+        );
+      } else {
+        setActionFeedback(
+          t('factions.my.removeMemberSuccess', '{{playerName}} removed from the faction.', { playerName })
+        );
+      }
+      await loadData();
+    } catch (err) {
+      setRemoveMemberErrors((prev) => ({
+        ...prev,
+        [playerId]: err instanceof Error ? err.message : t('common.error', 'Failed'),
+      }));
+    } finally {
+      setRemovingMember(false);
+      setTimeout(() => setActionFeedback(null), 3000);
+    }
+  }, [faction, memberToRemove, loadData, t]);
 
   const handleRespondToInvitation = useCallback(async (
     stableId: string,
@@ -338,6 +376,40 @@ export default function MyFaction() {
             </div>
           </div>
 
+          {/* Manage Members (leader only) */}
+          {isLeader && isApprovedOrActive && faction.members.some((m) => m.playerId !== faction.leaderId) && (
+            <div className="my-faction__manage-members" data-testid="manage-members">
+              <h4>{t('factions.my.manageMembers', 'Manage Members')}</h4>
+              <div className="my-faction__manage-members-list">
+                {faction.members
+                  .filter((member) => member.playerId !== faction.leaderId)
+                  .map((member) => (
+                    <div key={member.playerId} className="my-faction__manage-member-row">
+                      <div className="my-faction__manage-member-info">
+                        <span className="my-faction__manage-member-name">{member.playerName}</span>
+                        <span className="my-faction__manage-member-wrestler">{member.wrestlerName}</span>
+                      </div>
+                      <button
+                        type="button"
+                        className="btn-danger"
+                        onClick={() =>
+                          setMemberToRemove({ playerId: member.playerId, playerName: member.playerName })
+                        }
+                        disabled={removingMember}
+                      >
+                        {t('factions.my.removeMember', 'Remove')}
+                      </button>
+                      {removeMemberErrors[member.playerId] && (
+                        <div className="my-faction__manage-member-error" role="alert">
+                          {removeMemberErrors[member.playerId]}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
+
           {/* Leader actions */}
           {isLeader && (
             <div className="my-faction__leader-actions">
@@ -411,6 +483,53 @@ export default function MyFaction() {
           onClose={() => setShowInviteModal(false)}
           onInvited={handleInvited}
         />
+      )}
+
+      {faction && memberToRemove && (
+        <div className="my-faction__modal-overlay" role="dialog" aria-modal="true">
+          <div className="my-faction__modal">
+            <h3 className="my-faction__modal-title">
+              {t('factions.my.removeMemberConfirmTitle', 'Remove {{playerName}} from {{factionName}}?', {
+                playerName: memberToRemove.playerName,
+                factionName: faction.name,
+              })}
+            </h3>
+            {faction.members.length <= 2 && (
+              <p className="my-faction__modal-warning" role="alert">
+                {t(
+                  'factions.my.removeMemberDisbandWarning',
+                  'This will disband the faction — only the leader would remain.'
+                )}
+              </p>
+            )}
+            <p className="my-faction__modal-body">
+              {t(
+                'factions.my.removeMemberConfirmBody',
+                'They will lose access to faction-only surfaces and stop appearing in the roster.'
+              )}
+            </p>
+            <div className="my-faction__modal-actions">
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => setMemberToRemove(null)}
+                disabled={removingMember}
+              >
+                {t('factions.my.removeMemberCancel', 'Cancel')}
+              </button>
+              <button
+                type="button"
+                className="btn-danger"
+                onClick={handleConfirmRemoveMember}
+                disabled={removingMember}
+              >
+                {removingMember
+                  ? t('common.processing', 'Processing...')
+                  : t('factions.my.removeMemberConfirm', 'Remove member')}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/factions/__tests__/MyFaction.test.tsx
+++ b/frontend/src/components/factions/__tests__/MyFaction.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+
+const {
+  mockGetMyProfile,
+  mockFactionsGetById,
+  mockFactionsGetAll,
+  mockFactionsGetInvitations,
+  mockFactionsRemoveMember,
+  mockUseAuth,
+} = vi.hoisted(() => ({
+  mockGetMyProfile: vi.fn(),
+  mockFactionsGetById: vi.fn(),
+  mockFactionsGetAll: vi.fn(),
+  mockFactionsGetInvitations: vi.fn(),
+  mockFactionsRemoveMember: vi.fn(),
+  mockUseAuth: vi.fn(),
+}));
+
+vi.mock('../../../services/api', () => ({
+  profileApi: {
+    getMyProfile: mockGetMyProfile,
+  },
+  factionsApi: {
+    getById: mockFactionsGetById,
+    getAll: mockFactionsGetAll,
+    getInvitations: mockFactionsGetInvitations,
+    removeMember: mockFactionsRemoveMember,
+    disband: vi.fn(),
+    leave: vi.fn(),
+    respondToInvitation: vi.fn(),
+  },
+}));
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: mockUseAuth,
+}));
+
+// Translation mock that interpolates {{var}} placeholders so we can assert
+// against the rendered strings (player + faction names in the modal).
+const interpolatingT = (_key: string, fallback?: string, options?: Record<string, unknown>) => {
+  let text = fallback ?? _key;
+  if (options) {
+    for (const [name, value] of Object.entries(options)) {
+      text = text.replace(new RegExp(`{{\\s*${name}\\s*}}`, 'g'), String(value));
+    }
+  }
+  return text;
+};
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: interpolatingT }),
+}));
+
+vi.mock('../MyFaction.css', () => ({}));
+vi.mock('../CreateFactionModal', () => ({ default: () => null }));
+vi.mock('../InviteToFactionModal', () => ({ default: () => null }));
+
+import MyFaction from '../MyFaction';
+
+const leaderProfile = {
+  playerId: 'leader-1',
+  name: 'Leader Player',
+  currentWrestler: 'Leader Wrestler',
+  wins: 0,
+  losses: 0,
+  draws: 0,
+  stableId: 'fac-1',
+  createdAt: '',
+  updatedAt: '',
+};
+
+const memberProfile = {
+  ...leaderProfile,
+  playerId: 'member-1',
+  name: 'Member Player',
+  currentWrestler: 'Member Wrestler',
+};
+
+function makeMember(playerId: string, playerName: string, wrestlerName: string) {
+  return {
+    playerId,
+    playerName,
+    wrestlerName,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+  };
+}
+
+function makeFaction(memberIds: string[]) {
+  return {
+    stableId: 'fac-1',
+    name: 'New World Order',
+    leaderId: 'leader-1',
+    memberIds,
+    status: 'active',
+    wins: 5,
+    losses: 1,
+    draws: 0,
+    createdAt: '',
+    updatedAt: '',
+    members: memberIds.map((id) => {
+      if (id === 'leader-1') return makeMember('leader-1', 'Leader Player', 'Leader Wrestler');
+      if (id === 'member-1') return makeMember('member-1', 'Member Player', 'Member Wrestler');
+      if (id === 'member-2') return makeMember('member-2', 'Second Member', 'Second Wrestler');
+      return makeMember(id, id, id);
+    }),
+    standings: { winPercentage: 0, recentForm: [], currentStreak: { type: 'W', count: 0 } },
+    headToHead: [],
+    matchTypeRecords: [],
+    recentMatches: [],
+  };
+}
+
+function renderMyFaction() {
+  return render(
+    <BrowserRouter>
+      <MyFaction />
+    </BrowserRouter>
+  );
+}
+
+describe('MyFaction — FAC-02 Manage Members', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockFactionsGetInvitations.mockResolvedValue([]);
+    mockFactionsGetAll.mockResolvedValue([]);
+  });
+
+  it('shows the Manage Members panel when caller is the leader', async () => {
+    mockGetMyProfile.mockResolvedValue(leaderProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1', 'member-2']));
+
+    renderMyFaction();
+
+    const panel = await screen.findByTestId('manage-members');
+    // Leader row is excluded; both non-leader members appear with a Remove button.
+    expect(within(panel).queryByText('Leader Player')).toBeNull();
+    expect(within(panel).getByText('Member Player')).toBeInTheDocument();
+    expect(within(panel).getByText('Second Member')).toBeInTheDocument();
+    expect(within(panel).getAllByRole('button', { name: 'Remove' })).toHaveLength(2);
+  });
+
+  it('does not render Manage Members when the caller is not the leader', async () => {
+    mockGetMyProfile.mockResolvedValue(memberProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1', 'member-2']));
+
+    renderMyFaction();
+
+    // Wait for the faction detail to load (members panel for read-only view appears).
+    await screen.findByText('New World Order');
+    expect(screen.queryByTestId('manage-members')).toBeNull();
+  });
+
+  it('opens a confirmation modal when Remove is clicked on a non-leader member', async () => {
+    mockGetMyProfile.mockResolvedValue(leaderProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1', 'member-2']));
+
+    const user = userEvent.setup();
+    renderMyFaction();
+
+    const panel = await screen.findByTestId('manage-members');
+    const memberRow = within(panel).getByText('Member Player').closest('.my-faction__manage-member-row') as HTMLElement;
+    await user.click(within(memberRow).getByRole('button', { name: 'Remove' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Remove Member Player from New World Order?')).toBeInTheDocument();
+    // 3-member faction: removing one leaves 2, no disband warning.
+    expect(
+      within(dialog).queryByText('This will disband the faction — only the leader would remain.')
+    ).toBeNull();
+  });
+
+  it('calls factionsApi.removeMember with the correct args on confirm', async () => {
+    mockGetMyProfile.mockResolvedValue(leaderProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1', 'member-2']));
+    mockFactionsRemoveMember.mockResolvedValue({
+      message: 'ok',
+      stableId: 'fac-1',
+      removedPlayerId: 'member-1',
+      remainingMembers: 2,
+    });
+
+    const user = userEvent.setup();
+    renderMyFaction();
+
+    const panel = await screen.findByTestId('manage-members');
+    const memberRow = within(panel).getByText('Member Player').closest('.my-faction__manage-member-row') as HTMLElement;
+    await user.click(within(memberRow).getByRole('button', { name: 'Remove' }));
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Remove member' }));
+
+    await waitFor(() => {
+      expect(mockFactionsRemoveMember).toHaveBeenCalledTimes(1);
+    });
+    expect(mockFactionsRemoveMember).toHaveBeenCalledWith('fac-1', 'member-1');
+  });
+
+  it('shows the disband warning when removing the last non-leader member', async () => {
+    mockGetMyProfile.mockResolvedValue(leaderProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1']));
+
+    const user = userEvent.setup();
+    renderMyFaction();
+
+    const panel = await screen.findByTestId('manage-members');
+    await user.click(within(panel).getByRole('button', { name: 'Remove' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByText('This will disband the faction — only the leader would remain.')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1341,7 +1341,18 @@
     "streak": "Serie",
     "leader": "Anführer",
     "status": "Status",
-    "rank": "Rang"
+    "rank": "Rang",
+    "my": {
+      "manageMembers": "Mitglieder verwalten",
+      "removeMember": "Entfernen",
+      "removeMemberConfirmTitle": "{{playerName}} aus {{factionName}} entfernen?",
+      "removeMemberConfirmBody": "Sie verlieren den Zugang zu fraktionsexklusiven Bereichen und erscheinen nicht mehr in der Mitgliederliste.",
+      "removeMemberDisbandWarning": "Die Faktion wird aufgelöst — nur der Anführer würde übrig bleiben.",
+      "removeMemberSuccess": "{{playerName}} wurde aus der Faktion entfernt.",
+      "removeMemberDisbanded": "Faktion aufgelöst — nur der Anführer war übrig.",
+      "removeMemberCancel": "Abbrechen",
+      "removeMemberConfirm": "Mitglied entfernen"
+    }
   },
   "tagTeams": {
     "title": "Tag Teams",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1342,7 +1342,18 @@
     "streak": "Streak",
     "leader": "Leader",
     "status": "Status",
-    "rank": "Rank"
+    "rank": "Rank",
+    "my": {
+      "manageMembers": "Manage Members",
+      "removeMember": "Remove",
+      "removeMemberConfirmTitle": "Remove {{playerName}} from {{factionName}}?",
+      "removeMemberConfirmBody": "They will lose access to faction-only surfaces and stop appearing in the roster.",
+      "removeMemberDisbandWarning": "This will disband the faction — only the leader would remain.",
+      "removeMemberSuccess": "{{playerName}} removed from the faction.",
+      "removeMemberDisbanded": "Faction disbanded — only the leader remained.",
+      "removeMemberCancel": "Cancel",
+      "removeMemberConfirm": "Remove member"
+    }
   },
   "tagTeams": {
     "title": "Tag Teams",


### PR DESCRIPTION
## Summary
- Backend: `removeMember` now returns 403 (not 400) on permission denial, and treats a no-op remove (player already gone) as idempotent success to handle concurrent requests.
- Frontend: leaders of an active faction see a new **Manage Members** panel on `/my-faction` listing each non-leader member with a Remove button.
- Confirmation modal warns about auto-disband when removing the last non-leader member, then calls `factionsApi.removeMember` and refreshes. Per-row error rendering isolates failures.
- New EN + DE i18n keys under `factions.my.*`.
- Vitest coverage for both UI flow (5 cases) and handler permission/auto-disband behaviour (5 cases).

## Ticket
[FAC-02] Faction leader can remove members — gives a faction leader the ability to eject a member directly from the My Faction page. Backend already enforced leader/admin/self permission and auto-disband; this ticket adds the UI affordance, surfaces the disband warning, fills in test coverage, and tightens the handler to return 403 for permission denial and behave idempotently.

## Test plan
- [ ] As leader of a 3-member faction, see Manage Members panel with the two non-leader rows; click Remove → modal opens → confirm → member is removed and panel refreshes.
- [ ] As leader of a 2-member faction (leader + 1), Remove → modal shows the disband warning copy → confirm → faction disbands and you land on the no-faction state.
- [ ] As a non-leader member of a faction, Manage Members panel does not render.
- [ ] Hit `POST /stables/{stableId}/remove-member` from a player who is not the leader, admin, or the target → 403.
- [ ] CI passes (frontend + backend lint, vitest, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)