### PR TITLE
feat(factions): FAC-11 Faction Detail shell + Overview tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,13 @@ import EventResults from './components/events/EventResults';
 import FactionsList from './components/factions/FactionsList';
 import FactionStandings from './components/factions/FactionStandings';
 import FactionDetail from './components/factions/FactionDetail';
+import FactionOverview from './components/factions/tabs/FactionOverview';
+import FactionMembers from './components/factions/tabs/FactionMembers';
+import FactionStats from './components/factions/tabs/FactionStats';
+import FactionScheduleTab from './components/factions/tabs/FactionSchedule';
+import FactionPromosTab from './components/factions/tabs/FactionPromos';
+import FactionMessages from './components/factions/tabs/FactionMessages';
+import FactionManage from './components/factions/tabs/FactionManage';
 import MyFaction from './components/factions/MyFaction';
 // Tag Teams components
 import TagTeamsList from './components/tagTeams/TagTeamsList';
@@ -246,7 +253,15 @@ function AppLayout() {
             } />
             <Route path="/factions/:factionId" element={
               <FeatureRoute feature="stables"><FactionDetail /></FeatureRoute>
-            } />
+            }>
+              <Route index element={<FactionOverview />} />
+              <Route path="members" element={<FactionMembers />} />
+              <Route path="stats" element={<FactionStats />} />
+              <Route path="schedule" element={<FactionScheduleTab />} />
+              <Route path="promos" element={<FactionPromosTab />} />
+              <Route path="messages" element={<FactionMessages />} />
+              <Route path="manage" element={<FactionManage />} />
+            </Route>
             <Route path="/my-faction" element={
               <FeatureRoute feature="stables">
                 <ProtectedRoute requiredRole="Wrestler">

--- a/frontend/src/components/factions/FactionDetail.css
+++ b/frontend/src/components/factions/FactionDetail.css
@@ -1,396 +1,283 @@
+/*
+ * Faction Detail · shell (FAC-11).
+ *
+ * Hero banner + tab strip; each tab renders its own content underneath
+ * via <Outlet />. Prestige Brutalism: obsidian background, gold accents,
+ * tonal stacking, no borders.
+ */
+
 .faction-detail {
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-/* Header */
-.faction-detail__header {
-  display: flex;
-  gap: 1.5rem;
-  align-items: flex-start;
-}
-
-.faction-detail__header-image-wrapper {
-  width: 160px;
-  height: 160px;
-  flex-shrink: 0;
-  border-radius: 8px;
-  overflow: hidden;
-  border: 2px solid var(--color-border);
   background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
-.faction-detail__header-image {
+/* ─── Hero strip ─── */
+
+.faction-detail__hero {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 5;
+  min-height: 240px;
+  background-color: var(--color-bg);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.faction-detail__hero-image {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
 }
 
-.faction-detail__header-info {
+.faction-detail__hero-overlay {
+  position: absolute;
+  inset: 40% 0 0 0;
+  background: linear-gradient(to bottom, transparent 0%, #131313 90%);
+  pointer-events: none;
+}
+
+.faction-detail__hero-content {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 32px;
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  z-index: 1;
 }
 
-.faction-detail__name {
-  margin: 0;
-  font-size: 1.75rem;
-}
-
-.faction-detail__status {
-  display: inline-block;
-  padding: 0.2em 0.6em;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  width: fit-content;
-}
-
-.faction-detail__status--active {
-  background-color: var(--color-success);
-  color: #000;
-}
-
-.faction-detail__status--pending {
-  background-color: var(--color-warning);
-  color: #000;
-}
-
-.faction-detail__status--approved {
-  background-color: var(--color-info);
-  color: #fff;
-}
-
-.faction-detail__status--disbanded {
-  background-color: var(--color-text-muted);
-  color: #fff;
-}
-
-.faction-detail__leader {
-  color: var(--color-text-secondary);
-  font-size: 0.95rem;
-}
-
-.faction-detail__member-summary {
-  color: var(--color-text-muted);
-  font-size: 0.85rem;
-}
-
-/* Sections */
-.faction-detail__section {
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 1.5rem;
-}
-
-.faction-detail__section h3 {
-  margin: 0 0 1rem 0;
-  color: var(--color-primary);
-  font-size: 1.1rem;
-}
-
-/* Stats Grid */
-.faction-detail__stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 1rem;
-}
-
-.faction-detail__stat-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 1rem;
-  background-color: var(--color-bg);
-  border-radius: 6px;
-  border: 1px solid var(--color-border);
-}
-
-.faction-detail__stat-value {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.faction-detail__stat-value--wins {
-  color: var(--color-success);
-}
-
-.faction-detail__stat-value--losses {
-  color: var(--color-danger-alt);
-}
-
-.faction-detail__stat-value--draws {
-  color: var(--color-warning);
-}
-
-.faction-detail__stat-label {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-/* Form & Streak */
-.faction-detail__form-streak {
-  display: flex;
-  gap: 2rem;
-  margin-top: 1rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.faction-detail__form,
-.faction-detail__streak {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.faction-detail__form-label,
-.faction-detail__streak-label {
-  color: var(--color-text-secondary);
-  font-size: 0.875rem;
-  font-weight: 600;
-}
-
-/* Roster Grid */
-.faction-detail__roster-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.faction-detail__member-card {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.75rem;
-  background-color: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  text-decoration: none;
-  color: var(--color-text);
-  transition: border-color 0.2s;
-}
-
-.faction-detail__member-card:hover {
-  border-color: var(--color-primary);
-}
-
-.faction-detail__member-image {
-  width: 48px;
-  height: 48px;
-  border-radius: 4px;
-  object-fit: cover;
-  flex-shrink: 0;
-  border: 1px solid var(--color-border);
-}
-
-.faction-detail__member-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
+.faction-detail__hero-left {
   min-width: 0;
 }
 
-.faction-detail__member-player {
-  font-weight: 700;
-  font-size: 0.9rem;
+.faction-detail__hero-name {
+  margin: 0;
+  font-size: 4.5rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.faction-detail__hero-caption {
+  margin: 12px 0 0 0;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
 }
 
-.faction-detail__leader-badge {
-  font-size: 0.65rem;
-  padding: 0.1em 0.4em;
-  border-radius: 3px;
+.faction-detail__hero-status {
+  padding: 3px 8px;
+  font-weight: 800;
   background-color: var(--color-primary);
-  color: #000;
+  color: #1a1a1a;
+}
+
+.faction-detail__hero-status--pending {
+  background-color: #5a4a1e;
+  color: #fbbf24;
+}
+
+.faction-detail__hero-status--disbanded {
+  background-color: #2a2a2a;
+  color: #888;
+}
+
+.faction-detail__hero-divider {
+  color: var(--color-text-muted);
+}
+
+.faction-detail__hero-led {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.faction-detail__hero-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.faction-detail__hero-record {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.faction-detail__hero-record-label {
+  font-size: 0.7rem;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
 }
 
-.faction-detail__member-wrestler {
-  font-size: 0.8rem;
-  color: var(--color-text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.faction-detail__member-record {
-  font-size: 0.75rem;
-}
-
-.faction-detail__member-record .wins {
-  color: var(--color-success);
-  font-weight: 600;
-}
-
-.faction-detail__member-record .losses {
-  color: var(--color-danger-alt);
-  font-weight: 600;
-}
-
-.faction-detail__member-record .draws {
-  color: var(--color-warning);
-}
-
-/* Tables (Match Type Breakdown, Head to Head) */
-.faction-detail__table-wrapper {
-  overflow-x: auto;
-}
-
-.faction-detail__table {
-  width: 100%;
-  min-width: 300px;
-  border-collapse: collapse;
-}
-
-.faction-detail__table th {
-  text-align: center;
-  padding: 0.75rem;
-  border-bottom: 2px solid var(--color-border);
-  color: var(--color-text-secondary);
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.faction-detail__table td {
-  text-align: center;
-  padding: 0.6rem 0.75rem;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.faction-detail__table tbody tr:hover {
-  background-color: var(--color-surface-hover, rgba(255, 255, 255, 0.03));
-}
-
-.faction-detail__format-name,
-.faction-detail__opponent-name {
-  text-align: left;
-  font-weight: 600;
-}
-
-.faction-detail__opponent-name a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.faction-detail__opponent-name a:hover {
+.faction-detail__hero-record-value {
+  font-size: 2.5rem;
+  font-weight: 800;
   color: var(--color-primary);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.faction-detail__hero-heat {
+  display: flex;
+  gap: 4px;
+}
+
+.faction-detail__flame {
+  width: 22px;
+  height: 22px;
+}
+
+.faction-detail__flame--lit {
+  color: var(--color-primary);
+}
+
+.faction-detail__flame--dim {
+  color: #2f2f2f;
+}
+
+/* ─── Tab strip ─── */
+
+.faction-detail__tabs {
+  display: flex;
+  gap: 24px;
+  padding: 4px 32px 0;
+  background-color: var(--color-bg);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.faction-detail__tab {
+  position: relative;
+  padding: 12px 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 0.15s ease;
+}
+
+.faction-detail__tab:hover {
+  color: var(--color-text);
+}
+
+.faction-detail__tab--active {
+  color: var(--color-primary);
+}
+
+.faction-detail__tab--active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 4px;
+  background-color: var(--color-primary);
+}
+
+.faction-detail__content {
+  padding: 0 32px 32px;
+}
+
+/* Generic stub used by every "Coming soon" tab. */
+.faction-detail__tab-stub {
+  margin: 24px 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+/* ─── Error states ─── */
+
+.faction-detail__error {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.faction-detail__retry {
+  padding: 8px 16px;
+  background-color: var(--color-primary);
+  color: #1a1a1a;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+}
+
+.faction-detail__retry:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.faction-detail__back-link {
+  color: var(--color-text-secondary);
   text-decoration: underline;
 }
 
-.faction-detail__table .wins {
-  color: var(--color-success);
-  font-weight: bold;
-}
+/* ─── Responsive ─── */
 
-.faction-detail__table .losses {
-  color: var(--color-danger-alt);
-  font-weight: bold;
-}
+@media (max-width: 1024px) {
+  .faction-detail__hero-name {
+    font-size: 3rem;
+  }
 
-.faction-detail__table .draws {
-  color: var(--color-warning);
-}
-
-/* Recent Matches */
-.faction-detail__recent-matches {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.faction-detail__match-item {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.5rem 0.75rem;
-  background-color: var(--color-bg);
-  border-radius: 4px;
-  border: 1px solid var(--color-border);
-}
-
-.faction-detail__match-date {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  min-width: 90px;
-}
-
-.faction-detail__match-format {
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
-  flex: 1;
-}
-
-.faction-detail__match-result {
-  font-size: 0.8rem;
-  font-weight: 700;
-  padding: 0.15em 0.5em;
-  border-radius: 3px;
-}
-
-.faction-detail__match-result--win {
-  background-color: var(--color-success);
-  color: #000;
-}
-
-.faction-detail__match-result--loss {
-  background-color: var(--color-danger-alt);
-  color: #fff;
-}
-
-/* Back link */
-.faction-detail__back {
-  margin-top: 1rem;
+  .faction-detail__hero-record-value {
+    font-size: 2rem;
+  }
 }
 
 @media (max-width: 768px) {
-  .faction-detail__header {
+  .faction-detail__hero {
+    aspect-ratio: 4 / 3;
+    min-height: 320px;
+  }
+
+  .faction-detail__hero-content {
     flex-direction: column;
-    align-items: center;
-    text-align: center;
+    align-items: flex-start;
+    padding: 16px;
+    gap: 12px;
   }
 
-  .faction-detail__header-image-wrapper {
-    width: 120px;
-    height: 120px;
+  .faction-detail__hero-name {
+    font-size: 2.25rem;
   }
 
-  .faction-detail__header-info {
-    align-items: center;
+  .faction-detail__hero-right {
+    align-items: flex-start;
   }
 
-  .faction-detail__stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  .faction-detail__hero-record {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 8px;
   }
 
-  .faction-detail__roster-grid {
-    grid-template-columns: 1fr;
+  .faction-detail__hero-record-value {
+    font-size: 1.6rem;
   }
 
-  .faction-detail__section {
-    padding: 1rem;
+  .faction-detail__tabs {
+    padding: 4px 16px 0;
+    gap: 16px;
   }
 
-  .faction-detail__match-item {
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .faction-detail__match-date {
-    min-width: auto;
+  .faction-detail__content {
+    padding: 0 16px 24px;
   }
 }

--- a/frontend/src/components/factions/FactionDetail.tsx
+++ b/frontend/src/components/factions/FactionDetail.tsx
@@ -131,7 +131,16 @@ export default function FactionDetail() {
     lit: litHeat,
     total: HEAT_FLAME_COUNT,
   });
-  const statusLabel = t(`factions.hub.status.${faction.status}`, faction.status);
+  const statusFallbacks: Record<string, string> = {
+    pending: 'Pending',
+    approved: 'Active',
+    active: 'Active',
+    disbanded: 'Disbanded',
+  };
+  const statusLabel = t(
+    `factions.hub.status.${faction.status}`,
+    statusFallbacks[faction.status] ?? faction.status,
+  );
   const leaderName = faction.leaderName ?? t('factions.unknownLeader', 'Unknown');
 
   const outletContext: FactionDetailContext = { faction };

--- a/frontend/src/components/factions/FactionDetail.tsx
+++ b/frontend/src/components/factions/FactionDetail.tsx
@@ -1,17 +1,59 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { Link, NavLink, Outlet, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { factionsApi } from '../../services/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { logger } from '../../utils/logger';
-import type { StableDetailResponse, StablePlayerInfo, StableHeadToHead, StableMatchTypeRecord } from '../../types/stable';
+import type { StableDetailResponse } from '../../types/stable';
 import {
-  DEFAULT_WRESTLER_IMAGE,
+  DEFAULT_FACTION_IMAGE,
   resolveImageSrc,
   applyImageFallback,
 } from '../../constants/imageFallbacks';
 import Skeleton from '../ui/Skeleton';
 import './FactionDetail.css';
+
+/**
+ * Outlet context contract — child tabs receive the loaded faction so they
+ * don't re-fetch on mount. Each tab is free to fetch its own slice in
+ * addition; the shell only loads the identity + standings record.
+ */
+export interface FactionDetailContext {
+  faction: StableDetailResponse;
+}
+
+const HEAT_FLAME_COUNT = 5;
+
+function clampHeat(count: number | undefined): number {
+  if (!count || count < 0) return 0;
+  return Math.min(HEAT_FLAME_COUNT, Math.floor(count));
+}
+
+function FlameIcon({ lit }: { lit: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 16 16"
+      className={`faction-detail__flame ${lit ? 'faction-detail__flame--lit' : 'faction-detail__flame--dim'}`}
+    >
+      <path
+        d="M8 .5s2.5 3 2.5 5.5a2.5 2.5 0 0 1-1 2 1.5 1.5 0 0 0 1.5-2.5C12.5 7 14 9 14 11a6 6 0 1 1-12 0c0-2.5 2-4.5 2-7 0 2 2 3 4 3.5 0-2-1-3-1-4.5 0-1 1-2.5 1-2.5z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+const TABS = [
+  { value: 'overview', path: '', i18nKey: 'factions.detailTabs.overview', fallback: 'Overview' },
+  { value: 'members', path: 'members', i18nKey: 'factions.detailTabs.members', fallback: 'Members' },
+  { value: 'stats', path: 'stats', i18nKey: 'factions.detailTabs.stats', fallback: 'Stats' },
+  { value: 'schedule', path: 'schedule', i18nKey: 'factions.detailTabs.schedule', fallback: 'Schedule' },
+  { value: 'promos', path: 'promos', i18nKey: 'factions.detailTabs.promos', fallback: 'Promos' },
+  { value: 'messages', path: 'messages', i18nKey: 'factions.detailTabs.messages', fallback: 'Messages' },
+  { value: 'manage', path: 'manage', i18nKey: 'factions.detailTabs.manage', fallback: 'Manage' },
+] as const;
 
 export default function FactionDetail() {
   const { t } = useTranslation();
@@ -19,19 +61,20 @@ export default function FactionDetail() {
   const [faction, setFaction] = useState<StableDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useDocumentTitle(faction?.name ?? t('factions.detail', 'Faction Detail'));
 
   useEffect(() => {
     if (!factionId) return;
-    const abortController = new AbortController();
+    const ac = new AbortController();
 
     const fetchFaction = async () => {
       try {
         setLoading(true);
         setError(null);
-        const data = await factionsApi.getById(factionId, abortController.signal);
-        if (!abortController.signal.aborted) {
+        const data = await factionsApi.getById(factionId, ac.signal);
+        if (!ac.signal.aborted) {
           setFaction(data);
         }
       } catch (err) {
@@ -40,15 +83,15 @@ export default function FactionDetail() {
           setError(err.message || 'Failed to load faction');
         }
       } finally {
-        if (!abortController.signal.aborted) {
+        if (!ac.signal.aborted) {
           setLoading(false);
         }
       }
     };
 
     fetchFaction();
-    return () => abortController.abort();
-  }, [factionId]);
+    return () => ac.abort();
+  }, [factionId, reloadKey]);
 
   if (loading) {
     return <Skeleton variant="block" count={4} className="faction-detail-skeleton" />;
@@ -56,9 +99,16 @@ export default function FactionDetail() {
 
   if (error) {
     return (
-      <div className="error">
+      <div className="faction-detail__error">
         <p>{t('common.error', 'Error')}: {error}</p>
-        <Link to="/factions" className="btn btn-secondary">
+        <button
+          type="button"
+          className="faction-detail__retry"
+          onClick={() => setReloadKey((k) => k + 1)}
+        >
+          {t('common.retry', 'Retry')}
+        </button>
+        <Link to="/factions" className="faction-detail__back-link">
           {t('factions.backToList', 'Back to Factions')}
         </Link>
       </div>
@@ -67,245 +117,96 @@ export default function FactionDetail() {
 
   if (!faction) {
     return (
-      <div className="error">
+      <div className="faction-detail__error">
         <p>{t('factions.notFound', 'Faction not found.')}</p>
-        <Link to="/factions" className="btn btn-secondary">
+        <Link to="/factions" className="faction-detail__back-link">
           {t('factions.backToList', 'Back to Factions')}
         </Link>
       </div>
     );
   }
 
-  const totalMatches = faction.wins + faction.losses + faction.draws;
+  const litHeat = clampHeat(faction.standings.currentStreak?.count);
+  const heatLabel = t('factions.hub.heatLabel', 'Heat: {{lit}} of {{total}}', {
+    lit: litHeat,
+    total: HEAT_FLAME_COUNT,
+  });
+  const statusLabel = t(`factions.hub.status.${faction.status}`, faction.status);
+  const leaderName = faction.leaderName ?? t('factions.unknownLeader', 'Unknown');
+
+  const outletContext: FactionDetailContext = { faction };
 
   return (
     <div className="faction-detail">
-      {/* Header */}
-      <div className="faction-detail__header">
-        <div className="faction-detail__header-image-wrapper">
-          <img
-            src={resolveImageSrc(faction.imageUrl, DEFAULT_WRESTLER_IMAGE)}
-            onError={(event) => applyImageFallback(event, DEFAULT_WRESTLER_IMAGE)}
-            alt={faction.name}
-            className="faction-detail__header-image"
-          />
-        </div>
-        <div className="faction-detail__header-info">
-          <h2 className="faction-detail__name">{faction.name}</h2>
-          <span className={`faction-detail__status faction-detail__status--${faction.status}`}>
-            {faction.status}
-          </span>
-          {faction.leaderName && (
-            <p className="faction-detail__leader">
-              {t('factions.leader', 'Leader')}: <strong>{faction.leaderName}</strong>
-            </p>
-          )}
-          <p className="faction-detail__member-summary">
-            {t('factions.memberCount', '{{count}} members', { count: faction.members.length })}
-          </p>
-        </div>
-      </div>
-
-      {/* Overall Stats */}
-      <section className="faction-detail__section">
-        <h3>{t('factions.overallStats', 'Overall Stats')}</h3>
-        <div className="faction-detail__stats-grid">
-          <div className="faction-detail__stat-card">
-            <span className="faction-detail__stat-value faction-detail__stat-value--wins">{faction.wins}</span>
-            <span className="faction-detail__stat-label">{t('standings.table.wins', 'Wins')}</span>
-          </div>
-          <div className="faction-detail__stat-card">
-            <span className="faction-detail__stat-value faction-detail__stat-value--losses">{faction.losses}</span>
-            <span className="faction-detail__stat-label">{t('standings.table.losses', 'Losses')}</span>
-          </div>
-          <div className="faction-detail__stat-card">
-            <span className="faction-detail__stat-value faction-detail__stat-value--draws">{faction.draws}</span>
-            <span className="faction-detail__stat-label">{t('standings.table.draws', 'Draws')}</span>
-          </div>
-          <div className="faction-detail__stat-card">
-            <span className="faction-detail__stat-value">{faction.standings.winPercentage.toFixed(1)}%</span>
-            <span className="faction-detail__stat-label">{t('standings.table.winPercent', 'Win%')}</span>
-          </div>
-          <div className="faction-detail__stat-card">
-            <span className="faction-detail__stat-value">{totalMatches}</span>
-            <span className="faction-detail__stat-label">{t('factions.totalMatches', 'Total Matches')}</span>
-          </div>
-        </div>
-
-        {/* Form & Streak */}
-        <div className="faction-detail__form-streak">
-          <div className="faction-detail__form">
-            <span className="faction-detail__form-label">{t('standings.table.form', 'Form')}:</span>
-            {faction.standings.recentForm.length > 0 ? (
-              <span className="form-dots" aria-label={faction.standings.recentForm.join(', ')}>
-                {faction.standings.recentForm.map((result, i) => (
-                  <span
-                    key={i}
-                    className={`form-dot ${result === 'W' ? 'win' : result === 'L' ? 'loss' : 'draw'}`}
-                    title={result === 'W' ? 'Win' : result === 'L' ? 'Loss' : 'Draw'}
-                  />
-                ))}
-              </span>
-            ) : (
-              <span className="form-empty">-</span>
-            )}
-          </div>
-          <div className="faction-detail__streak">
-            <span className="faction-detail__streak-label">{t('standings.table.streak', 'Streak')}:</span>
-            {faction.standings.currentStreak.count >= 3 ? (
+      <header className="faction-detail__hero">
+        <img
+          src={resolveImageSrc(faction.imageUrl, DEFAULT_FACTION_IMAGE)}
+          onError={(event) => applyImageFallback(event, DEFAULT_FACTION_IMAGE)}
+          alt={t('factions.heroAlt', '{{name}} faction banner', { name: faction.name })}
+          loading="lazy"
+          className="faction-detail__hero-image"
+        />
+        <div className="faction-detail__hero-overlay" aria-hidden="true" />
+        <div className="faction-detail__hero-content">
+          <div className="faction-detail__hero-left">
+            <h1 className="faction-detail__hero-name">{faction.name}</h1>
+            <p className="faction-detail__hero-caption">
               <span
-                className={`streak-badge ${faction.standings.currentStreak.type === 'W' ? 'hot' : faction.standings.currentStreak.type === 'L' ? 'cold' : 'neutral'}`}
+                className={`faction-detail__hero-status faction-detail__hero-status--${faction.status}`}
+                aria-label={t('factions.statusLabel', 'Faction status: {{status}}', { status: statusLabel })}
               >
-                {faction.standings.currentStreak.count}
-                {faction.standings.currentStreak.type === 'W' ? 'W' : faction.standings.currentStreak.type === 'L' ? 'L' : 'D'}
+                {statusLabel}
               </span>
-            ) : (
-              <span className="streak-empty">-</span>
-            )}
+              <span className="faction-detail__hero-divider" aria-hidden="true">·</span>
+              <span className="faction-detail__hero-led">
+                {t('factions.hub.ledBy', 'Led by {{name}}', { name: leaderName })}
+              </span>
+            </p>
           </div>
-        </div>
-      </section>
-
-      {/* Roster */}
-      <section className="faction-detail__section">
-        <h3>{t('factions.roster', 'Roster')}</h3>
-        <div className="faction-detail__roster-grid">
-          {faction.members.map((member: StablePlayerInfo) => (
-            <Link
-              key={member.playerId}
-              to={`/stats/player/${member.playerId}`}
-              className="faction-detail__member-card"
+          <div className="faction-detail__hero-right">
+            <div className="faction-detail__hero-record">
+              <span className="faction-detail__hero-record-label">
+                {t('factions.recordLabel', 'RECORD')}
+              </span>
+              <span className="faction-detail__hero-record-value">
+                {faction.wins}-{faction.losses}-{faction.draws}
+              </span>
+            </div>
+            <div
+              className="faction-detail__hero-heat"
+              role="img"
+              aria-label={heatLabel}
             >
-              <img
-                src={resolveImageSrc(member.imageUrl, DEFAULT_WRESTLER_IMAGE)}
-                onError={(event) => applyImageFallback(event, DEFAULT_WRESTLER_IMAGE)}
-                alt={member.wrestlerName}
-                className="faction-detail__member-image"
-              />
-              <div className="faction-detail__member-info">
-                <span className="faction-detail__member-wrestler">{member.wrestlerName}</span>
-                <span className="faction-detail__member-player">
-                  {member.playerName}
-                  {member.playerId === faction.leaderId && (
-                    <span className="faction-detail__leader-badge">
-                      {t('factions.leaderBadge', 'Leader')}
-                    </span>
-                  )}
-                </span>
-                {member.psnId && (
-                  <span className="faction-detail__member-psn">PSN: {member.psnId}</span>
-                )}
-                <span className="faction-detail__member-record">
-                  <span className="wins">{member.wins}W</span>
-                  {' '}
-                  <span className="losses">{member.losses}L</span>
-                  {' '}
-                  <span className="draws">{member.draws}D</span>
-                </span>
-              </div>
-            </Link>
-          ))}
+              {Array.from({ length: HEAT_FLAME_COUNT }, (_, i) => (
+                <FlameIcon key={i} lit={i < litHeat} />
+              ))}
+            </div>
+          </div>
         </div>
-      </section>
+      </header>
 
-      {/* Match Type Breakdown */}
-      {faction.matchTypeRecords.length > 0 && (
-        <section className="faction-detail__section">
-          <h3>{t('factions.matchTypeBreakdown', 'Match Type Breakdown')}</h3>
-          <div className="faction-detail__table-wrapper">
-            <table className="faction-detail__table">
-              <thead>
-                <tr>
-                  <th>{t('factions.format', 'Format')}</th>
-                  <th>{t('standings.table.wins', 'W')}</th>
-                  <th>{t('standings.table.losses', 'L')}</th>
-                  <th>{t('standings.table.draws', 'D')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {faction.matchTypeRecords.map((record: StableMatchTypeRecord) => (
-                  <tr key={record.matchFormat}>
-                    <td className="faction-detail__format-name">{record.matchFormat}</td>
-                    <td className="wins">{record.wins}</td>
-                    <td className="losses">{record.losses}</td>
-                    <td className="draws">{record.draws}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+      <nav
+        className="faction-detail__tabs"
+        role="tablist"
+        aria-label={t('factions.detailTabs.label', 'Faction sections')}
+      >
+        {TABS.map((tab) => (
+          <NavLink
+            key={tab.value}
+            to={tab.path === '' ? `/factions/${factionId}` : `/factions/${factionId}/${tab.path}`}
+            end={tab.path === ''}
+            role="tab"
+            className={({ isActive }) =>
+              `faction-detail__tab ${isActive ? 'faction-detail__tab--active' : ''}`
+            }
+          >
+            {t(tab.i18nKey, tab.fallback)}
+          </NavLink>
+        ))}
+      </nav>
 
-      {/* Head to Head */}
-      {faction.headToHead.length > 0 && (
-        <section className="faction-detail__section">
-          <h3>{t('factions.headToHead', 'Head to Head')}</h3>
-          <div className="faction-detail__table-wrapper">
-            <table className="faction-detail__table">
-              <thead>
-                <tr>
-                  <th>{t('factions.opponent', 'Opponent')}</th>
-                  <th>{t('standings.table.wins', 'W')}</th>
-                  <th>{t('standings.table.losses', 'L')}</th>
-                  <th>{t('standings.table.draws', 'D')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {faction.headToHead.map((h2h: StableHeadToHead) => (
-                  <tr key={h2h.opponentStableId}>
-                    <td className="faction-detail__opponent-name">
-                      <Link to={`/factions/${h2h.opponentStableId}`}>
-                        {h2h.opponentStableName}
-                      </Link>
-                    </td>
-                    <td className="wins">{h2h.wins}</td>
-                    <td className="losses">{h2h.losses}</td>
-                    <td className="draws">{h2h.draws}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Recent Matches */}
-      {faction.recentMatches.length > 0 && (
-        <section className="faction-detail__section">
-          <h3>{t('factions.recentMatches', 'Recent Matches')}</h3>
-          <div className="faction-detail__recent-matches">
-            {faction.recentMatches.slice(0, 10).map((match, index) => {
-              const matchObj = match as Record<string, unknown>;
-              const matchDate = typeof matchObj['date'] === 'string'
-                ? new Date(matchObj['date']).toLocaleDateString()
-                : '';
-              const matchFormat = typeof matchObj['matchType'] === 'string'
-                ? matchObj['matchType']
-                : '';
-              const matchStatus = typeof matchObj['status'] === 'string'
-                ? matchObj['status']
-                : '';
-              const isWin = matchStatus === 'completed' && Array.isArray(matchObj['winners']);
-
-              return (
-                <div key={index} className="faction-detail__match-item">
-                  <span className="faction-detail__match-date">{matchDate}</span>
-                  <span className="faction-detail__match-format">{matchFormat}</span>
-                  <span className={`faction-detail__match-result ${isWin ? 'faction-detail__match-result--win' : 'faction-detail__match-result--loss'}`}>
-                    {matchStatus === 'completed' ? (isWin ? t('factions.win', 'W') : t('factions.loss', 'L')) : matchStatus}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      <div className="faction-detail__back">
-        <Link to="/factions" className="btn btn-secondary">
-          {t('factions.backToList', 'Back to Factions')}
-        </Link>
+      <div className="faction-detail__content">
+        <Outlet context={outletContext} />
       </div>
     </div>
   );

--- a/frontend/src/components/factions/__tests__/FactionDetail.test.tsx
+++ b/frontend/src/components/factions/__tests__/FactionDetail.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+const {
+  mockFactionsGetById,
+  mockFactionsGetPromos,
+  mockFactionsGetSchedule,
+} = vi.hoisted(() => ({
+  mockFactionsGetById: vi.fn(),
+  mockFactionsGetPromos: vi.fn(),
+  mockFactionsGetSchedule: vi.fn(),
+}));
+
+vi.mock('../../../services/api', () => ({
+  factionsApi: {
+    getById: mockFactionsGetById,
+    getPromos: mockFactionsGetPromos,
+    getSchedule: mockFactionsGetSchedule,
+  },
+}));
+
+const interpolatingT = (_key: string, fallback?: string, options?: Record<string, unknown>) => {
+  let text = fallback ?? _key;
+  if (options) {
+    for (const [name, value] of Object.entries(options)) {
+      text = text.replace(new RegExp(`{{\\s*${name}\\s*}}`, 'g'), String(value));
+    }
+  }
+  return text;
+};
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: interpolatingT }),
+}));
+
+vi.mock('../FactionDetail.css', () => ({}));
+vi.mock('../tabs/FactionOverview.css', () => ({}));
+
+import FactionDetail from '../FactionDetail';
+import FactionOverview from '../tabs/FactionOverview';
+import FactionMembers from '../tabs/FactionMembers';
+import FactionStats from '../tabs/FactionStats';
+import FactionScheduleTab from '../tabs/FactionSchedule';
+import FactionPromosTab from '../tabs/FactionPromos';
+import FactionMessages from '../tabs/FactionMessages';
+import FactionManage from '../tabs/FactionManage';
+
+const baseFaction = (overrides: Record<string, unknown> = {}) => ({
+  stableId: 'f1',
+  name: 'The Brood',
+  leaderId: 'p-leader',
+  leaderName: 'Edge',
+  memberIds: ['p-leader', 'p-2'],
+  status: 'active',
+  wins: 12,
+  losses: 4,
+  draws: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-04-01T00:00:00.000Z',
+  imageUrl: '/images/brood.png',
+  members: [
+    {
+      playerId: 'p-leader',
+      playerName: 'Edge Player',
+      wrestlerName: 'Edge',
+      wins: 6,
+      losses: 1,
+      draws: 0,
+      imageUrl: '/img/edge.png',
+    },
+    {
+      playerId: 'p-2',
+      playerName: 'Christian Player',
+      wrestlerName: 'Christian',
+      wins: 6,
+      losses: 3,
+      draws: 1,
+      imageUrl: '/img/christian.png',
+    },
+  ],
+  standings: {
+    winPercentage: 75.0,
+    recentForm: ['W', 'W', 'L', 'W', 'W'],
+    currentStreak: { type: 'W', count: 3 },
+  },
+  headToHead: [],
+  matchTypeRecords: [],
+  recentMatches: [
+    {
+      matchId: 'm1',
+      date: '2026-04-01T00:00:00.000Z',
+      matchFormat: 'singles',
+      winners: ['p-leader'],
+      losers: ['outsider'],
+      status: 'completed',
+    },
+  ],
+  ...overrides,
+});
+
+function renderShell(initialPath = '/factions/f1') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/factions/:factionId" element={<FactionDetail />}>
+          <Route index element={<FactionOverview />} />
+          <Route path="members" element={<FactionMembers />} />
+          <Route path="stats" element={<FactionStats />} />
+          <Route path="schedule" element={<FactionScheduleTab />} />
+          <Route path="promos" element={<FactionPromosTab />} />
+          <Route path="messages" element={<FactionMessages />} />
+          <Route path="manage" element={<FactionManage />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFactionsGetById.mockResolvedValue(baseFaction());
+  mockFactionsGetPromos.mockResolvedValue({ items: [] });
+  mockFactionsGetSchedule.mockResolvedValue({ items: [] });
+});
+
+describe('FactionDetail shell (FAC-11)', () => {
+  it('renders the hero with name, status, leader, record, and heat label', async () => {
+    renderShell();
+    expect(await screen.findByRole('heading', { name: 'The Brood' })).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Led by Edge')).toBeInTheDocument();
+    expect(screen.getByText('12-4-1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Heat: 3 of 5')).toBeInTheDocument();
+  });
+
+  it('renders all seven tabs with Overview active by default', async () => {
+    renderShell();
+    await screen.findByRole('heading', { name: 'The Brood' });
+    for (const label of ['Overview', 'Members', 'Stats', 'Schedule', 'Promos', 'Messages', 'Manage']) {
+      expect(screen.getByRole('tab', { name: label })).toBeInTheDocument();
+    }
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('navigates between tabs and applies the active class', async () => {
+    renderShell();
+    await screen.findByRole('heading', { name: 'The Brood' });
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Members' }));
+    await waitFor(() => {
+      expect(screen.getByText('Members tab — coming soon.')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('tab', { name: 'Members' })).toHaveAttribute('aria-current', 'page');
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Manage' }));
+    await waitFor(() => {
+      expect(screen.getByText('Manage tab — coming soon.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders an error state with a Retry button when the fetch fails', async () => {
+    mockFactionsGetById.mockRejectedValueOnce(new Error('Boom'));
+    renderShell();
+
+    expect(await screen.findByText(/Error.*Boom/)).toBeInTheDocument();
+    const retry = screen.getByRole('button', { name: 'Retry' });
+
+    // Subsequent call succeeds — Retry recovers without a page reload.
+    mockFactionsGetById.mockResolvedValueOnce(baseFaction());
+    await userEvent.click(retry);
+    expect(await screen.findByRole('heading', { name: 'The Brood' })).toBeInTheDocument();
+  });
+});
+
+describe('FactionOverview tab (FAC-11)', () => {
+  it('renders the roster row, recent results, streak, upcoming, and activity sections', async () => {
+    mockFactionsGetSchedule.mockResolvedValueOnce({
+      items: [
+        {
+          matchId: 's1',
+          scheduledFor: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+          matchFormat: 'singles',
+          eventId: null,
+          eventName: null,
+          location: null,
+          participants: [
+            { playerId: 'p-leader', playerName: 'Edge Player', isFactionMember: true },
+            { playerId: 'outsider', playerName: 'Outsider', isFactionMember: false },
+          ],
+        },
+      ],
+    });
+    mockFactionsGetPromos.mockResolvedValueOnce({
+      items: [
+        {
+          promoId: 'pr1',
+          promoType: 'call-out',
+          thumbnail: null,
+          headline: 'The Brood calls out',
+          excerpt: 'short body',
+          authorPlayerId: 'p-leader',
+          authorPlayerName: 'Edge Player',
+          authorWrestlerName: 'Edge',
+          targetPlayerId: 'outsider',
+          targetPlayerName: 'Outsider',
+          targetWrestlerName: 'Outsider Wrestler',
+          date: '2026-04-15T00:00:00.000Z',
+          viewCount: null,
+          heatImpact: null,
+          isReplyable: true,
+        },
+      ],
+    });
+
+    renderShell();
+
+    expect(await screen.findByText('Member Roster at a Glance')).toBeInTheDocument();
+    // Position label + roster wrestler names. "Edge" also appears in the hero
+    // ("Led by Edge"), so scope the assertion to the roster row's link.
+    expect(screen.getByText('LEADER')).toBeInTheDocument();
+    const rosterLeaderLink = screen.getByRole('link', { name: /LEADER\s+Edge\s+6-1-0/ });
+    expect(rosterLeaderLink).toBeInTheDocument();
+    expect(screen.getByText('Christian')).toBeInTheDocument();
+
+    expect(screen.getByText('Recent Faction Results')).toBeInTheDocument();
+    expect(screen.getByText('Promos Involving This Faction')).toBeInTheDocument();
+    expect(await screen.findByText('The Brood calls out')).toBeInTheDocument();
+
+    expect(screen.getByText('Streak')).toBeInTheDocument();
+    expect(screen.getByText('3W')).toBeInTheDocument();
+    expect(screen.getByLabelText('Last 10 results')).toBeInTheDocument();
+
+    // Upcoming card displays count
+    expect(await screen.findByText('Upcoming Matches (1)')).toBeInTheDocument();
+    expect(screen.getByText(/In .* days/)).toBeInTheDocument();
+
+    expect(screen.getByText('Faction Activity')).toBeInTheDocument();
+    expect(screen.getByText('The Brood was formed')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/factions/tabs/FactionManage.tsx
+++ b/frontend/src/components/factions/tabs/FactionManage.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+// Stub for FAC-16 — Manage tab content lands there.
+export default function FactionManage() {
+  const { t } = useTranslation();
+  return (
+    <p className="faction-detail__tab-stub">
+      {t('factions.detailTabs.stub.manage', 'Manage tab — coming soon.')}
+    </p>
+  );
+}

--- a/frontend/src/components/factions/tabs/FactionMembers.tsx
+++ b/frontend/src/components/factions/tabs/FactionMembers.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+// Stub for FAC-12 — Members tab content lands there.
+export default function FactionMembers() {
+  const { t } = useTranslation();
+  return (
+    <p className="faction-detail__tab-stub">
+      {t('factions.detailTabs.stub.members', 'Members tab — coming soon.')}
+    </p>
+  );
+}

--- a/frontend/src/components/factions/tabs/FactionMessages.tsx
+++ b/frontend/src/components/factions/tabs/FactionMessages.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+// Stub for FAC-15 — Messages tab content lands there.
+export default function FactionMessages() {
+  const { t } = useTranslation();
+  return (
+    <p className="faction-detail__tab-stub">
+      {t('factions.detailTabs.stub.messages', 'Messages tab — coming soon.')}
+    </p>
+  );
+}

--- a/frontend/src/components/factions/tabs/FactionOverview.css
+++ b/frontend/src/components/factions/tabs/FactionOverview.css
@@ -1,0 +1,338 @@
+/*
+ * Faction Detail · Overview tab content (FAC-11).
+ * Two-column split (left 8 / right 4). Tonal stacking, no borders.
+ */
+
+.faction-overview {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 32px;
+  padding: 24px 0;
+}
+
+.faction-overview__main {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  min-width: 0;
+}
+
+.faction-overview__rail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.faction-overview__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.faction-overview__section-title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.faction-overview__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+/* ─── Roster row ─── */
+
+.faction-overview__roster-scroll {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scroll-snap-type: x proximity;
+  padding-bottom: 8px;
+}
+
+.faction-overview__member {
+  flex: 0 0 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background-color: var(--color-surface);
+  text-decoration: none;
+  color: var(--color-text);
+  padding: 8px;
+  scroll-snap-align: start;
+  transition: background-color 0.15s ease;
+}
+
+.faction-overview__member:hover {
+  background-color: var(--color-surface-hover);
+}
+
+.faction-overview__member-image-wrap {
+  aspect-ratio: 4 / 5;
+  background-color: var(--color-bg);
+  overflow: hidden;
+}
+
+.faction-overview__member-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.faction-overview__member-position {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--color-primary);
+}
+
+.faction-overview__member-name {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.faction-overview__member-record {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Recent results ─── */
+
+.faction-overview__results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.faction-overview__result {
+  display: grid;
+  grid-template-columns: 100px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  background-color: var(--color-surface);
+  padding: 10px 12px;
+}
+
+.faction-overview__result-date {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.faction-overview__result-format {
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.faction-overview__result-pill {
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  font-weight: 800;
+  color: #1a1a1a;
+}
+
+.faction-overview__result-pill--w {
+  background-color: var(--color-primary);
+}
+
+.faction-overview__result-pill--l {
+  background-color: var(--color-danger-alt);
+  color: #1a1a1a;
+}
+
+.faction-overview__result-pill--d {
+  background-color: var(--color-text-muted);
+}
+
+/* ─── Promos ─── */
+
+.faction-overview__promos {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.faction-overview__promo {
+  background-color: var(--color-surface);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.faction-overview__promo-headline {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.faction-overview__promo-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+/* ─── Right rail cards ─── */
+
+.faction-overview__card {
+  background-color: var(--color-surface);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.faction-overview__card-title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+/* Streak */
+
+.faction-overview__streak {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.faction-overview__streak-value {
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: var(--color-primary);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.faction-overview__sparkline {
+  display: flex;
+  gap: 3px;
+}
+
+.faction-overview__spark {
+  width: 12px;
+  height: 12px;
+  background-color: var(--color-text-muted);
+}
+
+.faction-overview__spark--w {
+  background-color: var(--color-primary);
+}
+
+.faction-overview__spark--l {
+  background-color: var(--color-danger-alt);
+}
+
+.faction-overview__spark--d {
+  background-color: var(--color-neutral);
+}
+
+/* Upcoming */
+
+.faction-overview__upcoming {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.faction-overview__upcoming-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.faction-overview__upcoming-countdown {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  letter-spacing: 0.04em;
+}
+
+.faction-overview__upcoming-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.faction-overview__upcoming-format {
+  font-weight: 600;
+}
+
+.faction-overview__upcoming-member {
+  color: var(--color-text-muted);
+}
+
+/* Activity */
+
+.faction-overview__activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.faction-overview__activity-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.faction-overview__activity-summary {
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.faction-overview__activity-time {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 1024px) {
+  .faction-overview__promos {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .faction-overview {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .faction-overview__member {
+    flex-basis: 120px;
+  }
+}

--- a/frontend/src/components/factions/tabs/FactionOverview.tsx
+++ b/frontend/src/components/factions/tabs/FactionOverview.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useOutletContext } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { factionsApi } from '../../../services/api';
+import { logger } from '../../../utils/logger';
+import type { StableDetailResponse, StablePlayerInfo } from '../../../types/stable';
+import type {
+  FactionPromosResponse,
+  FactionScheduleResponse,
+} from '../../../types/faction';
+import {
+  DEFAULT_WRESTLER_IMAGE,
+  resolveImageSrc,
+  applyImageFallback,
+} from '../../../constants/imageFallbacks';
+import { deriveFactionActivity } from '../factionActivity';
+import './FactionOverview.css';
+
+interface FactionDetailContext {
+  faction: StableDetailResponse;
+  /** Recent form (last 5) reused from the shell so each tab doesn't refetch. */
+}
+
+const MEMBER_LIMIT = 8;
+const RESULTS_LIMIT = 4;
+const PROMOS_LIMIT = 3;
+const SCHEDULE_LIMIT = 3;
+
+type FormResult = 'W' | 'L' | 'D';
+
+function classifyResult(match: Record<string, unknown>, memberIds: Set<string>): FormResult | null {
+  const isDraw = match['isDraw'] === true;
+  if (isDraw) return 'D';
+  const winners = Array.isArray(match['winners']) ? (match['winners'] as string[]) : [];
+  const losers = Array.isArray(match['losers']) ? (match['losers'] as string[]) : [];
+  if (winners.some((id) => memberIds.has(id))) return 'W';
+  if (losers.some((id) => memberIds.has(id))) return 'L';
+  return null;
+}
+
+function memberPosition(
+  member: StablePlayerInfo,
+  leaderId: string,
+  totalMatches: number,
+): string {
+  if (member.playerId === leaderId) return 'LEADER';
+  if (totalMatches >= 10) return 'VETERAN';
+  return 'ROOKIE';
+}
+
+function formatCountdown(scheduledFor: string, now: number): string {
+  const ms = new Date(scheduledFor).getTime() - now;
+  if (!Number.isFinite(ms)) return '';
+  const minutes = Math.round(ms / 60_000);
+  if (Math.abs(minutes) < 60) return minutes >= 0 ? `In ${minutes}m` : `${-minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) return hours >= 0 ? `In ${hours}h` : `${-hours}h ago`;
+  const days = Math.round(hours / 24);
+  return days >= 0 ? `In ${days} days` : `${-days} days ago`;
+}
+
+export default function FactionOverview() {
+  const { t } = useTranslation();
+  const { faction } = useOutletContext<FactionDetailContext>();
+
+  const [promos, setPromos] = useState<FactionPromosResponse | null>(null);
+  const [schedule, setSchedule] = useState<FactionScheduleResponse | null>(null);
+  const [promosError, setPromosError] = useState(false);
+  const [scheduleError, setScheduleError] = useState(false);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    const load = async () => {
+      try {
+        const [promosRes, scheduleRes] = await Promise.all([
+          factionsApi
+            .getPromos(faction.stableId, { filter: 'all', limit: PROMOS_LIMIT }, ac.signal)
+            .catch((e) => {
+              if (e instanceof Error && e.name !== 'AbortError') {
+                logger.error('Faction overview: getPromos failed');
+                setPromosError(true);
+              }
+              return null;
+            }),
+          factionsApi
+            .getSchedule(faction.stableId, { limit: SCHEDULE_LIMIT }, ac.signal)
+            .catch((e) => {
+              if (e instanceof Error && e.name !== 'AbortError') {
+                logger.error('Faction overview: getSchedule failed');
+                setScheduleError(true);
+              }
+              return null;
+            }),
+        ]);
+        if (!ac.signal.aborted) {
+          if (promosRes) setPromos(promosRes);
+          if (scheduleRes) setSchedule(scheduleRes);
+        }
+      } catch {
+        // Per-call catches above handle individual failures.
+      }
+    };
+    load();
+    return () => ac.abort();
+  }, [faction.stableId]);
+
+  const memberIdSet = useMemo(() => new Set(faction.memberIds), [faction.memberIds]);
+
+  const recentResults = useMemo(() => {
+    const raw = (faction.recentMatches || []) as Array<Record<string, unknown>>;
+    return raw
+      .filter((m) => typeof m['matchId'] === 'string' && (m['status'] === 'completed' || m['status'] === undefined))
+      .slice(0, RESULTS_LIMIT)
+      .map((m, i) => ({
+        key: typeof m['matchId'] === 'string' ? (m['matchId'] as string) : `idx-${i}`,
+        date: typeof m['date'] === 'string' ? (m['date'] as string) : '',
+        format: typeof m['matchFormat'] === 'string'
+          ? (m['matchFormat'] as string)
+          : typeof m['matchType'] === 'string'
+            ? (m['matchType'] as string)
+            : 'unknown',
+        outcome: classifyResult(m, memberIdSet),
+      }));
+  }, [faction.recentMatches, memberIdSet]);
+
+  const activity = useMemo(
+    () =>
+      deriveFactionActivity(
+        [
+          {
+            stableId: faction.stableId,
+            name: faction.name,
+            leaderId: faction.leaderId,
+            memberIds: faction.memberIds,
+            status: faction.status,
+            wins: faction.wins,
+            losses: faction.losses,
+            draws: faction.draws,
+            imageUrl: faction.imageUrl,
+            createdAt: faction.createdAt,
+            updatedAt: faction.updatedAt,
+            disbandedAt: faction.disbandedAt,
+          },
+        ],
+        new Map(),
+        5,
+      ),
+    [faction],
+  );
+
+  const streak = faction.standings.currentStreak;
+  const sparkline: FormResult[] = (faction.standings.recentForm || []).slice(0, 10) as FormResult[];
+
+  const now = Date.now();
+
+  return (
+    <div className="faction-overview">
+      <div className="faction-overview__main">
+        {/* Member roster ─ at a glance */}
+        <section className="faction-overview__section">
+          <h2 className="faction-overview__section-title">
+            {t('factions.overview.rosterHeading', 'Member Roster at a Glance')}
+          </h2>
+          <div className="faction-overview__roster-scroll">
+            {faction.members.slice(0, MEMBER_LIMIT).map((member) => {
+              const totalMatches = member.wins + member.losses + member.draws;
+              const position = memberPosition(member, faction.leaderId, totalMatches);
+              return (
+                <Link
+                  key={member.playerId}
+                  to={`/player/${member.playerId}`}
+                  className="faction-overview__member"
+                >
+                  <div className="faction-overview__member-image-wrap">
+                    <img
+                      src={resolveImageSrc(member.imageUrl, DEFAULT_WRESTLER_IMAGE)}
+                      onError={(e) => applyImageFallback(e, DEFAULT_WRESTLER_IMAGE)}
+                      alt=""
+                      className="faction-overview__member-image"
+                    />
+                  </div>
+                  <span className="faction-overview__member-position">{position}</span>
+                  <span className="faction-overview__member-name">{member.wrestlerName}</span>
+                  <span className="faction-overview__member-record">
+                    {member.wins}-{member.losses}-{member.draws}
+                  </span>
+                </Link>
+              );
+            })}
+            {faction.members.length === 0 && (
+              <p className="faction-overview__empty">
+                {t('factions.overview.rosterEmpty', 'No members yet.')}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Recent results */}
+        <section className="faction-overview__section">
+          <h2 className="faction-overview__section-title">
+            {t('factions.overview.resultsHeading', 'Recent Faction Results')}
+          </h2>
+          {recentResults.length === 0 ? (
+            <p className="faction-overview__empty">
+              {t('factions.overview.resultsEmpty', 'No recent results.')}
+            </p>
+          ) : (
+            <ul className="faction-overview__results">
+              {recentResults.map((m) => (
+                <li key={m.key} className="faction-overview__result">
+                  <span className="faction-overview__result-date">
+                    {m.date ? new Date(m.date).toLocaleDateString() : '—'}
+                  </span>
+                  <span className="faction-overview__result-format">{m.format}</span>
+                  {m.outcome && (
+                    <span
+                      className={`faction-overview__result-pill faction-overview__result-pill--${m.outcome.toLowerCase()}`}
+                    >
+                      {m.outcome}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Promos mini-feed */}
+        <section className="faction-overview__section">
+          <h2 className="faction-overview__section-title">
+            {t('factions.overview.promosHeading', 'Promos Involving This Faction')}
+          </h2>
+          {promosError ? (
+            <p className="faction-overview__empty">
+              {t('factions.overview.promosError', 'Could not load promos.')}
+            </p>
+          ) : !promos ? (
+            <p className="faction-overview__empty">
+              {t('common.loading', 'Loading…')}
+            </p>
+          ) : promos.items.length === 0 ? (
+            <p className="faction-overview__empty">
+              {t('factions.overview.promosEmpty', 'No promos involving this faction yet.')}
+            </p>
+          ) : (
+            <ul className="faction-overview__promos">
+              {promos.items.map((promo) => (
+                <li key={promo.promoId} className="faction-overview__promo">
+                  <div className="faction-overview__promo-headline">
+                    {promo.headline ?? promo.excerpt}
+                  </div>
+                  <div className="faction-overview__promo-meta">
+                    <span>{promo.authorWrestlerName}</span>
+                    <time dateTime={promo.date}>
+                      {new Date(promo.date).toLocaleDateString()}
+                    </time>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      {/* Right rail */}
+      <aside className="faction-overview__rail">
+        <section className="faction-overview__card">
+          <h3 className="faction-overview__card-title">
+            {t('factions.overview.streakTitle', 'Streak')}
+          </h3>
+          <div className="faction-overview__streak">
+            <span className="faction-overview__streak-value">
+              {streak.count > 0 ? `${streak.count}${streak.type}` : '—'}
+            </span>
+          </div>
+          {sparkline.length > 0 && (
+            <div
+              className="faction-overview__sparkline"
+              aria-label={t('factions.overview.sparklineLabel', 'Last 10 results')}
+            >
+              {sparkline.map((r, i) => (
+                <span
+                  key={i}
+                  className={`faction-overview__spark faction-overview__spark--${r.toLowerCase()}`}
+                  aria-hidden="true"
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="faction-overview__card">
+          <h3 className="faction-overview__card-title">
+            {t('factions.overview.upcomingTitle', 'Upcoming Matches ({{count}})', {
+              count: schedule?.items.length ?? 0,
+            })}
+          </h3>
+          {scheduleError ? (
+            <p className="faction-overview__empty">
+              {t('factions.overview.scheduleError', 'Could not load schedule.')}
+            </p>
+          ) : !schedule ? (
+            <p className="faction-overview__empty">
+              {t('common.loading', 'Loading…')}
+            </p>
+          ) : schedule.items.length === 0 ? (
+            <p className="faction-overview__empty">
+              {t('factions.overview.scheduleEmpty', 'No matches scheduled in the next 60 days.')}
+            </p>
+          ) : (
+            <ul className="faction-overview__upcoming">
+              {schedule.items.map((m) => {
+                const memberCompeting = m.participants.find((p) => p.isFactionMember);
+                return (
+                  <li key={m.matchId} className="faction-overview__upcoming-row">
+                    <span className="faction-overview__upcoming-countdown">
+                      {formatCountdown(m.scheduledFor, now)}
+                    </span>
+                    <div className="faction-overview__upcoming-meta">
+                      <span className="faction-overview__upcoming-format">{m.matchFormat}</span>
+                      {memberCompeting && (
+                        <span className="faction-overview__upcoming-member">
+                          {memberCompeting.playerName}
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
+        <section className="faction-overview__card">
+          <h3 className="faction-overview__card-title">
+            {t('factions.overview.activityTitle', 'Faction Activity')}
+          </h3>
+          {activity.length === 0 ? (
+            <p className="faction-overview__empty">
+              {t('factions.overview.activityEmpty', 'No recent activity.')}
+            </p>
+          ) : (
+            <ul className="faction-overview__activity">
+              {activity.map((entry) => (
+                <li key={entry.id} className="faction-overview__activity-item">
+                  <span className="faction-overview__activity-summary">{entry.summary}</span>
+                  <time
+                    className="faction-overview__activity-time"
+                    dateTime={entry.timestamp}
+                  >
+                    {new Date(entry.timestamp).toLocaleDateString()}
+                  </time>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/factions/tabs/FactionPromos.tsx
+++ b/frontend/src/components/factions/tabs/FactionPromos.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+// Stub for FAC-14 — Promos tab content lands there.
+export default function FactionPromos() {
+  const { t } = useTranslation();
+  return (
+    <p className="faction-detail__tab-stub">
+      {t('factions.detailTabs.stub.promos', 'Promos tab — coming soon.')}
+    </p>
+  );
+}

--- a/frontend/src/components/factions/tabs/FactionSchedule.tsx
+++ b/frontend/src/components/factions/tabs/FactionSchedule.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+// Stub for FAC-14 — Schedule tab content lands there.
+export default function FactionSchedule() {
+  const { t } = useTranslation();
+  return (
+    <p className="faction-detail__tab-stub">
+      {t('factions.detailTabs.stub.schedule', 'Schedule tab — coming soon.')}
+    </p>
+  );
+}

--- a/frontend/src/components/factions/tabs/FactionStats.tsx
+++ b/frontend/src/components/factions/tabs/FactionStats.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
+// Stub for FAC-13 — Stats tab content lands there.
+export default function FactionStats() {
+  const { t } = useTranslation();
+  return (
+    <p className="faction-detail__tab-stub">
+      {t('factions.detailTabs.stub.stats', 'Stats tab — coming soon.')}
+    </p>
+  );
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1357,6 +1357,43 @@
       "activityTitle": "Neueste Faktionsaktivität",
       "activityEmpty": "Noch keine Aktivität."
     },
+    "heroAlt": "{{name}}-Faktionsbanner",
+    "statusLabel": "Faktionsstatus: {{status}}",
+    "recordLabel": "BILANZ",
+    "detailTabs": {
+      "label": "Faktionsbereiche",
+      "overview": "Übersicht",
+      "members": "Mitglieder",
+      "stats": "Statistik",
+      "schedule": "Spielplan",
+      "promos": "Promos",
+      "messages": "Nachrichten",
+      "manage": "Verwalten",
+      "stub": {
+        "members": "Mitglieder-Tab — folgt in Kürze.",
+        "stats": "Statistik-Tab — folgt in Kürze.",
+        "schedule": "Spielplan-Tab — folgt in Kürze.",
+        "promos": "Promos-Tab — folgt in Kürze.",
+        "messages": "Nachrichten-Tab — folgt in Kürze.",
+        "manage": "Verwalten-Tab — folgt in Kürze."
+      }
+    },
+    "overview": {
+      "rosterHeading": "Kader auf einen Blick",
+      "rosterEmpty": "Noch keine Mitglieder.",
+      "resultsHeading": "Letzte Faktionsergebnisse",
+      "resultsEmpty": "Keine aktuellen Ergebnisse.",
+      "promosHeading": "Promos zu dieser Faktion",
+      "promosEmpty": "Noch keine Promos zu dieser Faktion.",
+      "promosError": "Promos konnten nicht geladen werden.",
+      "streakTitle": "Serie",
+      "sparklineLabel": "Letzte 10 Ergebnisse",
+      "upcomingTitle": "Anstehende Matches ({{count}})",
+      "scheduleEmpty": "Keine Matches in den nächsten 60 Tagen.",
+      "scheduleError": "Spielplan konnte nicht geladen werden.",
+      "activityTitle": "Faktionsaktivität",
+      "activityEmpty": "Keine aktuellen Ereignisse."
+    },
     "members": "Mitglieder",
     "stats": "Statistiken",
     "headToHead": "Kopf an Kopf",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1358,6 +1358,43 @@
       "activityTitle": "Recent Faction Activity",
       "activityEmpty": "No recent activity yet."
     },
+    "heroAlt": "{{name}} faction banner",
+    "statusLabel": "Faction status: {{status}}",
+    "recordLabel": "RECORD",
+    "detailTabs": {
+      "label": "Faction sections",
+      "overview": "Overview",
+      "members": "Members",
+      "stats": "Stats",
+      "schedule": "Schedule",
+      "promos": "Promos",
+      "messages": "Messages",
+      "manage": "Manage",
+      "stub": {
+        "members": "Members tab — coming soon.",
+        "stats": "Stats tab — coming soon.",
+        "schedule": "Schedule tab — coming soon.",
+        "promos": "Promos tab — coming soon.",
+        "messages": "Messages tab — coming soon.",
+        "manage": "Manage tab — coming soon."
+      }
+    },
+    "overview": {
+      "rosterHeading": "Member Roster at a Glance",
+      "rosterEmpty": "No members yet.",
+      "resultsHeading": "Recent Faction Results",
+      "resultsEmpty": "No recent results.",
+      "promosHeading": "Promos Involving This Faction",
+      "promosEmpty": "No promos involving this faction yet.",
+      "promosError": "Could not load promos.",
+      "streakTitle": "Streak",
+      "sparklineLabel": "Last 10 results",
+      "upcomingTitle": "Upcoming Matches ({{count}})",
+      "scheduleEmpty": "No matches scheduled in the next 60 days.",
+      "scheduleError": "Could not load schedule.",
+      "activityTitle": "Faction Activity",
+      "activityEmpty": "No recent activity."
+    },
     "members": "Members",
     "stats": "Stats",
     "headToHead": "Head to Head",


### PR DESCRIPTION
## Summary
Replaces the flat [FactionDetail](frontend/src/components/factions/FactionDetail.tsx) with a tab-routed shell and lands the first tab (Overview).

### Shell
- Full-width hero strip: lazy-loaded image with a bottom-fade overlay, display-size faction name, status pill + "Led by …" caption, RECORD label with W-L-D in display gold, and a 5-flame heat gauge (lit count clamped from `currentStreak.count`).
- Seven-tab strip below the hero (Overview / Members / Stats / Schedule / Promos / Messages / Manage) rendered as `NavLink`s with the active tab in gold and a 4px underline. Tabs use `role="tab"` inside `role="tablist"`.
- The shell loads `factionsApi.getById` only — each tab fetches its own slice when activated. Error state has a Retry button that re-runs the fetch in place (no page reload).
- Hero exposes the faction to children via `<Outlet context={{ faction }} />` so child tabs read identity/standings without re-fetching.

### Overview tab ([tabs/FactionOverview.tsx](frontend/src/components/factions/tabs/FactionOverview.tsx))
- **Left col**: member roster horizontal-scroll (4:5 portrait, position label LEADER/VETERAN/ROOKIE, W-L-D); recent results list (top 4 from the existing `recentMatches` field); promos mini-feed (3 cards via `factionsApi.getPromos`).
- **Right col**: streak card with the value in display gold and a last-10 sparkline; upcoming-matches card (3 rows via `factionsApi.getSchedule`) with countdown labels; faction activity card sourced from the same `deriveFactionActivity` helper FAC-10 uses, scoped to this faction.

### Tab stubs
[tabs/FactionMembers / Stats / Schedule / Promos / Messages / Manage](frontend/src/components/factions/tabs/) render a minimal "Coming soon" placeholder. FAC-12..FAC-16 fill in each body without changing routing or imports.

### Routing
Nested routes wired in [App.tsx](frontend/src/App.tsx): `/factions/:factionId` is the parent with seven nested children (index = Overview, plus `members` / `stats` / `schedule` / `promos` / `messages` / `manage`).

### i18n
English and German keys added under `factions.detailTabs.*` and `factions.overview.*`. Hero status pill uses a proper-cased fallback table so the visible label is "Active" / "Pending" / "Disbanded" regardless of locale (same pattern used for the FAC-10 chip).

## Ticket
[FAC-11] Faction Detail shell + Overview tab (Phase 4, blocked by FAC-09, blocks FAC-12..FAC-15, FAC-20).

Scope respected:
- Six other tabs are stubs only — they render without errors and own their own future content.
- No per-tab fetches happen on shell mount. The Overview tab fires getPromos + getSchedule on activation, not the shell.
- Hero image is lazy-loaded (`loading="lazy"`); the `DEFAULT_FACTION_IMAGE` placeholder added in FAC-10 is reused.

## Test plan
- [x] `npx tsc --project tsconfig.app.json --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 479/479 pass (5 new)
- [ ] Manual at desktop + 375px: hero collapses to a single column, tabs become horizontally scrollable, each tab navigates without error, retry recovers a transient API failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)