### PR TITLE
feat(events): inline date editor on EventDetail for admins

### DIFF
--- a/frontend/src/components/events/EventDetail.css
+++ b/frontend/src/components/events/EventDetail.css
@@ -251,6 +251,72 @@
   min-width: 90px;
 }
 
+.event-detail-date-row {
+  align-items: center;
+}
+
+.event-detail-date-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.event-detail-date-edit input[type='date'] {
+  padding: 4px 8px;
+  background-color: #1a1a1a;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.event-detail-date-edit-btn,
+.event-detail-date-save,
+.event-detail-date-cancel {
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.event-detail-date-edit-btn {
+  color: #d4af37;
+  border-color: #d4af37;
+  background: transparent;
+}
+
+.event-detail-date-edit-btn:hover {
+  background-color: rgba(212, 175, 55, 0.12);
+}
+
+.event-detail-date-save {
+  color: #000;
+  background-color: #d4af37;
+  font-weight: 600;
+}
+
+.event-detail-date-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.event-detail-date-cancel {
+  color: #ccc;
+  background-color: #333;
+}
+
+.event-detail-date-error {
+  color: #fecaca;
+  background-color: #7f1d1d;
+  border: 1px solid #991b1b;
+  padding: 6px 10px;
+  border-radius: 4px;
+  margin-top: 6px;
+  font-size: 0.85rem;
+}
+
 .event-rating {
   color: #d4af37;
   font-weight: 600;

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -20,7 +20,7 @@ import EventCheckInRosterPanel from './EventCheckInRosterPanel';
 import MatchSlots from './MatchSlots';
 import SlotEditDialog from './SlotEditDialog';
 import type { HydratedMatchSlot } from '../../types';
-import { formatCalendarDate } from '../../utils/dateUtils';
+import { formatCalendarDate, toCalendarDate } from '../../utils/dateUtils';
 import './EventDetail.css';
 
 const eventTypeColors: Record<string, string> = {
@@ -73,6 +73,10 @@ export default function EventDetail() {
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [editingDate, setEditingDate] = useState(false);
+  const [dateDraft, setDateDraft] = useState('');
+  const [savingDate, setSavingDate] = useState(false);
+  const [dateError, setDateError] = useState<string | null>(null);
 
   // Admin-only data for inline record/edit/delete flows
   const [scheduledMatches, setScheduledMatches] = useState<Match[]>([]);
@@ -204,6 +208,41 @@ export default function EventDetail() {
       console.error('Failed to update event status:', err);
     } finally {
       setUpdatingStatus(false);
+    }
+  };
+
+  const handleStartEditDate = () => {
+    if (!eventData) return;
+    setDateDraft(toCalendarDate(eventData.date));
+    setDateError(null);
+    setEditingDate(true);
+  };
+
+  const handleCancelEditDate = () => {
+    setEditingDate(false);
+    setDateError(null);
+  };
+
+  const handleSaveDate = async () => {
+    if (!eventData || !eventId || savingDate) return;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateDraft)) {
+      setDateError(t('events.admin.editDate.invalid', 'Pick a valid date.'));
+      return;
+    }
+    if (dateDraft === toCalendarDate(eventData.date)) {
+      setEditingDate(false);
+      return;
+    }
+    setSavingDate(true);
+    setDateError(null);
+    try {
+      const updated = await eventsApi.update(eventId, { date: dateDraft });
+      setEventData({ ...eventData, date: updated.date });
+      setEditingDate(false);
+    } catch (err) {
+      setDateError(err instanceof Error ? err.message : t('events.admin.editDate.error', 'Failed to update date.'));
+    } finally {
+      setSavingDate(false);
     }
   };
 
@@ -606,10 +645,55 @@ export default function EventDetail() {
         )}
 
         <div className="event-detail-info">
-          <div className="event-detail-info-item">
+          <div className="event-detail-info-item event-detail-date-row">
             <span className="info-label">{t('events.detail.date')}:</span>
-            <span>{formattedDate}</span>
+            {isAdminOrModerator && editingDate ? (
+              <span className="event-detail-date-edit">
+                <input
+                  type="date"
+                  value={dateDraft}
+                  onChange={(e) => setDateDraft(e.target.value)}
+                  disabled={savingDate}
+                  aria-label={t('events.admin.editDate.label', 'Event date')}
+                />
+                <button
+                  type="button"
+                  className="event-detail-date-save"
+                  onClick={handleSaveDate}
+                  disabled={savingDate}
+                >
+                  {savingDate ? t('common.saving') : t('common.save', 'Save')}
+                </button>
+                <button
+                  type="button"
+                  className="event-detail-date-cancel"
+                  onClick={handleCancelEditDate}
+                  disabled={savingDate}
+                >
+                  {t('common.cancel', 'Cancel')}
+                </button>
+              </span>
+            ) : (
+              <>
+                <span>{formattedDate}</span>
+                {isAdminOrModerator && (
+                  <button
+                    type="button"
+                    className="event-detail-date-edit-btn"
+                    onClick={handleStartEditDate}
+                    aria-label={t('events.admin.editDate.label', 'Event date')}
+                  >
+                    {t('common.edit', 'Edit')}
+                  </button>
+                )}
+              </>
+            )}
           </div>
+          {dateError && (
+            <div className="event-detail-date-error" role="alert">
+              {dateError}
+            </div>
+          )}
           {eventData.venue && (
             <div className="event-detail-info-item">
               <span className="info-label">{t('events.detail.venue')}:</span>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1098,6 +1098,11 @@
       "confirmDeleteEvent": "Möchtest du \"{{name}}\" wirklich löschen?",
       "deleteEventSuccess": "Veranstaltung erfolgreich gelöscht.",
       "deleteEventError": "Veranstaltung konnte nicht gelöscht werden.",
+      "editDate": {
+        "label": "Veranstaltungsdatum",
+        "invalid": "Bitte ein gültiges Datum wählen.",
+        "error": "Datum konnte nicht aktualisiert werden."
+      },
       "loadEventsError": "Veranstaltungen konnten nicht geladen werden.",
       "name": "Veranstaltungsname",
       "namePlaceholder": "z.B. WrestleMania 41, Monday Night Raw",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1099,6 +1099,11 @@
       "confirmDeleteEvent": "Are you sure you want to delete \"{{name}}\"?",
       "deleteEventSuccess": "Event deleted successfully.",
       "deleteEventError": "Failed to delete event.",
+      "editDate": {
+        "label": "Event date",
+        "invalid": "Pick a valid date.",
+        "error": "Failed to update date."
+      },
       "loadEventsError": "Failed to load events.",
       "name": "Event Name",
       "namePlaceholder": "e.g., WrestleMania 41, Monday Night Raw",


### PR DESCRIPTION
## Summary
- Adds an "Edit" affordance next to the date on the event detail page, visible to admins/moderators
- Picks a new date with a native date input, saves via `eventsApi.update(eventId, { date })`
- Check-ins are keyed by `eventId`, so participants who marked themselves as available stay attached after the move — no need to delete + recreate the event

## Context
Without this, moving an event's date required either creating a new event (losing check-ins) or a manual DB edit. This was the immediate pain after #356 — the existing "OPEN SZN: In Your House" event needs its date corrected, and we want to do it without losing the people who marked as available.

## Test plan
- [x] Frontend TS clean (`npx tsc --project tsconfig.app.json --noEmit`)
- [x] Frontend events tests: 50/50 pass
- [ ] Manual: as admin, open an event, click Edit by the date, pick a new date, Save → confirm date updates and check-ins remain
- [ ] Manual: cancel/invalid date paths
- [ ] Manual: non-admin user does not see the Edit button

## Notes
- Builds on the calendar-date helpers from #356 (`toCalendarDate`)
- Backend `updateEvent` already accepts `date`; this PR is frontend + i18n only
- EN + DE strings under `events.admin.editDate.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)