### PR TITLE
fix(events): treat event date as calendar day, not a UTC instant

### DIFF
--- a/backend/functions/events/createEvent.ts
+++ b/backend/functions/events/createEvent.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
 import { parseBody } from '../../lib/parseBody';
 import { badRequest, created, notFound, serverError } from '../../lib/response';
+import { normalizeCalendarDate } from '../../lib/calendarDate';
 import type { EventCreateInput } from '../../lib/repositories/LeagueOpsRepository';
 import type { Location } from '../../lib/repositories/types';
 
@@ -47,6 +48,11 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     if (!raw.eventType) return badRequest('eventType is required');
     if (!raw.date) return badRequest('date is required');
 
+    const calendarDate = normalizeCalendarDate(raw.date);
+    if (!calendarDate) {
+      return badRequest('date must be a calendar date (YYYY-MM-DD)');
+    }
+
     if (!isValidEventType(raw.eventType)) {
       return badRequest('eventType must be one of ppv, weekly, special, or house');
     }
@@ -67,7 +73,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const input: EventCreateInput = {
       name: raw.name as string,
       eventType: raw.eventType,
-      date: raw.date as string,
+      date: calendarDate,
     };
     if (raw.venue !== undefined) input.venue = raw.venue as string;
     if (raw.description !== undefined) input.description = raw.description as string;

--- a/backend/functions/events/updateEvent.ts
+++ b/backend/functions/events/updateEvent.ts
@@ -3,6 +3,7 @@ import { getRepositories } from '../../lib/repositories';
 import { NotFoundError } from '../../lib/repositories/errors';
 import { success, badRequest, notFound, serverError } from '../../lib/response';
 import { parseBody } from '../../lib/parseBody';
+import { normalizeCalendarDate } from '../../lib/calendarDate';
 import type { EventPatch } from '../../lib/repositories/LeagueOpsRepository';
 
 interface UpdateEventBody {
@@ -64,6 +65,14 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           return notFound(`Company ${companyId} not found`);
         }
       }
+    }
+
+    if (body.date !== undefined) {
+      const normalized = normalizeCalendarDate(body.date);
+      if (!normalized) {
+        return badRequest('date must be a calendar date (YYYY-MM-DD)');
+      }
+      body.date = normalized;
     }
 
     const patch: EventPatch = {};

--- a/backend/lib/__tests__/calendarDate.test.ts
+++ b/backend/lib/__tests__/calendarDate.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeCalendarDate } from '../calendarDate';
+
+describe('normalizeCalendarDate', () => {
+  it('passes through YYYY-MM-DD unchanged', () => {
+    expect(normalizeCalendarDate('2026-05-17')).toBe('2026-05-17');
+  });
+
+  it('strips the time portion of a full ISO timestamp', () => {
+    // Storing the UTC date portion gives identical display in every viewer
+    // timezone — the original cause of the EST/UK day-shift bug.
+    expect(normalizeCalendarDate('2026-05-18T00:00:00.000Z')).toBe('2026-05-18');
+    expect(normalizeCalendarDate('2026-05-15T04:00:00.000Z')).toBe('2026-05-15');
+  });
+
+  it('returns null for malformed input', () => {
+    expect(normalizeCalendarDate('not-a-date')).toBeNull();
+    expect(normalizeCalendarDate('')).toBeNull();
+    expect(normalizeCalendarDate(undefined)).toBeNull();
+    expect(normalizeCalendarDate(123)).toBeNull();
+    expect(normalizeCalendarDate('2026-13-01')).toBeNull();
+    expect(normalizeCalendarDate('2026-01-32')).toBeNull();
+  });
+});

--- a/backend/lib/calendarDate.ts
+++ b/backend/lib/calendarDate.ts
@@ -1,0 +1,20 @@
+/**
+ * Normalize a date input to a calendar date string `YYYY-MM-DD`.
+ *
+ * Accepts `YYYY-MM-DD` directly, or a longer ISO timestamp where the leading
+ * date portion is taken as the calendar day. Returns `null` for anything that
+ * cannot be coerced — callers should treat that as a validation failure.
+ *
+ * Events represent a calendar day, not an instant. Storing the date this way
+ * keeps display identical across viewer timezones.
+ */
+export function normalizeCalendarDate(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length < 10) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const month = Number(m);
+  const day = Number(d);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return `${y}-${m}-${d}`;
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import {
 import Skeleton from './ui/Skeleton';
 import FindMatchWidget from './matchmaking/FindMatchWidget';
 import ChampionCarousel from './ChampionCarousel';
+import { formatCalendarDate } from '../utils/dateUtils';
 import './Dashboard.css';
 
 function renderStarRating(rating: number): string {
@@ -163,7 +164,7 @@ export default function Dashboard() {
                 >
                   <span className="db-live-badge">{t('dashboard.liveBadge')}</span>
                   <div className="db-event-name">{e.name}</div>
-                  <div className="db-event-date">{new Date(e.date).toLocaleDateString(undefined, { dateStyle: 'medium' })}</div>
+                  <div className="db-event-date">{formatCalendarDate(e.date, undefined, { dateStyle: 'medium' })}</div>
                 </Link>
               ))}
             </div>
