### PR TITLE
feat(stables): FAC-06 faction direct messages (1:1 backend)

### DIFF
--- a/backend/functions/stables/__tests__/getDirectMessageThread.test.ts
+++ b/backend/functions/stables/__tests__/getDirectMessageThread.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { buildThreadKey } from '../../../lib/repositories/factionMessages';
+import { handler as getDirectMessageThread } from '../getDirectMessageThread';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+const LEADER_SUB = 'leader-sub';
+const MEMBER_SUB = 'member-sub';
+const OUTSIDER_SUB = 'outsider-sub';
+
+function makeEvent(
+  stableId: string,
+  partnerPlayerId: string,
+  qs: Record<string, string> | null,
+  sub: string,
+): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/direct-messages/${partnerPlayerId}`,
+    pathParameters: { stableId, partnerPlayerId },
+    queryStringParameters: qs,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: { groups: 'Wrestler', username: 'tester', email: 't@t.com', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seed() {
+  const leader = await repos.roster.players.create({ name: 'Leader', currentWrestler: 'Rock' });
+  await repos.roster.players.update(leader.playerId, { userId: LEADER_SUB });
+  const member = await repos.roster.players.create({ name: 'Member', currentWrestler: 'Cena' });
+  await repos.roster.players.update(member.playerId, { userId: MEMBER_SUB });
+  const outsider = await repos.roster.players.create({ name: 'Outsider', currentWrestler: 'Orton' });
+  await repos.roster.players.update(outsider.playerId, { userId: OUTSIDER_SUB });
+
+  const stable = await repos.roster.stables.create({
+    name: 'NWO',
+    leaderId: leader.playerId,
+    memberIds: [leader.playerId, member.playerId],
+    status: 'active',
+  });
+
+  return { leader, member, outsider, stable };
+}
+
+async function postN(
+  factionId: string,
+  senderPlayerId: string,
+  recipientPlayerId: string,
+  count: number,
+): Promise<void> {
+  let now = Date.now();
+  const realNow = Date.now;
+  Date.now = () => now;
+  try {
+    for (let i = 0; i < count; i++) {
+      now += 1;
+      vi.setSystemTime(new Date(now));
+      await repos.factionDirectMessages.post({
+        factionId,
+        senderPlayerId,
+        recipientPlayerId,
+        body: `msg-${i + 1}`,
+      });
+    }
+  } finally {
+    Date.now = realNow;
+    vi.useRealTimers();
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+describe('getDirectMessageThread (FAC-06)', () => {
+  it('returns the thread newest-first to either participant', async () => {
+    const { leader, member, stable } = await seed();
+    await postN(stable.stableId, leader.playerId, member.playerId, 3);
+
+    // Leader reads the thread keyed by their partner = member
+    const asLeader = await getDirectMessageThread(
+      makeEvent(stable.stableId, member.playerId, null, LEADER_SUB),
+      ctx,
+      cb,
+    );
+    expect(asLeader!.statusCode).toBe(200);
+    const leaderPage = JSON.parse(asLeader!.body);
+    expect(leaderPage.items).toHaveLength(3);
+    expect(leaderPage.items.map((m: { body: string }) => m.body)).toEqual([
+      'msg-3',
+      'msg-2',
+      'msg-1',
+    ]);
+
+    // Member reads the same thread keyed by their partner = leader
+    const asMember = await getDirectMessageThread(
+      makeEvent(stable.stableId, leader.playerId, null, MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(asMember!.statusCode).toBe(200);
+    const memberPage = JSON.parse(asMember!.body);
+    expect(memberPage.items).toHaveLength(3);
+    expect(memberPage.items[0].threadKey).toBe(buildThreadKey(leader.playerId, member.playerId));
+  });
+
+  it('returns 403 to a non-member trying to read any thread', async () => {
+    const { leader, member, stable } = await seed();
+    await postN(stable.stableId, leader.playerId, member.playerId, 2);
+
+    const result = await getDirectMessageThread(
+      makeEvent(stable.stableId, member.playerId, null, OUTSIDER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(403);
+  });
+
+  it('returns 404 when the partner is not in the faction (no enumeration leak)', async () => {
+    const { outsider, stable } = await seed();
+
+    const result = await getDirectMessageThread(
+      makeEvent(stable.stableId, outsider.playerId, null, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('returns 404 when the partner does not exist at all', async () => {
+    const { stable } = await seed();
+
+    const result = await getDirectMessageThread(
+      makeEvent(stable.stableId, 'no-such-player', null, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('blocks a previously-member after they are removed from the faction', async () => {
+    const { leader, member, stable } = await seed();
+    await postN(stable.stableId, leader.playerId, member.playerId, 2);
+
+    // Sanity: while a member, the user can read the thread
+    const before = await getDirectMessageThread(
+      makeEvent(stable.stableId, leader.playerId, null, MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(before!.statusCode).toBe(200);
+
+    // Remove the member from the faction (mimics the FAC-02 removal path)
+    await repos.roster.stables.update(stable.stableId, {
+      memberIds: [leader.playerId],
+    });
+
+    const after = await getDirectMessageThread(
+      makeEvent(stable.stableId, leader.playerId, null, MEMBER_SUB),
+      ctx,
+      cb,
+    );
+    expect(after!.statusCode).toBe(403);
+  });
+
+  it('rejects self-as-partner with 404 (caller cannot DM themselves)', async () => {
+    const { leader, stable } = await seed();
+
+    const result = await getDirectMessageThread(
+      makeEvent(stable.stableId, leader.playerId, null, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('returns 404 when the faction does not exist', async () => {
+    const { member } = await seed();
+
+    const result = await getDirectMessageThread(
+      makeEvent('no-such-faction', member.playerId, null, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(404);
+  });
+});

--- a/backend/functions/stables/__tests__/getMyDirectMessageThreads.test.ts
+++ b/backend/functions/stables/__tests__/getMyDirectMessageThreads.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { handler as getMyThreads } from '../getMyDirectMessageThreads';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+const LEADER_SUB = 'leader-sub';
+const MEMBER_SUB = 'member-sub';
+const THIRD_SUB = 'third-sub';
+const OUTSIDER_SUB = 'outsider-sub';
+
+function makeEvent(stableId: string, sub: string): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/direct-messages`,
+    pathParameters: { stableId },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: { groups: 'Wrestler', username: 'tester', email: 't@t.com', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seed() {
+  const leader = await repos.roster.players.create({ name: 'Leader', currentWrestler: 'Rock' });
+  await repos.roster.players.update(leader.playerId, { userId: LEADER_SUB });
+  const member = await repos.roster.players.create({ name: 'Member', currentWrestler: 'Cena' });
+  await repos.roster.players.update(member.playerId, { userId: MEMBER_SUB });
+  const third = await repos.roster.players.create({ name: 'Third', currentWrestler: 'Punk' });
+  await repos.roster.players.update(third.playerId, { userId: THIRD_SUB });
+  const outsider = await repos.roster.players.create({ name: 'Outsider', currentWrestler: 'Orton' });
+  await repos.roster.players.update(outsider.playerId, { userId: OUTSIDER_SUB });
+
+  const stable = await repos.roster.stables.create({
+    name: 'NWO',
+    leaderId: leader.playerId,
+    memberIds: [leader.playerId, member.playerId, third.playerId],
+    status: 'active',
+  });
+
+  return { leader, member, third, outsider, stable };
+}
+
+async function postN(
+  factionId: string,
+  senderPlayerId: string,
+  recipientPlayerId: string,
+  count: number,
+  prefix = 'msg',
+): Promise<void> {
+  let now = Date.now();
+  const realNow = Date.now;
+  Date.now = () => now;
+  try {
+    for (let i = 0; i < count; i++) {
+      now += 1;
+      vi.setSystemTime(new Date(now));
+      await repos.factionDirectMessages.post({
+        factionId,
+        senderPlayerId,
+        recipientPlayerId,
+        body: `${prefix}-${i + 1}`,
+      });
+    }
+  } finally {
+    Date.now = realNow;
+    vi.useRealTimers();
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+describe('getMyDirectMessageThreads (FAC-06)', () => {
+  it('returns one row per partner with the correct last message (even on a 300-message thread)', async () => {
+    const { leader, member, third, stable } = await seed();
+
+    // Thread A (leader ↔ member): 300 messages alternating
+    for (let i = 0; i < 150; i++) {
+      // Stagger to keep createdAt monotonic
+      await postN(stable.stableId, leader.playerId, member.playerId, 1, `LM-out-${i}`);
+      await postN(stable.stableId, member.playerId, leader.playerId, 1, `LM-in-${i}`);
+    }
+
+    // Thread B (leader ↔ third): just a couple of messages
+    await postN(stable.stableId, leader.playerId, third.playerId, 1, 'LT-1');
+    await postN(stable.stableId, third.playerId, leader.playerId, 1, 'LT-2');
+
+    const result = await getMyThreads(
+      makeEvent(stable.stableId, LEADER_SUB),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toHaveLength(2);
+
+    // Each row has the correct partner identity hydrated
+    const byPartner = new Map<string, (typeof body.items)[number]>(
+      body.items.map((r: { partnerPlayerId: string }) => [r.partnerPlayerId, r]),
+    );
+    const rowMember = byPartner.get(member.playerId)!;
+    expect(rowMember.partnerPlayerName).toBe('Member');
+    expect(rowMember.partnerWrestlerName).toBe('Cena');
+    // Last message of the leader↔member thread is the final "LM-in-149-1" post
+    expect(rowMember.lastMessage.body).toBe('LM-in-149-1');
+    expect(rowMember.lastMessageAt).toBe(rowMember.lastMessage.createdAt);
+
+    const rowThird = byPartner.get(third.playerId)!;
+    expect(rowThird.partnerPlayerName).toBe('Third');
+    expect(rowThird.partnerWrestlerName).toBe('Punk');
+    expect(rowThird.lastMessage.body).toBe('LT-2-1');
+  });
+
+  it('returns 403 to a non-member of the faction', async () => {
+    const { leader, member, stable } = await seed();
+    await postN(stable.stableId, leader.playerId, member.playerId, 1);
+
+    const result = await getMyThreads(
+      makeEvent(stable.stableId, OUTSIDER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(403);
+  });
+
+  it('returns an empty list for a member with no DMs', async () => {
+    const { stable } = await seed();
+
+    const result = await getMyThreads(
+      makeEvent(stable.stableId, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toEqual([]);
+  });
+
+  it('returns 404 when the faction does not exist', async () => {
+    await seed();
+
+    const result = await getMyThreads(
+      makeEvent('no-such-faction', LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const { stable } = await seed();
+
+    const result = await getMyThreads(
+      makeEvent(stable.stableId, ''),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(401);
+  });
+});

--- a/backend/functions/stables/__tests__/postDirectMessage.test.ts
+++ b/backend/functions/stables/__tests__/postDirectMessage.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { buildThreadKey } from '../../../lib/repositories/factionMessages';
+import { handler as postDirectMessage } from '../postDirectMessage';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+const LEADER_SUB = 'leader-sub';
+const MEMBER_SUB = 'member-sub';
+const OUTSIDER_SUB = 'outsider-sub';
+
+function makeEvent(stableId: string, body: unknown, sub: string): APIGatewayProxyEvent {
+  return {
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/direct-messages`,
+    pathParameters: { stableId },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {
+      authorizer: { groups: 'Wrestler', username: 'tester', email: 't@t.com', principalId: sub },
+    } as unknown as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function seed() {
+  const leader = await repos.roster.players.create({ name: 'Leader', currentWrestler: 'Rock' });
+  await repos.roster.players.update(leader.playerId, { userId: LEADER_SUB });
+  const member = await repos.roster.players.create({ name: 'Member', currentWrestler: 'Cena' });
+  await repos.roster.players.update(member.playerId, { userId: MEMBER_SUB });
+  const outsider = await repos.roster.players.create({ name: 'Outsider', currentWrestler: 'Orton' });
+  await repos.roster.players.update(outsider.playerId, { userId: OUTSIDER_SUB });
+
+  const stable = await repos.roster.stables.create({
+    name: 'NWO',
+    leaderId: leader.playerId,
+    memberIds: [leader.playerId, member.playerId],
+    status: 'active',
+  });
+
+  return { leader, member, outsider, stable };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+describe('postDirectMessage (FAC-06)', () => {
+  it('lets two members DM each other and computes a deterministic threadKey', async () => {
+    const { leader, member, stable } = await seed();
+
+    const result = await postDirectMessage(
+      makeEvent(stable.stableId, { recipientPlayerId: member.playerId, body: '  Hi there  ' }, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(201);
+    const created = JSON.parse(result!.body);
+    expect(created.factionId).toBe(stable.stableId);
+    expect(created.senderPlayerId).toBe(leader.playerId);
+    expect(created.recipientPlayerId).toBe(member.playerId);
+    expect(created.body).toBe('Hi there');
+    expect(created.threadKey).toBe(buildThreadKey(leader.playerId, member.playerId));
+
+    // Persisted in the repo
+    const page = await repos.factionDirectMessages.listThread(stable.stableId, created.threadKey);
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0].body).toBe('Hi there');
+  });
+
+  it('returns 403 with errorKey=not_both_members when recipient is not in the faction', async () => {
+    const { member, outsider, stable } = await seed();
+
+    const result = await postDirectMessage(
+      makeEvent(stable.stableId, { recipientPlayerId: outsider.playerId, body: 'hello' }, MEMBER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(403);
+    const body = JSON.parse(result!.body);
+    expect(body.errorKey).toBe('not_both_members');
+
+    // Nothing persisted
+    const all = repos.factionDirectMessages.store;
+    expect(all).toHaveLength(0);
+    // Ensure variable usage to keep tsc happy
+    expect(member.playerId).toBeTruthy();
+  });
+
+  it('returns 403 not_both_members when the caller themselves is not in the faction', async () => {
+    const { member, stable } = await seed();
+
+    const result = await postDirectMessage(
+      makeEvent(stable.stableId, { recipientPlayerId: member.playerId, body: 'hi' }, OUTSIDER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(403);
+    const body = JSON.parse(result!.body);
+    expect(body.errorKey).toBe('not_both_members');
+  });
+
+  it('rejects a self-DM with 400', async () => {
+    const { leader, stable } = await seed();
+
+    const result = await postDirectMessage(
+      makeEvent(stable.stableId, { recipientPlayerId: leader.playerId, body: 'note to self' }, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(400);
+  });
+
+  it('returns 400 for an empty or whitespace-only body', async () => {
+    const { member, stable } = await seed();
+
+    const blank = await postDirectMessage(
+      makeEvent(stable.stableId, { recipientPlayerId: member.playerId, body: '   ' }, LEADER_SUB),
+      ctx,
+      cb,
+    );
+    expect(blank!.statusCode).toBe(400);
+
+    const empty = await postDirectMessage(
+      makeEvent(stable.stableId, { recipientPlayerId: member.playerId, body: '' }, LEADER_SUB),
+      ctx,
+      cb,
+    );
+    expect(empty!.statusCode).toBe(400);
+  });
+
+  it('returns 400 for a body longer than 2000 chars', async () => {
+    const { member, stable } = await seed();
+
+    const result = await postDirectMessage(
+      makeEvent(
+        stable.stableId,
+        { recipientPlayerId: member.playerId, body: 'a'.repeat(2001) },
+        LEADER_SUB,
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(400);
+  });
+
+  it('returns 400 when recipientPlayerId is missing', async () => {
+    const { stable } = await seed();
+
+    const result = await postDirectMessage(
+      makeEvent(stable.stableId, { body: 'hello' }, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(400);
+  });
+
+  it('returns 404 when the faction does not exist', async () => {
+    await seed();
+
+    const result = await postDirectMessage(
+      makeEvent('does-not-exist', { recipientPlayerId: 'whoever', body: 'hi' }, LEADER_SUB),
+      ctx,
+      cb,
+    );
+
+    // Caller has a player but with no faction match — surfaces as 404
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const { member, stable } = await seed();
+
+    const event = makeEvent(stable.stableId, { recipientPlayerId: member.playerId, body: 'hi' }, '');
+    const result = await postDirectMessage(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(401);
+  });
+});

--- a/backend/functions/stables/__tests__/postDirectMessage.test.ts
+++ b/backend/functions/stables/__tests__/postDirectMessage.test.ts
@@ -105,11 +105,17 @@ describe('postDirectMessage (FAC-06)', () => {
     const body = JSON.parse(result!.body);
     expect(body.errorKey).toBe('not_both_members');
 
-    // Nothing persisted
-    const all = repos.factionDirectMessages.store;
-    expect(all).toHaveLength(0);
-    // Ensure variable usage to keep tsc happy
-    expect(member.playerId).toBeTruthy();
+    // Nothing persisted — neither side has any threads
+    const memberThreads = await repos.factionDirectMessages.listThreadsForPlayer(
+      stable.stableId,
+      member.playerId,
+    );
+    expect(memberThreads).toEqual([]);
+    const outsiderThreads = await repos.factionDirectMessages.listThreadsForPlayer(
+      stable.stableId,
+      outsider.playerId,
+    );
+    expect(outsiderThreads).toEqual([]);
   });
 
   it('returns 403 not_both_members when the caller themselves is not in the faction', async () => {

--- a/backend/functions/stables/getDirectMessageThread.ts
+++ b/backend/functions/stables/getDirectMessageThread.ts
@@ -1,0 +1,76 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { buildThreadKey } from '../../lib/repositories/factionMessages';
+import { success, badRequest, forbidden, notFound, unauthorized, serverError } from '../../lib/response';
+import { getAuthContext } from '../../lib/auth';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    if (!auth.sub) {
+      return unauthorized('Authentication required');
+    }
+
+    const factionId = event.pathParameters?.stableId;
+    const partnerPlayerId = event.pathParameters?.partnerPlayerId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+    if (!partnerPlayerId) {
+      return badRequest('partnerPlayerId is required');
+    }
+
+    const qs = event.queryStringParameters || {};
+    const cursor = qs.cursor || undefined;
+
+    let limit = DEFAULT_LIMIT;
+    if (qs.limit !== undefined && qs.limit !== null && qs.limit !== '') {
+      const parsed = Number(qs.limit);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return badRequest('limit must be a positive number');
+      }
+      limit = Math.min(Math.floor(parsed), MAX_LIMIT);
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      factionDirectMessages: factionDirectMessagesRepo,
+    } = getRepositories();
+
+    const faction = await stablesRepo.findById(factionId);
+    if (!faction) {
+      return notFound('Faction not found');
+    }
+
+    const callerPlayer = await playersRepo.findByUserId(auth.sub);
+    const callerPlayerId = callerPlayer?.playerId;
+    const memberIds = faction.memberIds ?? [];
+    const isMember = callerPlayerId ? memberIds.includes(callerPlayerId) : false;
+
+    if (!isMember || !callerPlayerId) {
+      return forbidden('Only faction members can read direct messages');
+    }
+
+    // Don't leak whether the partner exists at all — return a generic 404
+    // for both "not a member" and "doesn't exist".
+    if (!memberIds.includes(partnerPlayerId) || partnerPlayerId === callerPlayerId) {
+      return notFound('Thread not found');
+    }
+
+    const threadKey = buildThreadKey(callerPlayerId, partnerPlayerId);
+    const page = await factionDirectMessagesRepo.listThread(factionId, threadKey, {
+      cursor,
+      limit,
+    });
+    return success(page);
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Invalid pagination cursor') {
+      return badRequest('Invalid pagination cursor');
+    }
+    console.error('Error reading faction direct message thread:', err);
+    return serverError('Failed to read direct message thread');
+  }
+};

--- a/backend/functions/stables/getMyDirectMessageThreads.ts
+++ b/backend/functions/stables/getMyDirectMessageThreads.ts
@@ -1,0 +1,69 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, badRequest, forbidden, notFound, unauthorized, serverError } from '../../lib/response';
+import { getAuthContext } from '../../lib/auth';
+import type { FactionDirectMessage } from '../../lib/repositories/factionMessages';
+
+interface ThreadRow {
+  partnerPlayerId: string;
+  partnerPlayerName: string | null;
+  partnerWrestlerName: string | null;
+  lastMessage: FactionDirectMessage;
+  lastMessageAt: string;
+}
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    if (!auth.sub) {
+      return unauthorized('Authentication required');
+    }
+
+    const factionId = event.pathParameters?.stableId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      factionDirectMessages: factionDirectMessagesRepo,
+    } = getRepositories();
+
+    const faction = await stablesRepo.findById(factionId);
+    if (!faction) {
+      return notFound('Faction not found');
+    }
+
+    const callerPlayer = await playersRepo.findByUserId(auth.sub);
+    const callerPlayerId = callerPlayer?.playerId;
+    const memberIds = faction.memberIds ?? [];
+    const isMember = callerPlayerId ? memberIds.includes(callerPlayerId) : false;
+
+    if (!isMember || !callerPlayerId) {
+      return forbidden('Only faction members can list direct message threads');
+    }
+
+    const summaries = await factionDirectMessagesRepo.listThreadsForPlayer(
+      factionId,
+      callerPlayerId,
+    );
+
+    const items: ThreadRow[] = await Promise.all(
+      summaries.map(async (s) => {
+        const partner = await playersRepo.findById(s.partnerPlayerId);
+        return {
+          partnerPlayerId: s.partnerPlayerId,
+          partnerPlayerName: partner?.name ?? null,
+          partnerWrestlerName: partner?.currentWrestler ?? null,
+          lastMessage: s.lastMessage,
+          lastMessageAt: s.lastMessage.createdAt,
+        };
+      }),
+    );
+
+    return success({ items });
+  } catch (err) {
+    console.error('Error listing faction direct message threads:', err);
+    return serverError('Failed to list direct message threads');
+  }
+};

--- a/backend/functions/stables/handler.ts
+++ b/backend/functions/stables/handler.ts
@@ -14,6 +14,9 @@ import { handler as removeMemberHandler } from './removeMember';
 import { handler as deleteStableHandler } from './deleteStable';
 import { handler as postMessageHandler } from './postMessage';
 import { handler as getMessagesHandler } from './getMessages';
+import { handler as postDirectMessageHandler } from './postDirectMessage';
+import { handler as getDirectMessageThreadHandler } from './getDirectMessageThread';
+import { handler as getMyDirectMessageThreadsHandler } from './getMyDirectMessageThreads';
 import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
@@ -105,6 +108,24 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/stables/{stableId}/messages',
     method: 'POST',
     handler: postMessageHandler,
+    requireAuth: true,
+  },
+  {
+    resource: '/stables/{stableId}/direct-messages',
+    method: 'GET',
+    handler: getMyDirectMessageThreadsHandler,
+    requireAuth: true,
+  },
+  {
+    resource: '/stables/{stableId}/direct-messages',
+    method: 'POST',
+    handler: postDirectMessageHandler,
+    requireAuth: true,
+  },
+  {
+    resource: '/stables/{stableId}/direct-messages/{partnerPlayerId}',
+    method: 'GET',
+    handler: getDirectMessageThreadHandler,
     requireAuth: true,
   },
   {

--- a/backend/functions/stables/postDirectMessage.ts
+++ b/backend/functions/stables/postDirectMessage.ts
@@ -1,0 +1,109 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda';
+import { v4 as uuidv4 } from 'uuid';
+import { getRepositories } from '../../lib/repositories';
+import { buildThreadKey } from '../../lib/repositories/factionMessages';
+import { created, badRequest, notFound, unauthorized, serverError } from '../../lib/response';
+import { getAuthContext } from '../../lib/auth';
+import { parseBody } from '../../lib/parseBody';
+import type { FactionDirectMessage } from '../../lib/repositories/factionMessages';
+
+interface PostDirectMessageBody {
+  recipientPlayerId?: string;
+  body?: string;
+}
+
+const MAX_BODY_LEN = 2000;
+
+const notBothMembers = (): APIGatewayProxyResult => ({
+  statusCode: 403,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGIN || 'https://leagueszn.jpdxsolo.com',
+    'Access-Control-Allow-Credentials': true,
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    'Cache-Control': 'no-store',
+    'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+  } as Record<string, string | boolean | number>,
+  body: JSON.stringify({
+    message: 'Both participants must be active members of this faction',
+    errorKey: 'not_both_members',
+  }),
+});
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const auth = getAuthContext(event);
+    if (!auth.sub) {
+      return unauthorized('Authentication required');
+    }
+
+    const factionId = event.pathParameters?.stableId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+
+    const { data, error: parseError } = parseBody<PostDirectMessageBody>(event);
+    if (parseError) return parseError;
+
+    const recipientPlayerId =
+      typeof data.recipientPlayerId === 'string' ? data.recipientPlayerId.trim() : '';
+    if (!recipientPlayerId) {
+      return badRequest('recipientPlayerId is required');
+    }
+
+    const rawBody = typeof data.body === 'string' ? data.body : '';
+    const trimmed = rawBody.trim();
+    if (trimmed.length === 0) {
+      return badRequest('Message body is required');
+    }
+    if (trimmed.length > MAX_BODY_LEN) {
+      return badRequest(`Message body must be ${MAX_BODY_LEN} characters or fewer`);
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      runInTransaction,
+    } = getRepositories();
+
+    const callerPlayer = await playersRepo.findByUserId(auth.sub);
+    if (!callerPlayer) {
+      return notBothMembers();
+    }
+
+    if (recipientPlayerId === callerPlayer.playerId) {
+      return badRequest('Cannot send a direct message to yourself');
+    }
+
+    const faction = await stablesRepo.findById(factionId);
+    if (!faction) {
+      return notFound('Faction not found');
+    }
+
+    const memberIds = faction.memberIds ?? [];
+    if (!memberIds.includes(callerPlayer.playerId) || !memberIds.includes(recipientPlayerId)) {
+      return notBothMembers();
+    }
+
+    const threadKey = buildThreadKey(callerPlayer.playerId, recipientPlayerId);
+
+    const message: FactionDirectMessage = {
+      messageId: uuidv4(),
+      factionId,
+      threadKey,
+      senderPlayerId: callerPlayer.playerId,
+      recipientPlayerId,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+
+    await runInTransaction(async (tx) => {
+      tx.appendFactionDirectMessage(message);
+    });
+
+    return created(message);
+  } catch (err) {
+    console.error('Error posting faction direct message:', err);
+    return serverError('Failed to post direct message');
+  }
+};

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -908,6 +908,14 @@ functions:
           path: stables/{stableId}/messages
           method: any
           cors: *corsConfig
+      - http:
+          path: stables/{stableId}/direct-messages
+          method: any
+          cors: *corsConfig
+      - http:
+          path: stables/{stableId}/direct-messages/{partnerPlayerId}
+          method: any
+          cors: *corsConfig
 
   # Tag Teams (consolidated: list, get, standings, create, update, respond, approve, reject, dissolve, delete)
   tagTeams:


### PR DESCRIPTION
## Summary
- Three new handlers under `backend/functions/stables/` for faction-scoped 1:1 DMs: `postDirectMessage`, `getDirectMessageThread`, `getMyDirectMessageThreads`.
- Dual-membership ACL — both participants must be active members of the same faction; the post handler returns 403 with `errorKey: not_both_members` so the frontend can surface a useful message.
- Deterministic thread key via the FAC-04 `buildThreadKey` helper; persisted through `runInTransaction` → `tx.appendFactionDirectMessage`.
- Read endpoint returns 404 (not 400) when the partner isn't in the faction or doesn't exist, to avoid player-enumeration leaks.
- Routes wired in the stables router + `serverless.yml`. IAM was already granted for `FactionDirectMessagesTable` at the provider level in FAC-04, so no IAM changes were needed.
- 21 Vitest cases across the three handlers covering happy path, removal-after-membership, self-DM, body bounds, and last-message correctness on a 300-message thread.

## Ticket
[FAC-06] Faction direct messages — 1:1 between members backend (Phase 2, blocked by FAC-04, blocks FAC-09 / FAC-14).

Goal: three HTTP routes for in-faction private 1:1 messaging — post a DM, list a single thread, list all of a caller's threads in the faction. Both participants must be active members of the same faction.

Notes / risks called out in the ticket and respected here:
- Determinism of `threadKey` is load-bearing → always computed via the FAC-04 helper.
- Recipient existence is hidden behind a generic 404, never 400 with "no such player".
- Removed-member access is current-state-only by design (PK is `factionId#threadKey`; access is re-granted on re-membership).
- No cross-faction DMs and no group DMs (out of scope for v1).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 1035/1035 pass (21 new)
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [ ] Manual against devtest: two members of an active faction exchange DMs; both see the same thread on reload. A third member is blocked. A non-member is fully blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)