### PR TITLE
feat(factions): faction leader can upload a faction image (FAC-03)

### DIFF
--- a/backend/functions/images/__tests__/images.test.ts
+++ b/backend/functions/images/__tests__/images.test.ts
@@ -222,7 +222,7 @@ describe('generateUploadUrl — auth & validation', () => {
     const result = await generateUploadUrl(event, ctx, cb);
 
     expect(result!.statusCode).toBe(400);
-    expect(JSON.parse(result!.body).message).toBe('folder must be "wrestlers", "championships", "shows", or "videos"');
+    expect(JSON.parse(result!.body).message).toBe('folder must be "wrestlers", "championships", "shows", "videos", or "factions"');
   });
 
   it('accepts "wrestlers" as a valid folder', async () => {
@@ -249,6 +249,36 @@ describe('generateUploadUrl — auth & validation', () => {
     const result = await generateUploadUrl(event, ctx, cb);
 
     expect(result!.statusCode).toBe(200);
+  });
+
+  it('accepts "factions" as a valid folder and prefixes the file key with factions/', async () => {
+    const event = withAuth(
+      makeEvent({
+        body: JSON.stringify({ fileName: 'banner.png', fileType: 'image/png', folder: 'factions' }),
+      }),
+      'Wrestler',
+    );
+
+    const result = await generateUploadUrl(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(200);
+    const responseBody = JSON.parse(result!.body) as { fileKey: string; imageUrl: string };
+    expect(responseBody.fileKey.startsWith('factions/')).toBe(true);
+    expect(responseBody.imageUrl).toContain('/factions/');
+  });
+
+  it('rejects disallowed file types when folder is "factions"', async () => {
+    const event = withAuth(
+      makeEvent({
+        body: JSON.stringify({ fileName: 'doc.pdf', fileType: 'application/pdf', folder: 'factions' }),
+      }),
+      'Wrestler',
+    );
+
+    const result = await generateUploadUrl(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(JSON.parse(result!.body).message).toContain('Only JPEG, PNG, GIF, and WebP');
   });
 
   // ─── File type validation ─────────────────────────────────────

--- a/backend/functions/images/generateUploadUrl.ts
+++ b/backend/functions/images/generateUploadUrl.ts
@@ -13,7 +13,7 @@ const s3Client = new S3Client({
 interface GenerateUploadUrlBody {
   fileName: string;
   fileType: string;
-  folder: 'wrestlers' | 'championships' | 'shows' | 'videos';
+  folder: 'wrestlers' | 'championships' | 'shows' | 'videos' | 'factions';
 }
 
 export const handler: APIGatewayProxyHandler = async (event) => {
@@ -28,8 +28,8 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return badRequest('fileName, fileType, and folder are required');
     }
 
-    if (!['wrestlers', 'championships', 'shows', 'videos'].includes(body.folder)) {
-      return badRequest('folder must be "wrestlers", "championships", "shows", or "videos"');
+    if (!['wrestlers', 'championships', 'shows', 'videos', 'factions'].includes(body.folder)) {
+      return badRequest('folder must be "wrestlers", "championships", "shows", "videos", or "factions"');
     }
 
     // Validate file type based on folder

--- a/frontend/src/components/factions/CreateFactionModal.css
+++ b/frontend/src/components/factions/CreateFactionModal.css
@@ -147,6 +147,46 @@
   cursor: not-allowed;
 }
 
+.create-faction-modal__upload {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.create-faction-modal__upload-preview {
+  width: 64px;
+  height: 64px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.create-faction-modal__upload-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.create-faction-modal__upload-hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.create-faction-modal__file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (max-width: 480px) {
   .create-faction-modal {
     padding: 1.5rem;

--- a/frontend/src/components/factions/CreateFactionModal.tsx
+++ b/frontend/src/components/factions/CreateFactionModal.tsx
@@ -1,7 +1,15 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { factionsApi } from '../../services/api';
+import { factionsApi, imagesApi } from '../../services/api';
+import {
+  DEFAULT_WRESTLER_IMAGE,
+  resolveImageSrc,
+  applyImageFallback,
+} from '../../constants/imageFallbacks';
 import './CreateFactionModal.css';
+
+const ACCEPTED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+const ACCEPT_ATTR = ACCEPTED_MIME_TYPES.join(',');
 
 interface Props {
   isOpen: boolean;
@@ -14,8 +22,42 @@ export default function CreateFactionModal({ isOpen, onClose, onCreated }: Props
   const [name, setName] = useState('');
   const [imageUrl, setImageUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handlePickImage = () => {
+    if (submitting || uploading) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    if (!ACCEPTED_MIME_TYPES.includes(file.type)) {
+      setError(t('factions.my.uploadFailed', 'Upload failed. Please try again.'));
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+    try {
+      const { uploadUrl, imageUrl: uploadedUrl } = await imagesApi.generateUploadUrl(
+        file.name,
+        file.type,
+        'factions'
+      );
+      await imagesApi.uploadToS3(uploadUrl, file);
+      setImageUrl(uploadedUrl);
+    } catch {
+      setError(t('factions.my.uploadFailed', 'Upload failed. Please try again.'));
+    } finally {
+      setUploading(false);
+    }
+  };
 
   if (!isOpen) return null;
 
@@ -90,14 +132,53 @@ export default function CreateFactionModal({ isOpen, onClose, onCreated }: Props
             </div>
 
             <div className="form-group">
-              <label htmlFor="faction-image">{t('factions.create.imageLabel', 'Image URL (optional)')}</label>
+              <label>{t('factions.my.uploadImage', 'Upload faction image')}</label>
+              <div className="create-faction-modal__upload">
+                {imageUrl.trim() && (
+                  <div className="create-faction-modal__upload-preview">
+                    <img
+                      src={resolveImageSrc(imageUrl, DEFAULT_WRESTLER_IMAGE)}
+                      onError={(event) => applyImageFallback(event, DEFAULT_WRESTLER_IMAGE)}
+                      alt={name || t('factions.create.title', 'Create a Faction')}
+                    />
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={handlePickImage}
+                  disabled={submitting || uploading}
+                  aria-busy={uploading}
+                >
+                  {uploading
+                    ? t('factions.my.uploadingImage', 'Uploading…')
+                    : imageUrl.trim()
+                      ? t('factions.my.replaceImage', 'Replace image')
+                      : t('factions.my.uploadImage', 'Upload faction image')}
+                </button>
+                <span className="create-faction-modal__upload-hint">
+                  {t('factions.my.uploadAcceptedTypes', 'PNG, JPEG, GIF, or WebP')}
+                </span>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={ACCEPT_ATTR}
+                  className="create-faction-modal__file-input"
+                  onChange={handleFileChange}
+                  aria-label={t('factions.my.uploadImage', 'Upload faction image')}
+                />
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="faction-image">{t('factions.create.imageUrlFallbackLabel', 'Or paste a URL')}</label>
               <input
                 type="url"
                 id="faction-image"
                 value={imageUrl}
                 onChange={(e) => setImageUrl(e.target.value)}
                 placeholder={t('factions.create.imagePlaceholder', 'https://...')}
-                disabled={submitting}
+                disabled={submitting || uploading}
               />
             </div>
 
@@ -117,7 +198,7 @@ export default function CreateFactionModal({ isOpen, onClose, onCreated }: Props
               <button
                 type="submit"
                 className="btn-primary"
-                disabled={submitting}
+                disabled={submitting || uploading}
                 aria-busy={submitting}
               >
                 {submitting

--- a/frontend/src/components/factions/FactionImageUploader.css
+++ b/frontend/src/components/factions/FactionImageUploader.css
@@ -1,0 +1,69 @@
+.faction-image-uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.faction-image-uploader__preview {
+  width: 96px;
+  height: 96px;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--color-surface-2, var(--color-surface));
+  border: 1px solid var(--color-border);
+}
+
+.faction-image-uploader__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.faction-image-uploader__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.faction-image-uploader__button {
+  padding: 0.55rem 1.1rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.faction-image-uploader__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.faction-image-uploader__hint {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.faction-image-uploader__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.faction-image-uploader__error {
+  font-size: 0.85rem;
+  color: var(--color-danger-alt, #f87171);
+}

--- a/frontend/src/components/factions/FactionImageUploader.tsx
+++ b/frontend/src/components/factions/FactionImageUploader.tsx
@@ -1,0 +1,112 @@
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { factionsApi, imagesApi } from '../../services/api';
+import {
+  DEFAULT_WRESTLER_IMAGE,
+  resolveImageSrc,
+  applyImageFallback,
+} from '../../constants/imageFallbacks';
+import './FactionImageUploader.css';
+
+const ACCEPTED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+const ACCEPT_ATTR = ACCEPTED_MIME_TYPES.join(',');
+
+interface Props {
+  stableId: string;
+  currentImageUrl?: string;
+  factionName: string;
+  onUploaded: (newImageUrl: string) => void;
+}
+
+export default function FactionImageUploader({
+  stableId,
+  currentImageUrl,
+  factionName,
+  onUploaded,
+}: Props) {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasImage = Boolean(currentImageUrl?.trim());
+  const buttonLabel = hasImage
+    ? t('factions.my.replaceImage', 'Replace image')
+    : t('factions.my.uploadImage', 'Upload faction image');
+
+  const handlePick = () => {
+    if (uploading) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset the input so picking the same file twice still fires onChange.
+    event.target.value = '';
+    if (!file) return;
+
+    if (!ACCEPTED_MIME_TYPES.includes(file.type)) {
+      setError(t('factions.my.uploadFailed', 'Upload failed. Please try again.'));
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+    try {
+      const { uploadUrl, imageUrl } = await imagesApi.generateUploadUrl(
+        file.name,
+        file.type,
+        'factions'
+      );
+      await imagesApi.uploadToS3(uploadUrl, file);
+      await factionsApi.update(stableId, { imageUrl });
+      onUploaded(imageUrl);
+    } catch {
+      setError(t('factions.my.uploadFailed', 'Upload failed. Please try again.'));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="faction-image-uploader" data-testid="faction-image-uploader">
+      <div className="faction-image-uploader__preview">
+        <img
+          src={resolveImageSrc(currentImageUrl, DEFAULT_WRESTLER_IMAGE)}
+          onError={(event) => applyImageFallback(event, DEFAULT_WRESTLER_IMAGE)}
+          alt={factionName}
+          className="faction-image-uploader__image"
+        />
+      </div>
+      <div className="faction-image-uploader__controls">
+        <button
+          type="button"
+          className="btn-secondary faction-image-uploader__button"
+          onClick={handlePick}
+          disabled={uploading}
+          aria-busy={uploading}
+        >
+          {uploading
+            ? t('factions.my.uploadingImage', 'Uploading…')
+            : buttonLabel}
+        </button>
+        <span className="faction-image-uploader__hint">
+          {t('factions.my.uploadAcceptedTypes', 'PNG, JPEG, GIF, or WebP')}
+        </span>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPT_ATTR}
+          className="faction-image-uploader__input"
+          onChange={handleFileChange}
+          aria-label={t('factions.my.uploadImage', 'Upload faction image')}
+        />
+      </div>
+      {error && (
+        <div className="faction-image-uploader__error" role="alert">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/factions/MyFaction.css
+++ b/frontend/src/components/factions/MyFaction.css
@@ -406,6 +406,21 @@
   cursor: not-allowed;
 }
 
+/* Image upload (leader-only, active faction) */
+.my-faction__image-upload {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.my-faction__image-upload h4 {
+  margin: 0 0 1rem;
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
 /* Manage Members (leader-only) */
 .my-faction__manage-members {
   background-color: var(--color-surface);

--- a/frontend/src/components/factions/MyFaction.tsx
+++ b/frontend/src/components/factions/MyFaction.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../constants/imageFallbacks';
 import CreateFactionModal from './CreateFactionModal';
 import InviteToFactionModal from './InviteToFactionModal';
+import FactionImageUploader from './FactionImageUploader';
 import './MyFaction.css';
 
 export default function MyFaction() {
@@ -196,6 +197,10 @@ export default function MyFaction() {
     setTimeout(() => setActionFeedback(null), 3000);
   }, [t, loadData]);
 
+  const handleImageUploaded = useCallback((newImageUrl: string) => {
+    setFaction((current) => (current ? { ...current, imageUrl: newImageUrl } : current));
+  }, []);
+
   const handleCreated = useCallback(() => {
     loadData();
   }, [loadData]);
@@ -341,6 +346,19 @@ export default function MyFaction() {
               </div>
             </div>
           </div>
+
+          {/* Image upload (leader, active/approved only) */}
+          {isLeader && isApprovedOrActive && (
+            <div className="my-faction__image-upload">
+              <h4>{t('factions.my.uploadImage', 'Upload faction image')}</h4>
+              <FactionImageUploader
+                stableId={faction.stableId}
+                currentImageUrl={faction.imageUrl}
+                factionName={faction.name}
+                onUploaded={handleImageUploaded}
+              />
+            </div>
+          )}
 
           {/* Members list */}
           <div className="my-faction__members">

--- a/frontend/src/components/factions/__tests__/MyFaction.test.tsx
+++ b/frontend/src/components/factions/__tests__/MyFaction.test.tsx
@@ -9,6 +9,9 @@ const {
   mockFactionsGetAll,
   mockFactionsGetInvitations,
   mockFactionsRemoveMember,
+  mockFactionsUpdate,
+  mockGenerateUploadUrl,
+  mockUploadToS3,
   mockUseAuth,
 } = vi.hoisted(() => ({
   mockGetMyProfile: vi.fn(),
@@ -16,6 +19,9 @@ const {
   mockFactionsGetAll: vi.fn(),
   mockFactionsGetInvitations: vi.fn(),
   mockFactionsRemoveMember: vi.fn(),
+  mockFactionsUpdate: vi.fn(),
+  mockGenerateUploadUrl: vi.fn(),
+  mockUploadToS3: vi.fn(),
   mockUseAuth: vi.fn(),
 }));
 
@@ -28,9 +34,14 @@ vi.mock('../../../services/api', () => ({
     getAll: mockFactionsGetAll,
     getInvitations: mockFactionsGetInvitations,
     removeMember: mockFactionsRemoveMember,
+    update: mockFactionsUpdate,
     disband: vi.fn(),
     leave: vi.fn(),
     respondToInvitation: vi.fn(),
+  },
+  imagesApi: {
+    generateUploadUrl: mockGenerateUploadUrl,
+    uploadToS3: mockUploadToS3,
   },
 }));
 
@@ -54,6 +65,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('../MyFaction.css', () => ({}));
+vi.mock('../FactionImageUploader.css', () => ({}));
 vi.mock('../CreateFactionModal', () => ({ default: () => null }));
 vi.mock('../InviteToFactionModal', () => ({ default: () => null }));
 
@@ -214,5 +226,62 @@ describe('MyFaction — FAC-02 Manage Members', () => {
     expect(
       within(dialog).getByText('This will disband the faction — only the leader would remain.')
     ).toBeInTheDocument();
+  });
+});
+
+describe('MyFaction — FAC-03 Image upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockFactionsGetInvitations.mockResolvedValue([]);
+    mockFactionsGetAll.mockResolvedValue([]);
+  });
+
+  it('uploads an image and calls factionsApi.update with the resulting URL', async () => {
+    mockGetMyProfile.mockResolvedValue(leaderProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1']));
+    mockGenerateUploadUrl.mockResolvedValue({
+      uploadUrl: 'https://s3.example.com/presigned',
+      imageUrl: 'https://example.com/x.png',
+      fileKey: 'factions/x.png',
+    });
+    mockUploadToS3.mockResolvedValue(undefined);
+    mockFactionsUpdate.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderMyFaction();
+
+    const uploader = await screen.findByTestId('faction-image-uploader');
+    const fileInput = uploader.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).not.toBeNull();
+
+    const file = new File(['fake-bytes'], 'banner.png', { type: 'image/png' });
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(mockFactionsUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockGenerateUploadUrl).toHaveBeenCalledWith('banner.png', 'image/png', 'factions');
+    expect(mockUploadToS3).toHaveBeenCalledWith('https://s3.example.com/presigned', file);
+    expect(mockFactionsUpdate).toHaveBeenCalledWith('fac-1', { imageUrl: 'https://example.com/x.png' });
+
+    // Calls happen in the documented order: presign → upload → persist.
+    const presignOrder = mockGenerateUploadUrl.mock.invocationCallOrder[0];
+    const uploadOrder = mockUploadToS3.mock.invocationCallOrder[0];
+    const updateOrder = mockFactionsUpdate.mock.invocationCallOrder[0];
+    expect(presignOrder).toBeLessThan(uploadOrder);
+    expect(uploadOrder).toBeLessThan(updateOrder);
+  });
+
+  it('does not render the upload affordance when the caller is not the leader', async () => {
+    mockGetMyProfile.mockResolvedValue(memberProfile);
+    mockFactionsGetById.mockResolvedValue(makeFaction(['leader-1', 'member-1', 'member-2']));
+
+    renderMyFaction();
+
+    // Wait for the faction detail to load.
+    await screen.findByText('New World Order');
+    expect(screen.queryByTestId('faction-image-uploader')).toBeNull();
   });
 });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1351,7 +1351,12 @@
       "removeMemberSuccess": "{{playerName}} wurde aus der Faktion entfernt.",
       "removeMemberDisbanded": "Faktion aufgelöst — nur der Anführer war übrig.",
       "removeMemberCancel": "Abbrechen",
-      "removeMemberConfirm": "Mitglied entfernen"
+      "removeMemberConfirm": "Mitglied entfernen",
+      "uploadImage": "Faktionsbild hochladen",
+      "uploadingImage": "Wird hochgeladen…",
+      "uploadFailed": "Upload fehlgeschlagen. Bitte erneut versuchen.",
+      "uploadAcceptedTypes": "PNG, JPEG, GIF oder WebP",
+      "replaceImage": "Bild ersetzen"
     }
   },
   "tagTeams": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1352,7 +1352,12 @@
       "removeMemberSuccess": "{{playerName}} removed from the faction.",
       "removeMemberDisbanded": "Faction disbanded — only the leader remained.",
       "removeMemberCancel": "Cancel",
-      "removeMemberConfirm": "Remove member"
+      "removeMemberConfirm": "Remove member",
+      "uploadImage": "Upload faction image",
+      "uploadingImage": "Uploading…",
+      "uploadFailed": "Upload failed. Please try again.",
+      "uploadAcceptedTypes": "PNG, JPEG, GIF, or WebP",
+      "replaceImage": "Replace image"
     }
   },
   "tagTeams": {

--- a/frontend/src/services/api/images.api.ts
+++ b/frontend/src/services/api/images.api.ts
@@ -4,7 +4,7 @@ export const imagesApi = {
   generateUploadUrl: async (
     fileName: string,
     fileType: string,
-    folder: 'wrestlers' | 'championships' | 'shows' | 'videos'
+    folder: 'wrestlers' | 'championships' | 'shows' | 'videos' | 'factions'
   ): Promise<{ uploadUrl: string; imageUrl: string; fileKey: string }> => {
     return fetchWithAuth(`${API_BASE_URL}/images/upload-url`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Adds `'factions'` to the presigned-URL upload folder allowlist (backend handler + frontend `imagesApi` type union).
- Introduces a reusable `<FactionImageUploader />` component (preview + file picker + error toast) and wires it into `MyFaction` for leaders of approved/active factions.
- Adds an inline upload affordance to `CreateFactionModal` so a leader can upload at creation time; the URL field is kept as a fallback ("Or paste a URL").
- Adds EN+DE i18n keys for the upload UI under `factions.my.*`.
- Vitest coverage for the upload happy path (presign → S3 PUT → faction update, in order) and the non-leader negative case.

## Ticket
**[FAC-03] Faction leader can upload a faction image** — Phase 1 (S, blocked by FAC-01).

Today the create / edit modals accept an image URL as free-text. The presigned-URL flow already exists for wrestlers, championships, shows, and videos; this ticket plugs factions in. Read surfaces (`FactionsList` → `FactionCard`, `FactionDetail`, `FactionStandings`, `MyFaction`) already render `imageUrl` via `resolveImageSrc` + `applyImageFallback`, so no read-side changes were needed.

Out of scope (matches ticket): image deletion affordance, multiple images per faction, cropping/resizing UI, individual member portraits.

## Test plan
- [x] Backend Vitest: 22 tests for `generateUploadUrl` pass, including new coverage for `'factions'` folder + invalid file types under `'factions'`.
- [x] Frontend Vitest: `MyFaction.test.tsx` passes 7/7 (5 pre-existing + 2 new for FAC-03 image upload).
- [x] Frontend ESLint clean; backend ESLint clean.
- [ ] Manual: as a faction leader, open My Faction → pick a PNG → confirm S3 upload completes and the new image appears immediately.
- [ ] Manual: as a non-leader member, confirm no upload affordance is rendered.
- [ ] Manual: in `CreateFactionModal`, pick an image → confirm preview appears and submit succeeds with the uploaded URL.

## Notes
- The 8 `App.test.tsx` failures present on `main` are pre-existing (macOS case-insensitivity on `MenuModeContext`) and unrelated to this PR — verified by running the suite on `main` before opening.
- Per the ticket's notes, the upload helper was extracted into a reusable component (`FactionImageUploader`) so FAC-13's redesigned Manage tab can drop it in without rebuilding the upload flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)