@@ -182,7 +183,7 @@ export default function Dashboard() {
                 <Link key={e.eventId} to={`/events/${e.eventId}`} className="db-event-card">
                   <div className="db-event-name">{e.name}</div>
                   <div className="db-event-countdown">{formatCountdown(e.date, now, t)}</div>
-                  <div className="db-event-date">{new Date(e.date).toLocaleDateString(undefined, { dateStyle: 'medium' })}</div>
+                  <div className="db-event-date">{formatCalendarDate(e.date, undefined, { dateStyle: 'medium' })}</div>
                 </Link>
               ))}
             </div>

--- a/frontend/src/components/admin/MatchCardBuilder.tsx
+++ b/frontend/src/components/admin/MatchCardBuilder.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { MatchDesignation, MatchCardEntry, LeagueEvent } from '../../types/event';
 import type { Player } from '../../types';
 import { matchesApi, playersApi, eventsApi } from '../../services/api';
+import { formatCalendarDate } from '../../utils/dateUtils';
 import SearchableSelect from './SearchableSelect';
 import EventCheckInRosterPanel from '../events/EventCheckInRosterPanel';
 import './MatchCardBuilder.css';
@@ -239,7 +240,7 @@ export default function MatchCardBuilder() {
             { value: '', label: t('events.admin.chooseEvent', '-- Choose an event --') },
             ...events.map((ev) => ({
               value: ev.eventId,
-              label: `${ev.name} (${new Date(ev.date).toLocaleDateString()})`,
+              label: `${ev.name} (${formatCalendarDate(ev.date)})`,
             })),
           ]}
         />

