### PR TITLE
feat(stables): faction channel messages — post + list backend (FAC-05)

### DIFF
--- a/backend/functions/stables/__tests__/getMessages.test.ts
+++ b/backend/functions/stables/__tests__/getMessages.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { handler as getMessages } from '../getMessages';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+const LEADER_SUB = 'leader-sub';
+const MEMBER_SUB = 'member-sub';
+const OUTSIDER_SUB = 'outsider-sub';
+
+function makeEvent(
+  stableId: string,
+  qs: Record<string, string> | null,
+  groups: string,
+  sub: string,
+): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/messages`,
+    pathParameters: { stableId },
+    queryStringParameters: qs,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: { groups, username: 'tester', email: 'test@test.com', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seed() {
+  const leader = await repos.roster.players.create({ name: 'Leader', currentWrestler: 'Rock' });
+  await repos.roster.players.update(leader.playerId, { userId: LEADER_SUB });
+  const member = await repos.roster.players.create({ name: 'Member', currentWrestler: 'Cena' });
+  await repos.roster.players.update(member.playerId, { userId: MEMBER_SUB });
+  const outsider = await repos.roster.players.create({ name: 'Outsider', currentWrestler: 'Orton' });
+  await repos.roster.players.update(outsider.playerId, { userId: OUTSIDER_SUB });
+
+  const stable = await repos.roster.stables.create({
+    name: 'NWO',
+    leaderId: leader.playerId,
+    memberIds: [leader.playerId, member.playerId],
+    status: 'active',
+  });
+
+  return { leader, member, outsider, stable };
+}
+
+async function postN(factionId: string, authorPlayerId: string, count: number): Promise<void> {
+  // Stagger createdAt by a millisecond per message so newest-first sort is deterministic.
+  let now = Date.now();
+  const realNow = Date.now;
+  Date.now = () => now;
+  try {
+    for (let i = 0; i < count; i++) {
+      now += 1;
+      vi.setSystemTime(new Date(now));
+      await repos.factionMessages.post({
+        factionId,
+        authorPlayerId,
+        body: `msg-${i + 1}`,
+      });
+    }
+  } finally {
+    Date.now = realNow;
+    vi.useRealTimers();
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+describe('getMessages (FAC-05)', () => {
+  it('returns the feed in newest-first order for a member', async () => {
+    const { member, stable } = await seed();
+    await postN(stable.stableId, member.playerId, 3);
+
+    const result = await getMessages(
+      makeEvent(stable.stableId, null, 'Wrestler', MEMBER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toHaveLength(3);
+    expect(body.items.map((m: { body: string }) => m.body)).toEqual(['msg-3', 'msg-2', 'msg-1']);
+    expect(body.nextCursor).toBeUndefined();
+  });
+
+  it('returns 403 to a non-member', async () => {
+    const { member, stable } = await seed();
+    await postN(stable.stableId, member.playerId, 2);
+
+    const result = await getMessages(
+      makeEvent(stable.stableId, null, 'Wrestler', OUTSIDER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(403);
+  });
+
+  it('paginates 60 messages with limit=20 across multiple pages', async () => {
+    const { member, stable } = await seed();
+    await postN(stable.stableId, member.playerId, 60);
+
+    const firstPageResult = await getMessages(
+      makeEvent(stable.stableId, { limit: '20' }, 'Wrestler', MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(firstPageResult!.statusCode).toBe(200);
+    const firstPage = JSON.parse(firstPageResult!.body);
+    expect(firstPage.items).toHaveLength(20);
+    expect(firstPage.nextCursor).toBeTruthy();
+    expect(firstPage.items[0].body).toBe('msg-60');
+    expect(firstPage.items[19].body).toBe('msg-41');
+
+    const secondPageResult = await getMessages(
+      makeEvent(stable.stableId, { limit: '20', cursor: firstPage.nextCursor }, 'Wrestler', MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(secondPageResult!.statusCode).toBe(200);
+    const secondPage = JSON.parse(secondPageResult!.body);
+    expect(secondPage.items).toHaveLength(20);
+    expect(secondPage.items[0].body).toBe('msg-40');
+    expect(secondPage.items[19].body).toBe('msg-21');
+    expect(secondPage.nextCursor).toBeTruthy();
+
+    // The two pages must not overlap.
+    const firstIds = new Set(firstPage.items.map((m: { messageId: string }) => m.messageId));
+    for (const m of secondPage.items) {
+      expect(firstIds.has(m.messageId)).toBe(false);
+    }
+  });
+});

--- a/backend/functions/stables/__tests__/postMessage.test.ts
+++ b/backend/functions/stables/__tests__/postMessage.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { handler as postMessage } from '../postMessage';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+const LEADER_SUB = 'leader-sub';
+const MEMBER_SUB = 'member-sub';
+const OUTSIDER_SUB = 'outsider-sub';
+const ADMIN_SUB = 'admin-sub';
+
+function makeEvent(stableId: string, body: unknown, groups: string, sub: string): APIGatewayProxyEvent {
+  return {
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/messages`,
+    pathParameters: { stableId },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: { groups, username: 'tester', email: 'test@test.com', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seed() {
+  const leader = await repos.roster.players.create({ name: 'Leader', currentWrestler: 'Rock' });
+  await repos.roster.players.update(leader.playerId, { userId: LEADER_SUB });
+  const member = await repos.roster.players.create({ name: 'Member', currentWrestler: 'Cena' });
+  await repos.roster.players.update(member.playerId, { userId: MEMBER_SUB });
+  const outsider = await repos.roster.players.create({ name: 'Outsider', currentWrestler: 'Orton' });
+  await repos.roster.players.update(outsider.playerId, { userId: OUTSIDER_SUB });
+
+  const stable = await repos.roster.stables.create({
+    name: 'NWO',
+    leaderId: leader.playerId,
+    memberIds: [leader.playerId, member.playerId],
+    status: 'active',
+  });
+
+  return { leader, member, outsider, stable };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+describe('postMessage (FAC-05)', () => {
+  it('lets a member post a user message and persists it with authorPlayerId = caller', async () => {
+    const { member, stable } = await seed();
+
+    const event = makeEvent(
+      stable.stableId,
+      { body: '  Hello faction  ' },
+      'Wrestler',
+      MEMBER_SUB,
+    );
+    const result = await postMessage(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(201);
+    const created = JSON.parse(result!.body);
+    expect(created.factionId).toBe(stable.stableId);
+    expect(created.authorPlayerId).toBe(member.playerId);
+    expect(created.body).toBe('Hello faction');
+    expect(created.messageType).toBe('user');
+    expect(created.messageId).toBeTruthy();
+    expect(created.createdAt).toBeTruthy();
+
+    const page = await repos.factionMessages.list(stable.stableId);
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0].body).toBe('Hello faction');
+  });
+
+  it('returns 403 when a non-member tries to post', async () => {
+    const { stable } = await seed();
+
+    const event = makeEvent(
+      stable.stableId,
+      { body: 'I am not in this faction' },
+      'Wrestler',
+      OUTSIDER_SUB,
+    );
+    const result = await postMessage(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(403);
+    const page = await repos.factionMessages.list(stable.stableId);
+    expect(page.items).toHaveLength(0);
+  });
+
+  it('returns 400 for an empty body', async () => {
+    const { stable } = await seed();
+
+    const blank = await postMessage(
+      makeEvent(stable.stableId, { body: '   ' }, 'Wrestler', MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(blank!.statusCode).toBe(400);
+
+    const empty = await postMessage(
+      makeEvent(stable.stableId, { body: '' }, 'Wrestler', MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(empty!.statusCode).toBe(400);
+  });
+
+  it('returns 400 for a body longer than 2000 chars', async () => {
+    const { stable } = await seed();
+
+    const longBody = 'a'.repeat(2001);
+    const result = await postMessage(
+      makeEvent(stable.stableId, { body: longBody }, 'Wrestler', MEMBER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(400);
+  });
+
+  it('rejects non-admins attempting messageType=system with 403', async () => {
+    const { stable } = await seed();
+
+    const result = await postMessage(
+      makeEvent(
+        stable.stableId,
+        { body: 'X joined the faction', messageType: 'system' },
+        'Wrestler',
+        MEMBER_SUB,
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(403);
+    const page = await repos.factionMessages.list(stable.stableId);
+    expect(page.items).toHaveLength(0);
+  });
+
+  it('lets an admin who is not a member post a message', async () => {
+    const { stable } = await seed();
+
+    // Admin caller has no player profile in the faction.
+    const result = await postMessage(
+      makeEvent(stable.stableId, { body: 'Admin notice' }, 'Admin', ADMIN_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(201);
+    const created = JSON.parse(result!.body);
+    expect(created.messageType).toBe('user');
+
+    const page = await repos.factionMessages.list(stable.stableId);
+    expect(page.items).toHaveLength(1);
+  });
+
+  it('lets an admin post a system message', async () => {
+    const { stable } = await seed();
+
+    const result = await postMessage(
+      makeEvent(
+        stable.stableId,
+        { body: 'Bron Breakker joined the faction', messageType: 'system' },
+        'Admin',
+        ADMIN_SUB,
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(201);
+    const created = JSON.parse(result!.body);
+    expect(created.messageType).toBe('system');
+  });
+});

--- a/backend/functions/stables/getMessages.ts
+++ b/backend/functions/stables/getMessages.ts
@@ -1,0 +1,62 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, badRequest, forbidden, notFound, unauthorized, serverError } from '../../lib/response';
+import { getAuthContext, hasRole } from '../../lib/auth';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    if (!auth.sub) {
+      return unauthorized('Authentication required');
+    }
+
+    const factionId = event.pathParameters?.stableId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+
+    const qs = event.queryStringParameters || {};
+    const cursor = qs.cursor || undefined;
+
+    let limit = DEFAULT_LIMIT;
+    if (qs.limit !== undefined && qs.limit !== null && qs.limit !== '') {
+      const parsed = Number(qs.limit);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return badRequest('limit must be a positive number');
+      }
+      limit = Math.min(Math.floor(parsed), MAX_LIMIT);
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      factionMessages: factionMessagesRepo,
+    } = getRepositories();
+
+    const stable = await stablesRepo.findById(factionId);
+    if (!stable) {
+      return notFound('Faction not found');
+    }
+
+    const isAdmin = hasRole(auth, 'Admin');
+    if (!isAdmin) {
+      const callerPlayer = await playersRepo.findByUserId(auth.sub);
+      const callerPlayerId = callerPlayer?.playerId;
+      const isMember = callerPlayerId ? stable.memberIds.includes(callerPlayerId) : false;
+      if (!isMember) {
+        return forbidden('Only faction members can read this channel');
+      }
+    }
+
+    const page = await factionMessagesRepo.list(factionId, { cursor, limit });
+    return success(page);
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid pagination cursor') {
+      return badRequest('Invalid pagination cursor');
+    }
+    console.error('Error reading faction messages:', err);
+    return serverError('Failed to read messages');
+  }
+};

--- a/backend/functions/stables/handler.ts
+++ b/backend/functions/stables/handler.ts
@@ -12,6 +12,8 @@ import { handler as disbandStableHandler } from './disbandStable';
 import { handler as reactivateStableHandler } from './reactivateStable';
 import { handler as removeMemberHandler } from './removeMember';
 import { handler as deleteStableHandler } from './deleteStable';
+import { handler as postMessageHandler } from './postMessage';
+import { handler as getMessagesHandler } from './getMessages';
 import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
@@ -91,6 +93,18 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/stables/{stableId}/remove-member',
     method: 'POST',
     handler: removeMemberHandler,
+    requireAuth: true,
+  },
+  {
+    resource: '/stables/{stableId}/messages',
+    method: 'GET',
+    handler: getMessagesHandler,
+    requireAuth: true,
+  },
+  {
+    resource: '/stables/{stableId}/messages',
+    method: 'POST',
+    handler: postMessageHandler,
     requireAuth: true,
   },
   {

--- a/backend/functions/stables/postMessage.ts
+++ b/backend/functions/stables/postMessage.ts
@@ -1,0 +1,87 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+import { getRepositories } from '../../lib/repositories';
+import { created, badRequest, forbidden, notFound, unauthorized, serverError } from '../../lib/response';
+import { getAuthContext, hasRole } from '../../lib/auth';
+import { parseBody } from '../../lib/parseBody';
+import type { FactionMessage, FactionMessageType } from '../../lib/repositories/factionMessages';
+
+interface PostMessageBody {
+  body?: string;
+  messageType?: FactionMessageType;
+}
+
+const MAX_BODY_LEN = 2000;
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    if (!auth.sub) {
+      return unauthorized('Authentication required');
+    }
+
+    const factionId = event.pathParameters?.stableId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+
+    const { data, error: parseError } = parseBody<PostMessageBody>(event);
+    if (parseError) return parseError;
+
+    const rawBody = typeof data.body === 'string' ? data.body : '';
+    const trimmed = rawBody.trim();
+    if (trimmed.length === 0) {
+      return badRequest('Message body is required');
+    }
+    if (trimmed.length > MAX_BODY_LEN) {
+      return badRequest(`Message body must be ${MAX_BODY_LEN} characters or fewer`);
+    }
+
+    const messageType: FactionMessageType = data.messageType ?? 'user';
+    if (messageType !== 'user' && messageType !== 'system') {
+      return badRequest('messageType must be "user" or "system"');
+    }
+
+    const isAdmin = hasRole(auth, 'Admin');
+
+    if (messageType === 'system' && !isAdmin) {
+      return forbidden('Only admins can post system messages');
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      runInTransaction,
+    } = getRepositories();
+
+    const stable = await stablesRepo.findById(factionId);
+    if (!stable) {
+      return notFound('Faction not found');
+    }
+
+    const callerPlayer = await playersRepo.findByUserId(auth.sub);
+    const callerPlayerId = callerPlayer?.playerId;
+    const isMember = callerPlayerId ? stable.memberIds.includes(callerPlayerId) : false;
+
+    if (!isMember && !isAdmin) {
+      return forbidden('Only faction members can post messages');
+    }
+
+    const message: FactionMessage = {
+      messageId: uuidv4(),
+      factionId,
+      authorPlayerId: callerPlayerId ?? auth.sub,
+      body: trimmed,
+      messageType,
+      createdAt: new Date().toISOString(),
+    };
+
+    await runInTransaction(async (tx) => {
+      tx.appendFactionMessage(message);
+    });
+
+    return created(message);
+  } catch (err) {
+    console.error('Error posting faction message:', err);
+    return serverError('Failed to post message');
+  }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -904,6 +904,10 @@ functions:
           path: stables/{stableId}/remove-member
           method: post
           cors: *corsConfig
+      - http:
+          path: stables/{stableId}/messages
+          method: any
+          cors: *corsConfig
 
   # Tag Teams (consolidated: list, get, standings, create, update, respond, approve, reject, dissolve, delete)
   tagTeams:


### PR DESCRIPTION
## Summary
- New `POST /stables/{stableId}/messages` handler — body validated to 1..2000 chars, member-or-admin auth, `messageType='system'` gated to admins. Persists via `runInTransaction → appendFactionMessage`.
- New `GET /stables/{stableId}/messages` handler — newest-first paginated feed, default limit 50 / max 100, opaque cursor. Same membership ACL.
- Routes wired into the consolidated stables router + `serverless.yml`. IAM for `FACTION_MESSAGES_TABLE` was already in place at the provider level from FAC-04.
- Vitest: 7 cases for `postMessage`, 3 for `getMessages` (member feed order, non-member 403, 60-item pagination across two pages).

## Ticket
[FAC-05] Faction channel messages — post + list backend.
Two HTTP routes for the faction channel: POST publishes a message visible to every active member, GET reads the feed. Membership is the only ACL — non-members get 403 even on read. `messageType='system'` is admin-only so server-side flows (e.g. invitation-accepted events) can synthesize events without giving wrestlers a way to fake them. Pagination cursor is opaque; raw DynamoDB pagination tokens are never returned to the client. Edits, deletions, real-time push, unread counts, and rate limiting are intentionally out of scope.

Per the FAC-01 rename guardrail, the new files live under `backend/functions/stables/` and the routes are mounted on `/stables/{stableId}/messages` (the frontend's `factionsApi.messages.*` hits these via the same back-compat trick).

## Test plan
- [x] `cd backend && npx vitest run functions/stables` — 15 / 15 pass (3 files)
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd backend && npx eslint functions/stables/{postMessage,getMessages,handler}.ts functions/stables/__tests__/{postMessage,getMessages}.test.ts` — clean
- [x] Full backend Vitest suite — 1014 / 1014 pass
- [ ] Manual against devtest: faction member POSTs a message and sees it in GET; non-member GET returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)