### PR TITLE
fix(factions): make promo cards readable + clickable on detail page

### DIFF
--- a/frontend/src/components/factions/tabs/FactionOverview.css
+++ b/frontend/src/components/factions/tabs/FactionOverview.css
@@ -170,11 +170,26 @@
 
 .faction-overview__promo {
   background-color: var(--color-surface);
-  padding: 12px;
+  min-width: 0;
+  transition: background-color 0.15s ease;
+}
+
+.faction-overview__promo:hover {
+  background-color: var(--color-surface-hover);
+}
+
+.faction-overview__promo-link {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-width: 0;
+  padding: 12px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.faction-overview__promo-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 .faction-overview__promo-headline {

--- a/frontend/src/components/factions/tabs/FactionOverview.tsx
+++ b/frontend/src/components/factions/tabs/FactionOverview.tsx
@@ -246,15 +246,20 @@ export default function FactionOverview() {
             <ul className="faction-overview__promos">
               {promos.items.map((promo) => (
                 <li key={promo.promoId} className="faction-overview__promo">
-                  <div className="faction-overview__promo-headline">
-                    {promo.headline ?? promo.excerpt}
-                  </div>
-                  <div className="faction-overview__promo-meta">
-                    <span>{promo.authorWrestlerName}</span>
-                    <time dateTime={promo.date}>
-                      {new Date(promo.date).toLocaleDateString()}
-                    </time>
-                  </div>
+                  <Link
+                    to={`/promos/${promo.promoId}`}
+                    className="faction-overview__promo-link"
+                  >
+                    <div className="faction-overview__promo-headline">
+                      {promo.headline ?? promo.excerpt}
+                    </div>
+                    <div className="faction-overview__promo-meta">
+                      <span>{promo.authorWrestlerName}</span>
+                      <time dateTime={promo.date}>
+                        {new Date(promo.date).toLocaleDateString()}
+                      </time>
+                    </div>
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/factions/tabs/FactionPromos.css
+++ b/frontend/src/components/factions/tabs/FactionPromos.css
@@ -84,69 +84,52 @@
   background-color: var(--color-surface);
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  transition: background-color 0.15s ease;
 }
 
-.faction-promos__thumb-link {
-  display: block;
-  position: relative;
-  background-color: var(--color-bg);
+.faction-promos__card:hover {
+  background-color: var(--color-surface-hover);
 }
 
-.faction-promos__thumb {
-  position: relative;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-}
-
-.faction-promos__thumb-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.faction-promos__thumb-placeholder {
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(135deg, #1a1a1a, #0f0f0f),
-    repeating-linear-gradient(45deg, transparent 0 8px, rgba(212, 175, 55, 0.04) 8px 16px);
-  background-blend-mode: overlay;
-}
-
-.faction-promos__play-overlay {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-primary);
-  font-size: 2.5rem;
-  opacity: 0.85;
-  pointer-events: none;
-}
-
-.faction-promos__body {
-  padding: 14px 16px;
+.faction-promos__card-link {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.faction-promos__headline-link {
+  gap: 8px;
+  padding: 16px 18px;
   text-decoration: none;
   color: inherit;
 }
 
+.faction-promos__card-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
 .faction-promos__headline {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1.15rem;
   font-weight: 800;
   color: var(--color-text);
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  letter-spacing: -0.005em;
+  line-height: 1.25;
+}
+
+.faction-promos__body-text {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.faction-promos__inline-image {
+  max-width: 220px;
+  max-height: 140px;
+  object-fit: cover;
+  background-color: var(--color-bg);
+  align-self: flex-start;
 }
 
 .faction-promos__byline {
@@ -197,7 +180,9 @@
 
 .faction-promos__reply {
   align-self: flex-start;
-  margin-top: 4px;
+  /* Sits as a sibling of the card-link now, so it provides its own
+   * outer spacing instead of inheriting the link's padding. */
+  margin: 0 18px 16px;
   padding: 6px 12px;
   background-color: var(--color-primary);
   color: #1a1a1a;

--- a/frontend/src/components/factions/tabs/FactionPromos.tsx
+++ b/frontend/src/components/factions/tabs/FactionPromos.tsx
@@ -194,28 +194,32 @@ export default function FactionPromos() {
                 </span>
               ) : null;
 
+            // Headline falls back to the first ~60 chars of the body
+            // when no title was set, so the card always leads with text.
+            const headline = promo.headline ?? promo.excerpt.slice(0, 60);
+            // Show the body only if we have additional content beyond the
+            // headline (i.e. the headline isn't already the same text).
+            const bodyText = promo.headline && promo.excerpt ? promo.excerpt : '';
+
             return (
               <article key={promo.promoId} className="faction-promos__card">
-                <Link to={`/promos/${promo.promoId}`} className="faction-promos__thumb-link">
-                  <div className="faction-promos__thumb">
-                    {promo.thumbnail ? (
-                      <img src={promo.thumbnail} alt="" className="faction-promos__thumb-image" />
-                    ) : (
-                      <span className="faction-promos__thumb-placeholder" aria-hidden="true" />
-                    )}
-                    <span className="faction-promos__play-overlay" aria-hidden="true">▶</span>
-                  </div>
-                </Link>
-                <div className="faction-promos__body">
-                  <Link
-                    to={`/promos/${promo.promoId}`}
-                    className="faction-promos__headline-link"
-                  >
-                    <h3 className="faction-promos__headline">
-                      {promo.headline ?? promo.excerpt}
-                    </h3>
-                  </Link>
+                <Link
+                  to={`/promos/${promo.promoId}`}
+                  className="faction-promos__card-link"
+                >
                   <p className="faction-promos__byline">{byline}</p>
+                  <h3 className="faction-promos__headline">{headline}</h3>
+                  {bodyText && (
+                    <p className="faction-promos__body-text">{bodyText}</p>
+                  )}
+                  {promo.thumbnail && (
+                    <img
+                      src={promo.thumbnail}
+                      alt=""
+                      className="faction-promos__inline-image"
+                      loading="lazy"
+                    />
+                  )}
                   <div className="faction-promos__meta">
                     <time dateTime={promo.date}>
                       {new Date(promo.date).toLocaleDateString()}
@@ -232,15 +236,15 @@ export default function FactionPromos() {
                     )}
                     {heatPill}
                   </div>
-                  {filter === 'directed-at-faction' && (
-                    <Link
-                      to={`/promos/new?targetPlayerId=${promo.authorPlayerId}&promoType=response&targetPromoId=${promo.promoId}`}
-                      className="faction-promos__reply"
-                    >
-                      {t('factions.promos.replyCta', 'Reply with a promo')}
-                    </Link>
-                  )}
-                </div>
+                </Link>
+                {filter === 'directed-at-faction' && (
+                  <Link
+                    to={`/promos/new?targetPlayerId=${promo.authorPlayerId}&promoType=response&targetPromoId=${promo.promoId}`}
+                    className="faction-promos__reply"
+                  >
+                    {t('factions.promos.replyCta', 'Reply with a promo')}
+                  </Link>
+                )}
               </article>
             );
           })}


### PR DESCRIPTION
## Summary
Two related dev-feedback fixes after the first devtest pass on the redesigned Faction Detail page.

### 1. Overview tab — "Promos involving this faction" cards are now clickable
Each mini-feed entry wraps in a `Link` to `/promos/{promoId}`. Hover state + focus-visible outline added so the affordance is obvious.

### 2. Promos tab — drop the play-icon thumbnail, show the promo content directly
The cards previously led with a giant 16:9 thumbnail and a play-icon overlay, which suggested "video to play" for what's mostly a text feed. New card layout:

- Byline first (small gold uppercase)
- Headline (display weight)
- Body excerpt (server-truncated to 200 chars, rendered with `white-space: pre-wrap` so line breaks survive)
- Inline thumbnail (when set) as a small inset image — not the hero
- Meta row (date / views / heat pill)

The whole card content is a single `Link` to the full promo for the click-through path. The directed-at-faction Reply CTA stays a sibling element so we don't nest anchors.

### Out of scope
No backend changes — both tabs already had the data they needed. The body text is whatever `excerpt` (200-char cap) the FAC-08 handler returns. If users want the full body inline, that's a separate backend change to either lift the cap or add a per-promo content fetch.

## Test plan
- [x] `npx tsc --project tsconfig.app.json --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 516/516 (no test churn; existing role/text-based selectors still find the new card structure)
- [ ] Manual against devtest: Overview promo cards navigate on click; Promos tab cards show the body excerpt prominently, reply CTA still works on the directed-at filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)