--- a/frontend/src/components/events/EventCard.tsx
+++ b/frontend/src/components/events/EventCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { EventCalendarEntry } from '../../types/event';
+import { formatCalendarDate } from '../../utils/dateUtils';
 import './EventCard.css';
 
 interface EventCardProps {
@@ -27,12 +28,11 @@ export default function EventCard({ event }: EventCardProps) {
   const typeColor = eventTypeColors[event.eventType] || '#9ca3af';
   const statusColor = statusColors[event.status] || '#9ca3af';
 
-  const formattedDate = new Date(event.date).toLocaleDateString('en-US', {
+  const formattedDate = formatCalendarDate(event.date, 'en-US', {
     weekday: 'short',
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 
   return (

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -20,6 +20,7 @@ import EventCheckInRosterPanel from './EventCheckInRosterPanel';
 import MatchSlots from './MatchSlots';
 import SlotEditDialog from './SlotEditDialog';
 import type { HydratedMatchSlot } from '../../types';
+import { formatCalendarDate } from '../../utils/dateUtils';
 import './EventDetail.css';
 
 const eventTypeColors: Record<string, string> = {
@@ -384,12 +385,11 @@ export default function EventDetail() {
   const typeColor = eventTypeColors[eventData.eventType] || '#9ca3af';
   const statusColor = statusColors[eventData.status] || '#9ca3af';
 
-  const formattedDate = new Date(eventData.date).toLocaleDateString('en-US', {
+  const formattedDate = formatCalendarDate(eventData.date, 'en-US', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 
   // Separate pre-show and main card matches

--- a/frontend/src/components/events/EventsCalendar.tsx
+++ b/frontend/src/components/events/EventsCalendar.tsx
@@ -6,6 +6,7 @@ import type { Show } from '../../types';
 import { eventsApi, showsApi, companiesApi } from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
+import { toCalendarDate, dateToCalendarDate } from '../../utils/dateUtils';
 import Skeleton from '../ui/Skeleton';
 import EmptyState from '../ui/EmptyState';
 import EventCard from './EventCard';
@@ -37,7 +38,7 @@ const dayOfWeekToNumber: Record<string, number> = {
 interface ShowCalendarEntry {
   show: Show;
   companyName: string;
-  date: string; // ISO date for this specific occurrence
+  date: string; // calendar date YYYY-MM-DD for this specific occurrence
   eventType: 'weekly' | 'ppv';
 }
 
@@ -129,11 +130,14 @@ export default function EventsCalendar() {
     return calendarEntries.filter((e) => e.eventType === activeFilter);
   }, [activeFilter, calendarEntries]);
 
-  // Events for the current calendar month
+  // Events for the current calendar month. Compare against the YYYY-MM-DD
+  // calendar day so the placement is identical for every viewer's timezone.
   const monthEvents = useMemo(() => {
     return filteredEntries.filter((e) => {
-      const d = new Date(e.date);
-      return d.getMonth() === currentMonth && d.getFullYear() === currentYear;
+      const ymd = toCalendarDate(e.date);
+      const m = /^(\d{4})-(\d{2})-/.exec(ymd);
+      if (!m) return false;
+      return Number(m[1]) === currentYear && Number(m[2]) - 1 === currentMonth;
     });
   }, [filteredEntries, currentMonth, currentYear]);
 
@@ -142,14 +146,8 @@ export default function EventsCalendar() {
     const map: Record<number, ShowCalendarEntry[]> = {};
     const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
 
-    const eventExistsForShowOnDate = (showId: string, date: Date) =>
-      calendarEntries.some((e) => {
-        if (e.showId !== showId) return false;
-        const eDate = new Date(e.date);
-        return eDate.getFullYear() === date.getFullYear() &&
-          eDate.getMonth() === date.getMonth() &&
-          eDate.getDate() === date.getDate();
-      });
+    const eventExistsForShowOnYmd = (showId: string, ymd: string) =>
+      calendarEntries.some((e) => e.showId === showId && toCalendarDate(e.date) === ymd);
 
     shows.forEach((show) => {
       // Weekly recurring shows
@@ -161,30 +159,36 @@ export default function EventsCalendar() {
         for (let d = 1; d <= daysInMonth; d++) {
           const date = new Date(currentYear, currentMonth, d);
           if (date.getDay() !== targetDay) continue;
-          if (eventExistsForShowOnDate(show.showId, date)) continue;
+          const ymd = dateToCalendarDate(date);
+          if (eventExistsForShowOnYmd(show.showId, ymd)) continue;
           const arr = map[d] ?? (map[d] = []);
           arr.push({
             show,
             companyName: companyNames[show.companyId] || '',
-            date: date.toISOString(),
+            date: ymd,
             eventType: 'weekly',
           });
         }
         return;
       }
 
-      // PPV shows pinned to a specific date
+      // PPV shows pinned to a specific date. Parse YMD directly so the
+      // pinned day is the same in every viewer's timezone.
       if (show.schedule === 'ppv' && show.ppvDate) {
         if (activeFilter !== 'all' && activeFilter !== 'ppv') return;
-        const ppvDate = new Date(show.ppvDate);
-        if (ppvDate.getFullYear() !== currentYear || ppvDate.getMonth() !== currentMonth) return;
-        if (eventExistsForShowOnDate(show.showId, ppvDate)) return;
-        const d = ppvDate.getDate();
-        const arr = map[d] ?? (map[d] = []);
+        const ymd = toCalendarDate(show.ppvDate);
+        const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd);
+        if (!parts) return;
+        const ppvYear = Number(parts[1]);
+        const ppvMonth = Number(parts[2]) - 1;
+        const ppvDay = Number(parts[3]);
+        if (ppvYear !== currentYear || ppvMonth !== currentMonth) return;
+        if (eventExistsForShowOnYmd(show.showId, ymd)) return;
+        const arr = map[ppvDay] ?? (map[ppvDay] = []);
         arr.push({
           show,
           companyName: companyNames[show.companyId] || '',
-          date: ppvDate.toISOString(),
+          date: ymd,
           eventType: 'ppv',
         });
       }
@@ -210,7 +214,9 @@ export default function EventsCalendar() {
   const eventsByDay = useMemo(() => {
     const map: Record<number, typeof monthEvents> = {};
     monthEvents.forEach((e) => {
-      const day = new Date(e.date).getDate();
+      const parts = /^\d{4}-\d{2}-(\d{2})$/.exec(toCalendarDate(e.date));
+      if (!parts) return;
+      const day = Number(parts[1]);
       if (!map[day]) map[day] = [];
       map[day].push(e);
     });

--- a/frontend/src/components/events/MatchEditForm.tsx
+++ b/frontend/src/components/events/MatchEditForm.tsx
@@ -26,6 +26,7 @@ import type { TagTeam } from '../../types/tagTeam';
 import type { LeagueEvent, MatchDesignation } from '../../types/event';
 import SearchableSelect from '../admin/SearchableSelect';
 import Skeleton from '../ui/Skeleton';
+import { formatCalendarDate } from '../../utils/dateUtils';
 import '../admin/ScheduleMatch.css';
 import './MatchEditForm.css';
 
@@ -454,7 +455,7 @@ export default function MatchEditForm({
                   { value: '', label: t('scheduleMatch.noEvent', 'No Event (Standalone Match)') },
                   ...events.map((ev) => ({
                     value: ev.eventId,
-                    label: `${ev.name} (${new Date(ev.date).toLocaleDateString()})`,
+                    label: `${ev.name} (${formatCalendarDate(ev.date)})`,
                   })),
                 ]}
               />

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -3,6 +3,49 @@
  */
 
 /**
+ * Normalize a value to a calendar date string `YYYY-MM-DD`.
+ *
+ * Why this exists: events store a calendar day (no time), but legacy rows are
+ * full ISO timestamps. Stripping to the UTC date portion gives a single
+ * representation that renders identically in every viewer timezone.
+ */
+export function toCalendarDate(value: string): string {
+  if (!value) return value;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(value);
+  return match?.[1] ?? value;
+}
+
+/**
+ * Serialize a local `Date` to `YYYY-MM-DD` using its local calendar
+ * components — used when the user picked a day on a calendar grid that
+ * was rendered in their local timezone.
+ */
+export function dateToCalendarDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Format a calendar date for display. Accepts `YYYY-MM-DD` or a legacy ISO
+ * timestamp; always renders the same calendar day regardless of viewer
+ * timezone (anchored to UTC).
+ */
+export function formatCalendarDate(
+  value: string,
+  locale?: string,
+  options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' },
+): string {
+  const ymd = toCalendarDate(value);
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd);
+  if (!m) return value;
+  const date = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+  return date.toLocaleDateString(locale, { ...options, timeZone: 'UTC' });
+}
+
+/**
  * Formats a date string to a localized short date format.
  * Example: "Jan 15, 2024"
  *


### PR DESCRIPTION
## Summary
- Event dates are now treated as pure calendar days (`YYYY-MM-DD`) end-to-end — no time component, no timezone semantics
- A new admin in EST creating an event for **May 17** will now appear as **May 17** for viewers in every timezone

## Root cause
Event dates were stored as full ISO timestamps (e.g. `2026-05-18T00:00:00.000Z` for the "OPEN SZN: In Your House" PPV currently in prod) and rendered with `new Date(...).toLocaleDateString()` calls that interpret the instant in the viewer's local timezone. UTC midnight falls on May 17 in EDT but May 18 in BST, so the calendar grid placement and several display sites shifted by a day depending on the viewer.

## Changes
- **Backend**: `createEvent` and `updateEvent` normalize `date` to `YYYY-MM-DD` via a new `lib/calendarDate.ts` helper. Existing clients sending full ISO are coerced by slicing the UTC date portion; malformed input is rejected with a 400.
- **Frontend create site**: `EventsCalendar.tsx` now sends YMD for weekly and PPV entries and matches events to calendar cells by YMD string equality, so grid placement is identical across timezones.
- **Frontend display sites**: `EventCard`, `EventDetail`, `Dashboard`, `MatchCardBuilder`, and `MatchEditForm` route through a new `formatCalendarDate` helper that anchors rendering to UTC. Same input → same output everywhere.

## Test plan
- [x] Backend TS clean (`npx tsc --noEmit`)
- [x] Frontend TS clean (`npx tsc --project tsconfig.app.json --noEmit`)
- [x] Backend: 1064/1064 tests pass (incl. 3 new `normalizeCalendarDate` tests)
- [x] Frontend: 524/524 tests pass
- [ ] Manual: as EST admin, create a PPV event for May 17 → confirm both EST and (e.g.) Europe/London display "May 17"
- [ ] Manual: switch browser TZ to Europe/London and verify the events calendar grid places the event on the 17th, not the 18th
- [ ] Manual: confirm Dashboard upcoming events and event card list display matching dates across TZs

## Legacy data
Existing events in the DB are full ISO timestamps. With the new `formatCalendarDate`, they now display consistently across timezones (taking the UTC date portion). The one event whose timestamp straddles UTC midnight ("OPEN SZN: In Your House", stored as `2026-05-18T00:00:00.000Z`) will display as **May 18** universally after this change — if the admin's original intent was May 17, re-edit that event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)