### PR TITLE
fix(factions): FAC-21 contrast + DM avatars · FAC-22 hero record + banner-name overlap

### DIFF
--- a/backend/functions/stables/__tests__/getMyDirectMessageThreads.test.ts
+++ b/backend/functions/stables/__tests__/getMyDirectMessageThreads.test.ts
@@ -138,6 +138,35 @@ describe('getMyDirectMessageThreads (FAC-06)', () => {
     expect(rowThird.lastMessage.body).toBe('LT-2-1');
   });
 
+  // FAC-21: each thread row must carry the partner's imageUrl (or null when
+  // they don't have one) so the frontend can render the actual profile pic
+  // instead of the default placeholder on every row.
+  it('hydrates partnerImageUrl from the partner player record', async () => {
+    const { leader, member, third, stable } = await seed();
+    await repos.roster.players.update(member.playerId, {
+      imageUrl: 'https://example.com/member-portrait.jpg',
+    });
+    // `third` is intentionally left without an imageUrl so we exercise the null branch.
+
+    await postN(stable.stableId, leader.playerId, member.playerId, 1, 'L1');
+    await postN(stable.stableId, leader.playerId, third.playerId, 1, 'L2');
+
+    const result = await getMyThreads(
+      makeEvent(stable.stableId, LEADER_SUB),
+      ctx,
+      cb,
+    );
+    expect(result!.statusCode).toBe(200);
+    const body = JSON.parse(result!.body);
+    const byPartner = new Map<string, (typeof body.items)[number]>(
+      body.items.map((r: { partnerPlayerId: string }) => [r.partnerPlayerId, r]),
+    );
+    expect(byPartner.get(member.playerId)!.partnerImageUrl).toBe(
+      'https://example.com/member-portrait.jpg',
+    );
+    expect(byPartner.get(third.playerId)!.partnerImageUrl).toBeNull();
+  });
+
   it('returns 403 to a non-member of the faction', async () => {
     const { leader, member, stable } = await seed();
     await postN(stable.stableId, leader.playerId, member.playerId, 1);

--- a/backend/functions/stables/getMyDirectMessageThreads.ts
+++ b/backend/functions/stables/getMyDirectMessageThreads.ts
@@ -8,6 +8,7 @@ interface ThreadRow {
   partnerPlayerId: string;
   partnerPlayerName: string | null;
   partnerWrestlerName: string | null;
+  partnerImageUrl: string | null;
   lastMessage: FactionDirectMessage;
   lastMessageAt: string;
 }
@@ -55,6 +56,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           partnerPlayerId: s.partnerPlayerId,
           partnerPlayerName: partner?.name ?? null,
           partnerWrestlerName: partner?.currentWrestler ?? null,
+          partnerImageUrl: partner?.imageUrl ?? null,
           lastMessage: s.lastMessage,
           lastMessageAt: s.lastMessage.createdAt,
         };

--- a/backend/functions/stables/getStable.ts
+++ b/backend/functions/stables/getStable.ts
@@ -139,6 +139,12 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     return success({
       ...stable,
+      // FAC-22: override the (possibly stale or uninitialized) raw counters
+      // with the values we just derived from completed-match outcomes so the
+      // Detail hero matches Standings, which also computes from matches.
+      wins: computedWins,
+      losses: computedLosses,
+      draws: computedDraws,
       members,
       leaderName,
       headToHead,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -35,7 +35,7 @@ h2 {
 
 .btn-primary {
   background-color: var(--color-primary);
-  color: #000;
+  color: var(--color-on-primary);
 }
 
 .btn-primary:hover {
@@ -75,7 +75,7 @@ h2 {
 /* Exclude nav/sidebar/topnav/language/hamburger so their own styles (e.g. gold text on dark) apply */
 button:not([class*="btn-"]):not(.sidebar-collapse-toggle):not(.nav-section-toggle):not(.nav-subgroup-toggle):not(.user-nav-toggle):not(.topnav-menu-btn):not(.topnav-logout):not(.topnav-layout-btn):not(.top-bar-layout-toggle):not(.hamburger-btn):not(.language-switcher-btn):not(.promo-type-option):not(.preview-toggle):not(.cancel-btn):not(.filter-tab):not(.factions-toggle-btn):not(.tag-teams-list__toggle-btn):not(.tag-team-mode-btn):not(.remove-team-btn):not(.remove-member-btn):not(.add-team-btn):not(.delete-match-btn):not(.notification-bell-btn):not(.notification-mark-all-btn):not(.notification-item-content):not(.notification-delete-btn):not(.promo-read-more) {
   background-color: var(--color-primary);
-  color: #000;
+  color: var(--color-on-primary);
   border: none;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -275,7 +275,7 @@
   margin: 0.75rem 1rem;
   padding: 0.5rem 1rem !important;
   background-color: var(--color-primary) !important;
-  color: #000 !important;
+  color: var(--color-on-primary) !important;
   border: none;
   border-radius: 4px;
   font-size: 0.875rem;

--- a/frontend/src/components/factions/FactionDetail.css
+++ b/frontend/src/components/factions/FactionDetail.css
@@ -24,6 +24,20 @@
   isolation: isolate;
 }
 
+/* FAC-22: when the faction has a custom banner we drop the overlay name <h1>,
+   so the hero strip doesn't need to reserve vertical space for it. Keep the
+   16:9-ish aspect ratio of the banner art and let the caption sit flush at
+   the bottom. */
+.faction-detail__hero--banner {
+  aspect-ratio: 16 / 9;
+}
+
+.faction-detail__hero--banner .faction-detail__hero-caption {
+  /* No <h1> above the caption in banner mode — remove the 12px gap that
+     was budgeted for the headline-to-caption space. */
+  margin-top: 0;
+}
+
 .faction-detail__hero-image {
   width: 100%;
   height: 100%;

--- a/frontend/src/components/factions/FactionDetail.tsx
+++ b/frontend/src/components/factions/FactionDetail.tsx
@@ -157,9 +157,19 @@ export default function FactionDetail() {
 
   const outletContext: FactionDetailContext = { faction };
 
+  // FAC-22: when a faction has a custom banner the banner art usually already
+  // carries the brand (logo / name baked into the image), so we drop the
+  // overlay <h1> to avoid the name reading twice. The fallback gradient
+  // placeholder has no text, so we still need the text header in that case.
+  const hasCustomBanner = Boolean(faction.imageUrl);
+
   return (
     <div className="faction-detail">
-      <header className="faction-detail__hero">
+      <header
+        className={`faction-detail__hero ${
+          hasCustomBanner ? 'faction-detail__hero--banner' : ''
+        }`}
+      >
         <img
           src={resolveImageSrc(faction.imageUrl, DEFAULT_FACTION_IMAGE)}
           onError={(event) => applyImageFallback(event, DEFAULT_FACTION_IMAGE)}
@@ -170,7 +180,9 @@ export default function FactionDetail() {
         <div className="faction-detail__hero-overlay" aria-hidden="true" />
         <div className="faction-detail__hero-content">
           <div className="faction-detail__hero-left">
-            <h1 className="faction-detail__hero-name">{faction.name}</h1>
+            {!hasCustomBanner && (
+              <h1 className="faction-detail__hero-name">{faction.name}</h1>
+            )}
             <p className="faction-detail__hero-caption">
               <span
                 className={`faction-detail__hero-status faction-detail__hero-status--${faction.status}`}

--- a/frontend/src/components/factions/FactionDetail.tsx
+++ b/frontend/src/components/factions/FactionDetail.tsx
@@ -29,6 +29,18 @@ function clampHeat(count: number | undefined): number {
   return Math.min(HEAT_FLAME_COUNT, Math.floor(count));
 }
 
+// FAC-22: defensive against legacy / mis-typed records where wins/losses/draws
+// could be undefined or negative. The backend now computes these from match
+// outcomes, but this guard keeps "-1-1-0"-style renders out of the UI regardless.
+function safeCount(n: number | null | undefined): number {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function formatRecord(wins: number | null | undefined, losses: number | null | undefined, draws: number | null | undefined): string {
+  return `${safeCount(wins)}-${safeCount(losses)}-${safeCount(draws)}`;
+}
+
 function FlameIcon({ lit }: { lit: boolean }) {
   return (
     <svg
@@ -178,7 +190,7 @@ export default function FactionDetail() {
                 {t('factions.recordLabel', 'RECORD')}
               </span>
               <span className="faction-detail__hero-record-value">
-                {faction.wins}-{faction.losses}-{faction.draws}
+                {formatRecord(faction.wins, faction.losses, faction.draws)}
               </span>
             </div>
             <div

--- a/frontend/src/components/factions/__tests__/FactionDetail.test.tsx
+++ b/frontend/src/components/factions/__tests__/FactionDetail.test.tsx
@@ -146,17 +146,21 @@ beforeEach(() => {
 
 describe('FactionDetail shell (FAC-11)', () => {
   it('renders the hero with name, status, leader, record, and heat label', async () => {
+    // FAC-22: when a custom imageUrl is set, the <h1> is intentionally
+    // suppressed (banner art carries the brand). Wait on the record value
+    // as the "got past loading" signal instead. Also verify the banner
+    // image alt still announces the faction name for screen readers.
     renderShell();
-    expect(await screen.findByRole('heading', { name: 'The Brood' })).toBeInTheDocument();
+    expect(await screen.findByText('12-4-1')).toBeInTheDocument();
+    expect(screen.getByAltText('The Brood faction banner')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.getByText('Led by Edge')).toBeInTheDocument();
-    expect(screen.getByText('12-4-1')).toBeInTheDocument();
     expect(screen.getByLabelText('Heat: 3 of 5')).toBeInTheDocument();
   });
 
   it('renders all seven tabs with Overview active by default', async () => {
     renderShell();
-    await screen.findByRole('heading', { name: 'The Brood' });
+    await screen.findByText('12-4-1');
     for (const label of ['Overview', 'Members', 'Stats', 'Schedule', 'Promos', 'Messages', 'Manage']) {
       expect(screen.getByRole('tab', { name: label })).toBeInTheDocument();
     }
@@ -165,7 +169,7 @@ describe('FactionDetail shell (FAC-11)', () => {
 
   it('navigates between tabs and applies the active class', async () => {
     renderShell();
-    await screen.findByRole('heading', { name: 'The Brood' });
+    await screen.findByText('12-4-1');
 
     // Tabs are stubbed at the top of the file so this assertion stays
     // focused on routing — placeholders verify the right tab rendered.
@@ -191,7 +195,60 @@ describe('FactionDetail shell (FAC-11)', () => {
     // Subsequent call succeeds — Retry recovers without a page reload.
     mockFactionsGetById.mockResolvedValueOnce(baseFaction());
     await userEvent.click(retry);
-    expect(await screen.findByRole('heading', { name: 'The Brood' })).toBeInTheDocument();
+    expect(await screen.findByText('12-4-1')).toBeInTheDocument();
+  });
+});
+
+describe('FactionDetail hero — FAC-22 record + banner-name fixes', () => {
+  it('suppresses the name <h1> when the faction has a custom banner', async () => {
+    mockFactionsGetById.mockResolvedValueOnce(
+      baseFaction({ imageUrl: '/images/brood.png' }),
+    );
+    renderShell();
+
+    // Wait for the hero to render (record is the "got past loading" signal).
+    await screen.findByText('12-4-1');
+    // The <h1> name overlay should NOT appear when a banner is set —
+    // the banner art carries the brand and we don't want the name to read
+    // twice.
+    expect(screen.queryByRole('heading', { name: 'The Brood' })).toBeNull();
+    // The banner image's alt text still announces the name for a11y.
+    expect(screen.getByAltText('The Brood faction banner')).toBeInTheDocument();
+  });
+
+  it('renders the name <h1> when the faction has no custom banner', async () => {
+    mockFactionsGetById.mockResolvedValueOnce(
+      baseFaction({ imageUrl: undefined }),
+    );
+    renderShell();
+
+    // No banner → the fallback gradient has no text of its own, so the
+    // name needs to be visible.
+    expect(
+      await screen.findByRole('heading', { name: 'The Brood' }),
+    ).toBeInTheDocument();
+  });
+
+  it('clamps undefined wins/losses/draws to 0 instead of rendering "-1"', async () => {
+    mockFactionsGetById.mockResolvedValueOnce(
+      baseFaction({ wins: undefined, losses: undefined, draws: undefined }),
+    );
+    renderShell();
+
+    // Pre-fix this would render "" + "-" + "1" + "-" + ... → "--" mess.
+    expect(await screen.findByText('0-0-0')).toBeInTheDocument();
+  });
+
+  it('clamps negative wins to 0 instead of bleeding into the record string', async () => {
+    mockFactionsGetById.mockResolvedValueOnce(
+      baseFaction({ wins: -1, losses: 1, draws: 0 }),
+    );
+    renderShell();
+
+    // The reported bug: hero showed "-1-1-0" because wins came through
+    // as -1 and JSX interpolated it raw. formatRecord should clamp.
+    expect(await screen.findByText('0-1-0')).toBeInTheDocument();
+    expect(screen.queryByText('-1-1-0')).toBeNull();
   });
 });
 

--- a/frontend/src/components/factions/tabs/FactionMessages.tsx
+++ b/frontend/src/components/factions/tabs/FactionMessages.tsx
@@ -687,9 +687,13 @@ export default function FactionMessages() {
                     }
                   >
                     <img
-                      src={resolveImageSrc(undefined, DEFAULT_WRESTLER_IMAGE)}
+                      src={resolveImageSrc(thread.partnerImageUrl ?? undefined, DEFAULT_WRESTLER_IMAGE)}
                       onError={(e) => applyImageFallback(e, DEFAULT_WRESTLER_IMAGE)}
-                      alt=""
+                      alt={
+                        thread.partnerWrestlerName ??
+                        thread.partnerPlayerName ??
+                        ''
+                      }
                       className="faction-messages__thread-avatar"
                     />
                     <div className="faction-messages__thread-body">

--- a/frontend/src/components/factions/tabs/__tests__/FactionMessages.test.tsx
+++ b/frontend/src/components/factions/tabs/__tests__/FactionMessages.test.tsx
@@ -115,6 +115,7 @@ beforeEach(() => {
       partnerPlayerId: 'partner-1',
       partnerPlayerName: 'Partner 1',
       partnerWrestlerName: 'Christian',
+      partnerImageUrl: 'https://example.com/christian.jpg',
       lastMessage: {
         messageId: 'dm-1',
         factionId: 'f1',
@@ -222,6 +223,56 @@ describe('FactionMessages tab (FAC-15)', () => {
       expect(screen.getByText('DIRECT · Christian')).toBeInTheDocument();
     });
     expect(screen.getByText('PRIVATE — JUST YOU TWO')).toBeInTheDocument();
+  });
+
+  // FAC-21: thread row avatars must use the partner's profile picture when
+  // we have one, and fall back to the default placeholder when we don't.
+  it("renders the partner's profile image on each DM row when available", async () => {
+    mockListMyThreads.mockResolvedValueOnce([
+      {
+        partnerPlayerId: 'partner-with-pic',
+        partnerPlayerName: 'Partner With Pic',
+        partnerWrestlerName: 'Edge',
+        partnerImageUrl: 'https://example.com/edge-portrait.jpg',
+        lastMessage: {
+          messageId: 'dm-a',
+          factionId: 'f1',
+          threadKey: 'me#partner-with-pic',
+          senderPlayerId: 'partner-with-pic',
+          recipientPlayerId: 'me',
+          body: 'Hi',
+          createdAt: '2026-04-30T10:00:00.000Z',
+        },
+        lastMessageAt: '2026-04-30T10:00:00.000Z',
+      },
+      {
+        partnerPlayerId: 'partner-no-pic',
+        partnerPlayerName: 'Partner No Pic',
+        partnerWrestlerName: 'Christian',
+        partnerImageUrl: null,
+        lastMessage: {
+          messageId: 'dm-b',
+          factionId: 'f1',
+          threadKey: 'me#partner-no-pic',
+          senderPlayerId: 'partner-no-pic',
+          recipientPlayerId: 'me',
+          body: 'Hey',
+          createdAt: '2026-04-30T10:00:00.000Z',
+        },
+        lastMessageAt: '2026-04-30T10:00:00.000Z',
+      },
+    ]);
+    renderTab();
+
+    const withPic = await screen.findByAltText('Edge');
+    expect(withPic).toHaveAttribute('src', 'https://example.com/edge-portrait.jpg');
+
+    const withoutPic = screen.getByAltText('Christian');
+    // resolveImageSrc returns the default image when input is undefined/null —
+    // we don't assert the exact URL of the default (changing the asset would
+    // break the test) but we confirm we did NOT keep the partner's null URL.
+    expect(withoutPic.getAttribute('src')).not.toBe('null');
+    expect(withoutPic.getAttribute('src')).not.toBe('');
   });
 
   it('opens the deep-linked DM on mount when ?dm=<partnerPlayerId> is set', async () => {

--- a/frontend/src/types/faction.ts
+++ b/frontend/src/types/faction.ts
@@ -132,6 +132,7 @@ export interface DirectMessageThreadSummary {
   partnerPlayerId: string;
   partnerPlayerName: string | null;
   partnerWrestlerName: string | null;
+  partnerImageUrl: string | null;
   lastMessage: FactionDirectMessage;
   lastMessageAt: string;
 }

--- a/frontend/src/variables.css
+++ b/frontend/src/variables.css
@@ -1,6 +1,10 @@
 :root {
   --color-primary: #d4af37;
   --color-primary-hover: #b8941f;
+  /* Canonical "text on gold" — use this anywhere `background: var(--color-primary)` is set so the
+     default `--color-text: #fff` doesn't inherit through and render unreadable white-on-gold.
+     Value is intentionally near-black to clear WCAG AA contrast at every realistic weight. */
+  --color-on-primary: #1a1a1a;
   --color-bg: #0f0f0f;
   --color-surface: #1a1a1a;
   --color-surface-hover: #252525;


### PR DESCRIPTION
Two related polish bugs surfaced from the live Ministry of Darkness page, handled in one PR. Targets `feat/factions`.

## FAC-21 — UI polish (contrast + DM avatars)

- Introduces a canonical `--color-on-primary: #1a1a1a` token in `variables.css` so anywhere a component sets `background: var(--color-primary)`, the matching text token is one grep away instead of every site hardcoding `color: #000`. Updates `.btn-primary`, the catch-all button fallback in `App.css`, and `.sidebar-logout` to use the new token.
- DM conversation rows in the Messages tab used to render the generic placeholder for every partner because the avatar src was hardcoded to `undefined`. Backend hydration in `getMyDirectMessageThreads.ts` now returns `partnerImageUrl` (string | null) next to the existing partner-name fields; the frontend reads it via `resolveImageSrc` + `applyImageFallback` and uses the partner name for the image `alt` (was empty).

## FAC-22 — Faction Detail hero record + banner-name overlap

- The hero rendered `-1-1-0` even though Standings showed `8-14-1` for the same faction. Two root causes — fixed both:
  - `getStable.ts` spread the raw `Stable` record (with possibly stale/uninitialized counters) into the response, even though it already computed correct values from match outcomes (used for `winPercentage`). Now the response overrides `wins/losses/draws` with the computed values so Detail and Standings agree.
  - Frontend JSX interpolated raw fields, letting any `undefined`/`null`/negative leak into the rendered string. New `formatRecord` + `safeCount` helpers clamp each component to a non-negative integer, so `-1` never reaches the UI again regardless of upstream weirdness.
- When a faction has a custom banner (`imageUrl` truthy), the giant `<h1>` overlay is suppressed since the banner art already carries the brand (the Ministry of Darkness banner has the name baked into the image). New `.faction-detail__hero--banner` modifier shrinks the reserved vertical space and zeroes the caption's top margin. When no banner is set, the fallback gradient has no text of its own so the `<h1>` still renders.

## Test plan

- [x] `cd backend && npx vitest run functions/stables` — 62 tests pass
- [x] `cd frontend && npx vitest run src/components/factions` — 61 tests pass
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [ ] Manual on devtest:
  - Ministry of Darkness hero record matches Standings (8-14-1, not -1-1-0).
  - Ministry of Darkness hero shows the banner without the duplicate name `<h1>`.
  - A faction with no `imageUrl` still shows the name overlay.
  - DM threads in the Messages tab render the partner's profile image; missing ones fall back to the default placeholder.
  - Logout / `.btn-primary` everywhere reads with dark text on gold.

## Commits

- `fee6562` style(tokens): introduce --color-on-primary for "text on gold" surfaces
- `5d5edfc` feat(factions): hydrate partnerImageUrl on DM thread summaries
- `dd30c96` feat(factions): render partner profile image on DM conversation rows
- `1e6e2c7` test(factions): cover partnerImageUrl on DM thread rows
- `a80fa63` fix(factions): derive Detail-hero record from matches, never from raw counters
- `1b0330c` fix(factions): suppress hero name overlay when faction has a custom banner
- `d6351c8` test(factions): cover FAC-22 record-formatter + banner-name suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)