### PR TITLE
feat(admin): add division filter to Manage Players

### DIFF
--- a/frontend/src/components/admin/ManagePlayers.css
+++ b/frontend/src/components/admin/ManagePlayers.css
@@ -59,6 +59,44 @@
   margin-bottom: 1rem;
 }
 
+.players-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.players-list-header h3 {
+  margin-bottom: 0;
+}
+
+.players-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.players-filter label {
+  color: #9ca3af;
+  font-size: 0.875rem;
+}
+
+.players-filter select {
+  padding: 0.5rem 0.75rem;
+  background-color: #1a1a1a;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.players-filter select:focus {
+  outline: none;
+  border-color: #d4af37;
+}
+
 .players-table-wrapper {
   overflow-x: auto;
 }

--- a/frontend/src/components/admin/ManagePlayers.tsx
+++ b/frontend/src/components/admin/ManagePlayers.tsx
@@ -90,9 +90,23 @@ export default function ManagePlayers() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
 
+  // Division filter for the players table. `null` means "not yet initialized";
+  // a one-shot effect picks Heavyweight (or "all" if Heavyweight is missing)
+  // once divisions load. Special values: 'all' = no filter, 'none' = players
+  // with no division assigned.
+  const [divisionFilter, setDivisionFilter] = useState<string | null>(null);
+
   useEffect(() => {
     loadData();
   }, []);
+
+  useEffect(() => {
+    if (divisionFilter !== null || divisions.length === 0) return;
+    const heavyweight = divisions.find(
+      (d) => d.name.toLowerCase() === 'heavyweight',
+    );
+    setDivisionFilter(heavyweight ? heavyweight.divisionId : 'all');
+  }, [divisions, divisionFilter]);
 
   const loadData = async () => {
     try {
@@ -137,6 +151,12 @@ export default function ManagePlayers() {
       ),
     [wrestlers, formData.currentWrestlerId, formData.alternateWrestlerId],
   );
+
+  const filteredPlayers = useMemo(() => {
+    if (divisionFilter === null || divisionFilter === 'all') return players;
+    if (divisionFilter === 'none') return players.filter((p) => !p.divisionId);
+    return players.filter((p) => p.divisionId === divisionFilter);
+  }, [players, divisionFilter]);
 
   const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -517,9 +537,32 @@ export default function ManagePlayers() {
       )}
 
       <div className="players-list">
-        <h3>All Players ({players.length})</h3>
+        <div className="players-list-header">
+          <h3>
+            All Players ({filteredPlayers.length}
+            {filteredPlayers.length !== players.length ? ` of ${players.length}` : ''})
+          </h3>
+          <div className="players-filter">
+            <label htmlFor="divisionFilter">Division:</label>
+            <select
+              id="divisionFilter"
+              value={divisionFilter ?? 'all'}
+              onChange={(e) => setDivisionFilter(e.target.value)}
+            >
+              <option value="all">All</option>
+              {divisions.map((division) => (
+                <option key={division.divisionId} value={division.divisionId}>
+                  {division.name}
+                </option>
+              ))}
+              <option value="none">No Division</option>
+            </select>
+          </div>
+        </div>
         {players.length === 0 ? (
           <p>No players yet. Add your first player!</p>
+        ) : filteredPlayers.length === 0 ? (
+          <p>No players match the selected division.</p>
         ) : (
           <div className="players-table-wrapper">
           <table className="players-table">
@@ -538,7 +581,7 @@ export default function ManagePlayers() {
               </tr>
             </thead>
             <tbody>
-              {players.map((player) => (
+              {filteredPlayers.map((player) => (
                 <tr key={player.playerId}>
                   <td>
                     <img

--- a/frontend/src/components/admin/__tests__/ManagePlayers.test.tsx
+++ b/frontend/src/components/admin/__tests__/ManagePlayers.test.tsx
@@ -114,7 +114,8 @@ describe('ManagePlayers', () => {
     expect(screen.getByText('Jane')).toBeInTheDocument();
     expect(screen.getByText('Becky Lynch')).toBeInTheDocument();
     expect(screen.getByText('10W - 3L - 1D')).toBeInTheDocument();
-    expect(screen.getByText('Raw')).toBeInTheDocument();
+    // "Raw" appears as both a filter dropdown option and a division cell; target the cell
+    expect(screen.getByText('Raw', { selector: '.division-cell' })).toBeInTheDocument();
     // "Linked" appears as both a table header and badge; target the badge by CSS class
     expect(screen.getByText('Linked', { selector: '.linked-badge' })).toBeInTheDocument();
     expect(screen.getByText('Manual')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Added a division dropdown above the Manage Players table with options for **All**, each division, and **No Division**
- Default selection is **Heavyweight** when that division exists; falls back to **All** if not found
- Player count displays "N of M" while a filter is active

## Test plan
- [x] `npx tsc --project tsconfig.app.json --noEmit` passes
- [x] `npx vitest run src/components/admin/__tests__/ManagePlayers.test.tsx` — 15/15 pass
- [ ] Manual: open Admin → Manage Players, confirm Heavyweight is preselected (in envs where it exists), switch to other divisions / All / No Division and verify the table filters correctly
- [ ] Manual: confirm count text shows "N of M" while filtered and "N" while showing all

🤖 Generated with [Claude Code](https://claude.com/claude-code)