### PR TITLE
feat(stables): FAC-08 faction schedule + promos read endpoints

### DIFF
--- a/backend/functions/stables/__tests__/getFactionPromos.test.ts
+++ b/backend/functions/stables/__tests__/getFactionPromos.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { handler as getFactionPromos } from '../getFactionPromos';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(
+  stableId: string,
+  qs: Record<string, string> | null = null,
+): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/promos`,
+    pathParameters: { stableId },
+    queryStringParameters: qs,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function makePlayer(name: string, wrestler: string): Promise<{ playerId: string }> {
+  const p = await repos.roster.players.create({ name, currentWrestler: wrestler });
+  return { playerId: p.playerId };
+}
+
+interface PromoSeed {
+  promoId?: string;
+  author: string;
+  target?: string;
+  content?: string;
+  title?: string;
+  promoType?: 'open-mic' | 'call-out' | 'response' | 'pre-match' | 'post-match' | 'championship' | 'return';
+  createdAt: string;
+  isHidden?: boolean;
+}
+
+async function makePromo(seed: PromoSeed): Promise<string> {
+  vi.setSystemTime(new Date(seed.createdAt));
+  const created = await repos.content.promos.create({
+    playerId: seed.author,
+    promoType: seed.promoType ?? 'open-mic',
+    title: seed.title,
+    content: seed.content ?? 'lorem ipsum',
+    targetPlayerId: seed.target,
+  });
+  if (seed.isHidden) {
+    await repos.content.promos.update(created.promoId, { isHidden: true });
+  }
+  return created.promoId;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-10T12:00:00.000Z'));
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getFactionPromos (FAC-08)', () => {
+  it('returns 404 when the faction does not exist', async () => {
+    const result = await getFactionPromos(makeEvent('does-not-exist'), ctx, cb);
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('returns an empty list for a faction with no relevant promos', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'Empty',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const result = await getFactionPromos(makeEvent(stable.stableId), ctx, cb);
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toEqual([]);
+  });
+
+  describe('filter modes', () => {
+    async function seedFilterFixture() {
+      const a1 = await makePlayer('A1', 'Rock');
+      const a2 = await makePlayer('A2', 'Cena');
+      const outsider = await makePlayer('Outsider', 'Orton');
+
+      const stable = await repos.roster.stables.create({
+        name: 'NWO',
+        leaderId: a1.playerId,
+        memberIds: [a1.playerId, a2.playerId],
+        status: 'active',
+      });
+
+      // 1. Author=member, target=member (FEATURING)
+      const featuring = await makePromo({
+        author: a1.playerId,
+        target: a2.playerId,
+        content: 'inside the faction',
+        createdAt: '2026-05-01T00:00:00.000Z',
+      });
+      // 2. Author=member, target=outsider (BY-FACTION but not featuring)
+      const byFactionOnly = await makePromo({
+        author: a1.playerId,
+        target: outsider.playerId,
+        content: 'a member calls out an outsider',
+        createdAt: '2026-05-02T00:00:00.000Z',
+      });
+      // 3. Author=outsider, target=member (DIRECTED-AT-FACTION)
+      const directedAt = await makePromo({
+        author: outsider.playerId,
+        target: a1.playerId,
+        content: 'outsider responds',
+        createdAt: '2026-05-03T00:00:00.000Z',
+      });
+      // 4. Author=outsider, target=outsider (NEITHER — should appear in none)
+      await makePromo({
+        author: outsider.playerId,
+        target: outsider.playerId,
+        content: 'unrelated',
+        createdAt: '2026-05-04T00:00:00.000Z',
+      });
+
+      return { a1, a2, outsider, stable, featuring, byFactionOnly, directedAt };
+    }
+
+    it('filter=by-faction returns only promos authored by a member', async () => {
+      const { stable, featuring, byFactionOnly } = await seedFilterFixture();
+
+      const result = await getFactionPromos(
+        makeEvent(stable.stableId, { filter: 'by-faction' }),
+        ctx,
+        cb,
+      );
+      const body = JSON.parse(result!.body);
+      const ids = body.items.map((p: { promoId: string }) => p.promoId).sort();
+      expect(ids).toEqual([featuring, byFactionOnly].sort());
+    });
+
+    it('filter=directed-at-faction returns only promos whose target is a member AND author is not', async () => {
+      const { stable, directedAt } = await seedFilterFixture();
+
+      const result = await getFactionPromos(
+        makeEvent(stable.stableId, { filter: 'directed-at-faction' }),
+        ctx,
+        cb,
+      );
+      const body = JSON.parse(result!.body);
+      const ids = body.items.map((p: { promoId: string }) => p.promoId);
+      expect(ids).toEqual([directedAt]);
+    });
+
+    it('filter=featuring-faction returns only promos where BOTH author and target are members', async () => {
+      const { stable, featuring } = await seedFilterFixture();
+
+      const result = await getFactionPromos(
+        makeEvent(stable.stableId, { filter: 'featuring-faction' }),
+        ctx,
+        cb,
+      );
+      const body = JSON.parse(result!.body);
+      const ids = body.items.map((p: { promoId: string }) => p.promoId);
+      expect(ids).toEqual([featuring]);
+    });
+
+    it('filter=all (default) returns the union: author OR target is a member', async () => {
+      const { stable, featuring, byFactionOnly, directedAt } = await seedFilterFixture();
+
+      const result = await getFactionPromos(makeEvent(stable.stableId), ctx, cb);
+      const body = JSON.parse(result!.body);
+      const ids = body.items.map((p: { promoId: string }) => p.promoId).sort();
+      expect(ids).toEqual([featuring, byFactionOnly, directedAt].sort());
+    });
+  });
+
+  it('drops hidden promos from the public feed', async () => {
+    const a = await makePlayer('Author', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'X',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    await makePromo({
+      author: a.playerId,
+      content: 'visible',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    await makePromo({
+      author: a.playerId,
+      content: 'hidden',
+      createdAt: '2026-05-02T00:00:00.000Z',
+      isHidden: true,
+    });
+
+    const result = await getFactionPromos(makeEvent(stable.stableId), ctx, cb);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].excerpt).toBe('visible');
+  });
+
+  it('sorts newest-first and paginates with the cursor', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'X',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    for (let i = 0; i < 5; i++) {
+      const day = String(i + 1).padStart(2, '0');
+      await makePromo({
+        author: a.playerId,
+        content: `p${i + 1}`,
+        createdAt: `2026-05-${day}T00:00:00.000Z`,
+      });
+    }
+
+    const first = JSON.parse(
+      (await getFactionPromos(makeEvent(stable.stableId, { limit: '2' }), ctx, cb))!.body,
+    );
+    expect(first.items.map((p: { excerpt: string }) => p.excerpt)).toEqual(['p5', 'p4']);
+    expect(first.nextCursor).toBeTruthy();
+
+    const second = JSON.parse(
+      (await getFactionPromos(
+        makeEvent(stable.stableId, { limit: '2', cursor: first.nextCursor }),
+        ctx,
+        cb,
+      ))!.body,
+    );
+    expect(second.items.map((p: { excerpt: string }) => p.excerpt)).toEqual(['p3', 'p2']);
+    expect(second.nextCursor).toBeTruthy();
+
+    const third = JSON.parse(
+      (await getFactionPromos(
+        makeEvent(stable.stableId, { limit: '2', cursor: second.nextCursor }),
+        ctx,
+        cb,
+      ))!.body,
+    );
+    expect(third.items.map((p: { excerpt: string }) => p.excerpt)).toEqual(['p1']);
+    expect(third.nextCursor).toBeUndefined();
+  });
+
+  it('hydrates author and target names', async () => {
+    const a = await makePlayer('Author Name', 'Wrestler A');
+    const t = await makePlayer('Target Name', 'Wrestler T');
+    const stable = await repos.roster.stables.create({
+      name: 'X',
+      leaderId: a.playerId,
+      memberIds: [a.playerId, t.playerId],
+      status: 'active',
+    });
+
+    await makePromo({
+      author: a.playerId,
+      target: t.playerId,
+      content: 'hi',
+      title: 'Headline',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const result = await getFactionPromos(makeEvent(stable.stableId), ctx, cb);
+    const body = JSON.parse(result!.body);
+    expect(body.items[0]).toMatchObject({
+      authorPlayerName: 'Author Name',
+      authorWrestlerName: 'Wrestler A',
+      targetPlayerName: 'Target Name',
+      targetWrestlerName: 'Wrestler T',
+      headline: 'Headline',
+    });
+  });
+
+  it('returns 400 for an unknown filter value', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'X',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const result = await getFactionPromos(
+      makeEvent(stable.stableId, { filter: 'invalid-mode' }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(400);
+  });
+});

--- a/backend/functions/stables/__tests__/getFactionSchedule.test.ts
+++ b/backend/functions/stables/__tests__/getFactionSchedule.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+import { buildInMemoryRepositories } from '../../../lib/repositories/inMemory';
+import {
+  setRepositoriesForTesting,
+  resetRepositoriesForTesting,
+  type Repositories,
+} from '../../../lib/repositories';
+import { handler as getFactionSchedule } from '../getFactionSchedule';
+
+let repos: Repositories;
+const ctx = {} as Context;
+const cb: Callback = () => {};
+
+function makeEvent(
+  stableId: string,
+  qs: Record<string, string> | null = null,
+): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: `/stables/${stableId}/schedule`,
+    pathParameters: { stableId },
+    queryStringParameters: qs,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+    requestContext: {} as APIGatewayProxyEvent['requestContext'],
+  };
+}
+
+async function makePlayer(name: string, wrestler: string): Promise<{ playerId: string }> {
+  const p = await repos.roster.players.create({ name, currentWrestler: wrestler });
+  return { playerId: p.playerId };
+}
+
+interface MatchSeed {
+  matchId: string;
+  date: string;
+  status: 'scheduled' | 'completed' | 'cancelled' | 'open-signups';
+  matchFormat?: string;
+  participants: string[];
+  eventId?: string;
+}
+
+async function makeMatch(seed: MatchSeed): Promise<void> {
+  await repos.competition.matches.create({
+    matchId: seed.matchId,
+    date: seed.date,
+    matchFormat: seed.matchFormat ?? 'singles',
+    participants: seed.participants,
+    eventId: seed.eventId,
+    status: seed.status,
+    createdAt: seed.date,
+  });
+}
+
+const NOW = new Date('2026-05-10T12:00:00.000Z');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  resetRepositoriesForTesting();
+  repos = buildInMemoryRepositories();
+  setRepositoriesForTesting(repos);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getFactionSchedule (FAC-08)', () => {
+  it('returns 404 when the faction does not exist', async () => {
+    const result = await getFactionSchedule(makeEvent('does-not-exist'), ctx, cb);
+    expect(result!.statusCode).toBe(404);
+  });
+
+  it('returns an empty list for a faction with no scheduled matches', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'Empty',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const result = await getFactionSchedule(makeEvent(stable.stableId), ctx, cb);
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toEqual([]);
+  });
+
+  it('returns only scheduled matches involving a member, sorted ascending, within the default 60-day window', async () => {
+    const a = await makePlayer('Alpha', 'Rock');
+    const b = await makePlayer('Beta', 'Cena');
+    const outsider = await makePlayer('Outsider', 'Orton');
+    const stable = await repos.roster.stables.create({
+      name: 'NWO',
+      leaderId: a.playerId,
+      memberIds: [a.playerId, b.playerId],
+      status: 'active',
+    });
+
+    // In window, faction member as participant
+    await makeMatch({
+      matchId: 'm1',
+      date: '2026-06-15T12:00:00.000Z',
+      status: 'scheduled',
+      participants: [a.playerId, outsider.playerId],
+    });
+    // In window but no faction member — excluded
+    await makeMatch({
+      matchId: 'm2',
+      date: '2026-06-01T12:00:00.000Z',
+      status: 'scheduled',
+      participants: [outsider.playerId],
+    });
+    // Earlier date, faction member — should come first when sorted
+    await makeMatch({
+      matchId: 'm3',
+      date: '2026-05-20T12:00:00.000Z',
+      status: 'scheduled',
+      participants: [b.playerId, outsider.playerId],
+    });
+    // Completed match — excluded even though it involves a member
+    await makeMatch({
+      matchId: 'm4',
+      date: '2026-05-15T12:00:00.000Z',
+      status: 'completed',
+      participants: [a.playerId, outsider.playerId],
+    });
+    // Outside default 60-day window (NOW + ~90 days) — excluded
+    await makeMatch({
+      matchId: 'm5',
+      date: '2026-08-15T12:00:00.000Z',
+      status: 'scheduled',
+      participants: [a.playerId],
+    });
+
+    const result = await getFactionSchedule(makeEvent(stable.stableId), ctx, cb);
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    expect(body.items.map((m: { matchId: string }) => m.matchId)).toEqual(['m3', 'm1']);
+    expect(body.items[0].participants).toEqual([
+      { playerId: b.playerId, playerName: 'Beta', isFactionMember: true },
+      { playerId: outsider.playerId, playerName: 'Outsider', isFactionMember: false },
+    ]);
+  });
+
+  it('round-trips the from/to boundaries: from-inclusive, but one second earlier is excluded', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'BoundaryFC',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const from = '2026-06-01T00:00:00.000Z';
+    const to = '2026-06-30T23:59:59.999Z';
+
+    await makeMatch({
+      matchId: 'at-from',
+      date: from,
+      status: 'scheduled',
+      participants: [a.playerId],
+    });
+    await makeMatch({
+      matchId: 'before-from',
+      date: '2026-05-31T23:59:59.000Z',
+      status: 'scheduled',
+      participants: [a.playerId],
+    });
+    await makeMatch({
+      matchId: 'at-to',
+      date: to,
+      status: 'scheduled',
+      participants: [a.playerId],
+    });
+    await makeMatch({
+      matchId: 'after-to',
+      date: '2026-07-01T00:00:00.000Z',
+      status: 'scheduled',
+      participants: [a.playerId],
+    });
+
+    const result = await getFactionSchedule(makeEvent(stable.stableId, { from, to }), ctx, cb);
+    const body = JSON.parse(result!.body);
+    expect(body.items.map((m: { matchId: string }) => m.matchId)).toEqual(['at-from', 'at-to']);
+  });
+
+  it('hydrates eventName and location from the events repo', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'HydrateFC',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const ev = await repos.leagueOps.events.create({
+      name: 'WrestleSomething',
+      eventType: 'ppv',
+      date: '2026-06-10T20:00:00.000Z',
+      venue: 'MSG, New York',
+    });
+
+    await makeMatch({
+      matchId: 'mh1',
+      date: '2026-06-10T20:00:00.000Z',
+      status: 'scheduled',
+      participants: [a.playerId],
+      eventId: ev.eventId,
+    });
+
+    const result = await getFactionSchedule(makeEvent(stable.stableId), ctx, cb);
+    const body = JSON.parse(result!.body);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].eventId).toBe(ev.eventId);
+    expect(body.items[0].eventName).toBe('WrestleSomething');
+    expect(body.items[0].location).toBe('MSG, New York');
+  });
+
+  it('returns 400 for an invalid from date', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'X',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const result = await getFactionSchedule(
+      makeEvent(stable.stableId, { from: 'not-a-date' }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(400);
+  });
+
+  it('returns 400 when from is after to', async () => {
+    const a = await makePlayer('A', 'Rock');
+    const stable = await repos.roster.stables.create({
+      name: 'X',
+      leaderId: a.playerId,
+      memberIds: [a.playerId],
+      status: 'active',
+    });
+
+    const result = await getFactionSchedule(
+      makeEvent(stable.stableId, { from: '2026-07-01T00:00:00.000Z', to: '2026-06-01T00:00:00.000Z' }),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(400);
+  });
+});

--- a/backend/functions/stables/getFactionPromos.ts
+++ b/backend/functions/stables/getFactionPromos.ts
@@ -1,0 +1,199 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+import type { Promo } from '../../lib/repositories/types';
+
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+
+const FILTER_MODES = ['all', 'by-faction', 'directed-at-faction', 'featuring-faction'] as const;
+type FilterMode = typeof FILTER_MODES[number];
+
+interface PromoRow {
+  promoId: string;
+  promoType: Promo['promoType'];
+  thumbnail: string | null;
+  headline: string | null;
+  excerpt: string;
+  authorPlayerId: string;
+  authorPlayerName: string;
+  authorWrestlerName: string;
+  targetPlayerId: string | null;
+  targetPlayerName: string | null;
+  targetWrestlerName: string | null;
+  date: string;
+  viewCount: number | null;
+  heatImpact: number | null;
+  isReplyable: boolean;
+}
+
+interface PromosPage {
+  items: PromoRow[];
+  nextCursor?: string;
+}
+
+const encodeOffset = (offset: number): string =>
+  Buffer.from(String(offset), 'utf-8').toString('base64');
+
+const decodeOffset = (cursor: string | undefined): number => {
+  if (!cursor) return 0;
+  const n = Number(Buffer.from(cursor, 'base64').toString('utf-8'));
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error('Invalid pagination cursor');
+  }
+  return n;
+};
+
+/**
+ * GET /stables/{stableId}/promos?filter=&limit=&cursor=
+ *
+ * Public read. Returns promos authored by or directed at any current member
+ * of the faction, sorted newest-first. Cursor-based pagination.
+ *
+ * Filter modes (load-bearing on FAC-14 — do not rename):
+ *  - "all"                  : author ∈ memberIds OR target ∈ memberIds   (default)
+ *  - "by-faction"           : author ∈ memberIds
+ *  - "directed-at-faction"  : target ∈ memberIds AND author ∉ memberIds
+ *  - "featuring-faction"    : author ∈ memberIds AND target ∈ memberIds
+ *
+ * The "by-faction" mode uses the PlayerIndex GSI (one Query per member).
+ * The other modes need to filter on targetPlayerId, which has no GSI today —
+ * those paths fall back to a full table scan. If promo traffic grows, add a
+ * TargetPlayerIndex GSI and route those modes through it.
+ *
+ * Heat impact and view count are returned as `null` placeholders — heat is
+ * owned by FAC-11, and view counts aren't tracked yet. Frontends should
+ * treat the contract as stable and render `—` when null.
+ */
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const factionId = event.pathParameters?.stableId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+
+    const qs = event.queryStringParameters || {};
+    const filterRaw = (qs.filter || 'all').trim();
+    if (!FILTER_MODES.includes(filterRaw as FilterMode)) {
+      return badRequest(`filter must be one of ${FILTER_MODES.join(', ')}`);
+    }
+    const filter = filterRaw as FilterMode;
+
+    let limit = DEFAULT_LIMIT;
+    if (qs.limit) {
+      const parsed = Number(qs.limit);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return badRequest('limit must be a positive number');
+      }
+      limit = Math.min(Math.floor(parsed), MAX_LIMIT);
+    }
+
+    let offset: number;
+    try {
+      offset = decodeOffset(qs.cursor);
+    } catch {
+      return badRequest('Invalid pagination cursor');
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      content: { promos: promosRepo },
+    } = getRepositories();
+
+    const faction = await stablesRepo.findById(factionId);
+    if (!faction) {
+      return notFound('Faction not found');
+    }
+
+    const memberIds = new Set(faction.memberIds ?? []);
+
+    let candidates: Promo[];
+    if (filter === 'by-faction') {
+      // Cheap path: one GSI Query per member, then merge + dedupe by promoId.
+      const perMember = await Promise.all(
+        Array.from(memberIds).map((id) => promosRepo.listByPlayer(id)),
+      );
+      const seen = new Set<string>();
+      candidates = [];
+      for (const list of perMember) {
+        for (const p of list) {
+          if (!seen.has(p.promoId)) {
+            seen.add(p.promoId);
+            candidates.push(p);
+          }
+        }
+      }
+    } else {
+      // Modes that pivot on targetPlayerId need a scan today.
+      candidates = await promosRepo.list();
+    }
+
+    const matching = candidates.filter((p) => {
+      const authorInFaction = memberIds.has(p.playerId);
+      const targetInFaction = p.targetPlayerId ? memberIds.has(p.targetPlayerId) : false;
+      switch (filter) {
+        case 'by-faction':
+          return authorInFaction;
+        case 'directed-at-faction':
+          return targetInFaction && !authorInFaction;
+        case 'featuring-faction':
+          return authorInFaction && targetInFaction;
+        case 'all':
+        default:
+          return authorInFaction || targetInFaction;
+      }
+    });
+
+    // Drop hidden promos so the public feed can't be poisoned by moderated content.
+    const visible = matching.filter((p) => !p.isHidden);
+
+    visible.sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
+
+    const pageItems = visible.slice(offset, offset + limit);
+
+    // Hydrate author + target names (one findById per unique player).
+    const lookupIds = new Set<string>();
+    for (const p of pageItems) {
+      lookupIds.add(p.playerId);
+      if (p.targetPlayerId) lookupIds.add(p.targetPlayerId);
+    }
+    const playerEntries = await Promise.all(
+      Array.from(lookupIds).map(async (pid) => [pid, await playersRepo.findById(pid)] as const),
+    );
+    const playerById = new Map(playerEntries);
+
+    const items: PromoRow[] = pageItems.map((p) => {
+      const author = playerById.get(p.playerId);
+      const target = p.targetPlayerId ? playerById.get(p.targetPlayerId) ?? null : null;
+      const excerpt = (p.content || '').slice(0, 200);
+      return {
+        promoId: p.promoId,
+        promoType: p.promoType,
+        thumbnail: p.imageUrl ?? null,
+        headline: p.title ?? null,
+        excerpt,
+        authorPlayerId: p.playerId,
+        authorPlayerName: author?.name ?? 'Unknown',
+        authorWrestlerName: author?.currentWrestler ?? 'Unknown',
+        targetPlayerId: p.targetPlayerId ?? null,
+        targetPlayerName: target?.name ?? null,
+        targetWrestlerName: target?.currentWrestler ?? null,
+        date: p.createdAt,
+        viewCount: null,
+        heatImpact: null,
+        isReplyable: p.promoType !== 'response',
+      };
+    });
+
+    const nextOffset = offset + pageItems.length;
+    const response: PromosPage = {
+      items,
+      ...(nextOffset < visible.length ? { nextCursor: encodeOffset(nextOffset) } : {}),
+    };
+
+    return success(response);
+  } catch (err) {
+    console.error('Error computing faction promos:', err);
+    return serverError('Failed to compute faction promos');
+  }
+};

--- a/backend/functions/stables/getFactionSchedule.ts
+++ b/backend/functions/stables/getFactionSchedule.ts
@@ -1,0 +1,140 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, badRequest, notFound, serverError } from '../../lib/response';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const DEFAULT_WINDOW_DAYS = 60;
+
+interface ParticipantRow {
+  playerId: string;
+  playerName: string;
+  isFactionMember: boolean;
+}
+
+interface ScheduledMatchRow {
+  matchId: string;
+  scheduledFor: string;
+  matchFormat: string;
+  eventId: string | null;
+  eventName: string | null;
+  location: string | null;
+  participants: ParticipantRow[];
+}
+
+/**
+ * GET /stables/{stableId}/schedule?from=&to=&limit=
+ *
+ * Public read. Returns upcoming/scheduled matches involving any current member
+ * of the faction, in the supplied time window. Default window is the next 60
+ * days. Sorted by scheduledFor ascending.
+ *
+ * The membership pivot is the *current* memberIds — a wrestler who left the
+ * faction last week won't have their upcoming matches in this list. (Past
+ * matches are surfaced via FAC-07's stats endpoint.)
+ */
+export const handler: APIGatewayProxyHandler = async (event) => {
+  try {
+    const factionId = event.pathParameters?.stableId;
+    if (!factionId) {
+      return badRequest('stableId is required');
+    }
+
+    const qs = event.queryStringParameters || {};
+
+    let limit = DEFAULT_LIMIT;
+    if (qs.limit) {
+      const parsed = Number(qs.limit);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return badRequest('limit must be a positive number');
+      }
+      limit = Math.min(Math.floor(parsed), MAX_LIMIT);
+    }
+
+    const now = new Date();
+    const defaultTo = new Date(now.getTime() + DEFAULT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const from = qs.from ? new Date(qs.from) : now;
+    const to = qs.to ? new Date(qs.to) : defaultTo;
+    if (Number.isNaN(from.getTime())) {
+      return badRequest('from must be a valid ISO date');
+    }
+    if (Number.isNaN(to.getTime())) {
+      return badRequest('to must be a valid ISO date');
+    }
+    if (from > to) {
+      return badRequest('from must be before to');
+    }
+
+    const {
+      roster: { stables: stablesRepo, players: playersRepo },
+      competition: { matches: matchesRepo },
+      leagueOps: { events: eventsRepo },
+    } = getRepositories();
+
+    const faction = await stablesRepo.findById(factionId);
+    if (!faction) {
+      return notFound('Faction not found');
+    }
+
+    const memberIds = new Set(faction.memberIds ?? []);
+
+    const scheduled = await matchesRepo.listByStatus('scheduled');
+
+    const fromMs = from.getTime();
+    const toMs = to.getTime();
+
+    const filtered = scheduled.filter((m) => {
+      const t = new Date(m.date).getTime();
+      if (Number.isNaN(t) || t < fromMs || t > toMs) return false;
+      return (m.participants || []).some((pid) => memberIds.has(pid));
+    });
+
+    filtered.sort((a, b) => a.date.localeCompare(b.date));
+    const sliced = filtered.slice(0, limit);
+
+    // Hydrate participants + events in parallel batches.
+    const playerIds = new Set<string>();
+    const eventIds = new Set<string>();
+    for (const m of sliced) {
+      for (const pid of m.participants || []) playerIds.add(pid);
+      if (m.eventId) eventIds.add(m.eventId);
+    }
+
+    const [playerEntries, eventEntries] = await Promise.all([
+      Promise.all(
+        Array.from(playerIds).map(async (pid) => [pid, await playersRepo.findById(pid)] as const),
+      ),
+      Promise.all(
+        Array.from(eventIds).map(async (eid) => [eid, await eventsRepo.findById(eid)] as const),
+      ),
+    ]);
+
+    const playerById = new Map(playerEntries);
+    const eventById = new Map(eventEntries);
+
+    const items: ScheduledMatchRow[] = sliced.map((m) => {
+      const ev = m.eventId ? eventById.get(m.eventId) ?? null : null;
+      return {
+        matchId: m.matchId,
+        scheduledFor: m.date,
+        matchFormat: m.matchFormat || m.matchType || 'unknown',
+        eventId: m.eventId ?? null,
+        eventName: ev?.name ?? null,
+        location: ev?.venue ?? null,
+        participants: (m.participants || []).map((pid) => {
+          const p = playerById.get(pid);
+          return {
+            playerId: pid,
+            playerName: p?.name ?? 'Unknown',
+            isFactionMember: memberIds.has(pid),
+          };
+        }),
+      };
+    });
+
+    return success({ items });
+  } catch (err) {
+    console.error('Error computing faction schedule:', err);
+    return serverError('Failed to compute faction schedule');
+  }
+};

--- a/backend/functions/stables/handler.ts
+++ b/backend/functions/stables/handler.ts
@@ -18,6 +18,8 @@ import { handler as postDirectMessageHandler } from './postDirectMessage';
 import { handler as getDirectMessageThreadHandler } from './getDirectMessageThread';
 import { handler as getMyDirectMessageThreadsHandler } from './getMyDirectMessageThreads';
 import { handler as getFactionStatsHandler } from './getFactionStats';
+import { handler as getFactionScheduleHandler } from './getFactionSchedule';
+import { handler as getFactionPromosHandler } from './getFactionPromos';
 import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
@@ -133,6 +135,16 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/stables/{stableId}/stats',
     method: 'GET',
     handler: getFactionStatsHandler,
+  },
+  {
+    resource: '/stables/{stableId}/schedule',
+    method: 'GET',
+    handler: getFactionScheduleHandler,
+  },
+  {
+    resource: '/stables/{stableId}/promos',
+    method: 'GET',
+    handler: getFactionPromosHandler,
   },
   {
     resource: '/stables/{stableId}',

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -920,6 +920,14 @@ functions:
           path: stables/{stableId}/stats
           method: get
           cors: *corsConfig
+      - http:
+          path: stables/{stableId}/schedule
+          method: get
+          cors: *corsConfig
+      - http:
+          path: stables/{stableId}/promos
+          method: get
+          cors: *corsConfig
 
   # Tag Teams (consolidated: list, get, standings, create, update, respond, approve, reject, dissolve, delete)
   tagTeams:


### PR DESCRIPTION
## Summary
- Two new public read endpoints under `/stables/{stableId}/`:
  - `GET /schedule?from=&to=&limit=` — upcoming scheduled matches involving any current member, default 60-day window, sorted ascending; participants and events are hydrated with names + venue.
  - `GET /promos?filter=&limit=&cursor=` — promos authored by or directed at a current member, four filter modes (`all` / `by-faction` / `directed-at-faction` / `featuring-faction`), cursor-based pagination, newest-first.
- Both pivot off `stable.memberIds` read fresh — a wrestler who left last week won't appear in the live feed.
- `by-faction` uses the `PlayerIndex` GSI (one Query per member) for the cheap path. The other promo modes need to filter on `targetPlayerId`, which has no GSI today — those fall back to a full `list()`. Documented in JSDoc with a pointer toward a future `TargetPlayerIndex` GSI if traffic warrants it.
- Hidden promos (`isHidden: true`) are dropped from the public feed.
- `viewCount` and `heatImpact` are returned as `null` placeholders to keep the contract stable for FAC-11 (heat) and any future view-count tracking.

## Ticket
[FAC-08] Member-related queries — schedule + promos backend (Phase 2, blocked by FAC-01, blocks FAC-09 / FAC-14).

Notes / risks called out in the ticket and respected here:
- Pivots off current memberIds (not historical) — Stats tab (FAC-07) is the historical surface.
- Only `status === 'scheduled'` matches surface; there's no `in_progress` status in this codebase.
- Filter values are kept exactly as specified — load-bearing on the FAC-14 frontend.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc -p tsconfig.json --noEmit` clean
- [x] `npm test` — 1060/1060 pass (17 new)
- [ ] Manual against devtest: `/stables/{id}/schedule` returns matches in the next 60 days; `/stables/{id}/promos` with each of the four filter modes returns the expected slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)