### PR TITLE
feat(events): admin lock for event check-ins

### DIFF
--- a/backend/functions/events/__tests__/checkIn.test.ts
+++ b/backend/functions/events/__tests__/checkIn.test.ts
@@ -145,6 +145,24 @@ describe('checkIn', () => {
     expect(mockPut).not.toHaveBeenCalled();
   });
 
+  it('returns 403 when check-ins are locked by admin', async () => {
+    mockQuery.mockResolvedValue({ Items: [{ playerId: 'p1', userId: 'user-sub-1' }] });
+    mockGet.mockResolvedValue({
+      Item: {
+        eventId: 'evt-1',
+        status: 'upcoming',
+        date: '2026-05-01T00:00:00.000Z',
+        checkInsLocked: true,
+      },
+    });
+
+    const result = await checkIn(wrestlerEvent('evt-1', { status: 'available' }));
+
+    expect(result!.statusCode).toBe(403);
+    expect(JSON.parse(result!.body).message).toBe('Check-ins are locked for this event');
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
   it('returns 404 for non-existent event', async () => {
     mockQuery.mockResolvedValue({ Items: [{ playerId: 'p1', userId: 'user-sub-1' }] });
     mockGet.mockResolvedValue({ Item: undefined });

--- a/backend/functions/events/checkIn.ts
+++ b/backend/functions/events/checkIn.ts
@@ -54,6 +54,10 @@ export const handler = async (
       return badRequest('Check-in is only allowed for upcoming or in-progress events');
     }
 
+    if (eventItem.checkInsLocked) {
+      return forbidden('Check-ins are locked for this event');
+    }
+
     if (!eventItem.date) {
       return serverError('Event is missing a date');
     }

--- a/backend/functions/events/deleteCheckIn.ts
+++ b/backend/functions/events/deleteCheckIn.ts
@@ -38,6 +38,10 @@ export const handler = async (
       return badRequest('Check-in can only be cleared for upcoming or in-progress events');
     }
 
+    if (eventItem.checkInsLocked) {
+      return forbidden('Check-ins are locked for this event');
+    }
+
     // Idempotent delete -- does not error if the row does not exist
     await events.deleteCheckIn(eventId, playerId);
 

--- a/backend/functions/events/updateEvent.ts
+++ b/backend/functions/events/updateEvent.ts
@@ -21,6 +21,7 @@ interface UpdateEventBody {
   rating?: number;
   companyIds?: string[];
   showId?: string;
+  checkInsLocked?: boolean;
 }
 
 const VALID_EVENT_TYPES = ['ppv', 'weekly', 'special', 'house'];
@@ -90,6 +91,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     if (body.rating !== undefined) patch.rating = body.rating;
     if (body.companyIds !== undefined) patch.companyIds = body.companyIds;
     if (body.showId !== undefined) patch.showId = body.showId;
+    if (body.checkInsLocked !== undefined) patch.checkInsLocked = body.checkInsLocked;
 
     if (Object.keys(patch).length === 0) {
       return badRequest('No valid fields to update');

--- a/backend/lib/repositories/LeagueOpsRepository.ts
+++ b/backend/lib/repositories/LeagueOpsRepository.ts
@@ -42,6 +42,7 @@ export interface EventPatch {
   matchCards?: LeagueEvent['matchCards'];
   attendance?: number;
   rating?: number;
+  checkInsLocked?: boolean;
 }
 
 // ─── Show input types ───────────────────────────────────────────────

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -330,6 +330,10 @@ export interface LeagueEvent {
   matchCards: MatchCardEntry[];
   attendance?: number;
   rating?: number;
+  // When true, players cannot create or change their check-in for this event.
+  // Independent of `status`: admins can lock sign-ups while the event is still
+  // upcoming (e.g. to close the roster once it's filled).
+  checkInsLocked?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/components/events/EventCheckIn.tsx
+++ b/frontend/src/components/events/EventCheckIn.tsx
@@ -8,15 +8,18 @@ interface EventCheckInProps {
   currentStatus: EventCheckInStatus | null;
   summary: EventCheckInSummary;
   onChange: (status: EventCheckInStatus | null) => Promise<void>;
+  /** Admin-controlled lock; independent of `eventStatus`. */
+  signupsLocked?: boolean;
 }
 
 const RSVP_OPTIONS: EventCheckInStatus[] = ['available', 'tentative', 'unavailable'];
 
-function EventCheckIn({ eventStatus, currentStatus, summary, onChange }: EventCheckInProps) {
+function EventCheckIn({ eventStatus, currentStatus, summary, onChange, signupsLocked = false }: EventCheckInProps) {
   const { t } = useTranslation();
   const [submitting, setSubmitting] = useState(false);
 
-  const locked = eventStatus !== 'upcoming' && eventStatus !== 'in-progress';
+  const statusLocked = eventStatus !== 'upcoming' && eventStatus !== 'in-progress';
+  const locked = statusLocked || signupsLocked;
   const disabled = locked || submitting;
 
   const handleChange = async (status: EventCheckInStatus | null) => {
@@ -70,7 +73,9 @@ function EventCheckIn({ eventStatus, currentStatus, summary, onChange }: EventCh
 
       {locked && (
         <div className="event-checkin-locked-hint">
-          {t('events.checkIn.lockedAfterStart')}
+          {signupsLocked && !statusLocked
+            ? t('events.checkIn.lockedByAdmin')
+            : t('events.checkIn.lockedAfterStart')}
         </div>
       )}
     </div>

--- a/frontend/src/components/events/EventDetail.css
+++ b/frontend/src/components/events/EventDetail.css
@@ -132,6 +132,33 @@
   cursor: pointer;
 }
 
+.event-detail-lock-btn {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 3px 10px;
+  border-radius: 4px;
+  border: 1px solid #d4af37;
+  background: transparent;
+  color: #d4af37;
+  cursor: pointer;
+}
+
+.event-detail-lock-btn:hover:not(:disabled) {
+  background: rgba(212, 175, 55, 0.15);
+}
+
+.event-detail-lock-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+.event-detail-lock-btn.is-locked {
+  background: rgba(212, 175, 55, 0.18);
+  color: #f3d57f;
+}
+
 .event-detail-delete-btn:hover:not(:disabled) {
   background: rgba(220, 38, 38, 0.15);
 }

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -77,6 +77,8 @@ export default function EventDetail() {
   const [dateDraft, setDateDraft] = useState('');
   const [savingDate, setSavingDate] = useState(false);
   const [dateError, setDateError] = useState<string | null>(null);
+  const [togglingLock, setTogglingLock] = useState(false);
+  const [lockError, setLockError] = useState<string | null>(null);
 
   // Admin-only data for inline record/edit/delete flows
   const [scheduledMatches, setScheduledMatches] = useState<Match[]>([]);
@@ -243,6 +245,21 @@ export default function EventDetail() {
       setDateError(err instanceof Error ? err.message : t('events.admin.editDate.error', 'Failed to update date.'));
     } finally {
       setSavingDate(false);
+    }
+  };
+
+  const handleToggleSignupLock = async () => {
+    if (!eventData || !eventId || togglingLock) return;
+    const next = !eventData.checkInsLocked;
+    setTogglingLock(true);
+    setLockError(null);
+    try {
+      const updated = await eventsApi.update(eventId, { checkInsLocked: next });
+      setEventData({ ...eventData, checkInsLocked: updated.checkInsLocked });
+    } catch (err) {
+      setLockError(err instanceof Error ? err.message : t('events.admin.lockSignups.error', 'Failed to update sign-ups.'));
+    } finally {
+      setTogglingLock(false);
     }
   };
 
@@ -619,6 +636,24 @@ export default function EventDetail() {
                 </select>
                 <button
                   type="button"
+                  className={`event-detail-lock-btn${eventData.checkInsLocked ? ' is-locked' : ''}`}
+                  onClick={handleToggleSignupLock}
+                  disabled={togglingLock}
+                  title={
+                    eventData.checkInsLocked
+                      ? t('events.admin.lockSignups.unlock', 'Unlock sign-ups')
+                      : t('events.admin.lockSignups.lock', 'Lock sign-ups')
+                  }
+                  aria-pressed={!!eventData.checkInsLocked}
+                >
+                  {togglingLock
+                    ? t('common.saving')
+                    : eventData.checkInsLocked
+                      ? t('events.admin.lockSignups.unlock', 'Unlock sign-ups')
+                      : t('events.admin.lockSignups.lock', 'Lock sign-ups')}
+                </button>
+                <button
+                  type="button"
                   className="event-detail-delete-btn"
                   onClick={handleDeleteEvent}
                   disabled={deleting}
@@ -641,6 +676,11 @@ export default function EventDetail() {
         {deleteError && (
           <div className="event-detail-delete-error" role="alert">
             {deleteError}
+          </div>
+        )}
+        {lockError && (
+          <div className="event-detail-delete-error" role="alert">
+            {lockError}
           </div>
         )}
 
@@ -727,6 +767,7 @@ export default function EventDetail() {
               currentStatus={myCheckIn?.status ?? null}
               summary={checkInSummary}
               onChange={handleCheckInChange}
+              signupsLocked={!!eventData.checkInsLocked}
             />
             {checkInError && (
               <div className="event-checkin-error" role="alert">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1103,6 +1103,11 @@
         "invalid": "Bitte ein gültiges Datum wählen.",
         "error": "Datum konnte nicht aktualisiert werden."
       },
+      "lockSignups": {
+        "lock": "Anmeldung sperren",
+        "unlock": "Anmeldung freigeben",
+        "error": "Anmeldung konnte nicht aktualisiert werden."
+      },
       "loadEventsError": "Veranstaltungen konnten nicht geladen werden.",
       "name": "Veranstaltungsname",
       "namePlaceholder": "z.B. WrestleMania 41, Monday Night Raw",
@@ -1134,6 +1139,7 @@
       "clearResponse": "Antwort zurücksetzen",
       "summary": "{{available}} verfügbar · {{tentative}} vielleicht · {{unavailable}} nicht verfügbar",
       "lockedAfterStart": "Anmeldungen sind gesperrt, sobald das Event begonnen hat oder beendet ist.",
+      "lockedByAdmin": "Die Anmeldung für dieses Event ist geschlossen.",
       "error": "Antwort konnte nicht aktualisiert werden. Bitte versuche es erneut.",
       "success": "Antwort gespeichert.",
       "noPlayerProfile": "Verknüpfe ein Spielerprofil, um zuzusagen.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1104,6 +1104,11 @@
         "invalid": "Pick a valid date.",
         "error": "Failed to update date."
       },
+      "lockSignups": {
+        "lock": "Lock sign-ups",
+        "unlock": "Unlock sign-ups",
+        "error": "Failed to update sign-ups."
+      },
       "loadEventsError": "Failed to load events.",
       "name": "Event Name",
       "namePlaceholder": "e.g., WrestleMania 41, Monday Night Raw",
@@ -1135,6 +1140,7 @@
       "clearResponse": "Clear my response",
       "summary": "{{available}} available · {{tentative}} tentative · {{unavailable}} unavailable",
       "lockedAfterStart": "Check-ins are locked once the event has started or ended.",
+      "lockedByAdmin": "Sign-ups are closed for this event.",
       "error": "Couldn't update your response. Please try again.",
       "success": "Response saved.",
       "noPlayerProfile": "Link a player profile to RSVP.",

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -30,6 +30,8 @@ export interface LeagueEvent {
   matchCards: MatchCardEntry[];
   attendance?: number;
   rating?: number;
+  // When true, players cannot create or change their check-in for this event.
+  checkInsLocked?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -97,6 +99,7 @@ export interface UpdateEventInput extends Partial<CreateEventInput> {
   rating?: number;
   companyIds?: string[];
   showId?: string;
+  checkInsLocked?: boolean;
 }
 
 export type EventCheckInStatus = 'available' | 'tentative' | 'unavailable';


### PR DESCRIPTION
## Summary
- Admins/moderators get a **Lock sign-ups / Unlock sign-ups** toggle on the event detail page (next to the status select and delete button)
- While locked: wrestlers see the RSVP buttons disabled (gray) and a "Sign-ups are closed for this event" message; backend rejects check-in writes with `403`

## Why
Once an event's roster is filled, the admin wants to close it off — but the existing only-when-event-has-started lock isn't enough. This adds an explicit, admin-controlled lock that's independent of event status.

## Changes
**Backend**
- `LeagueEvent.checkInsLocked?: boolean` added to the type and `EventPatch`
- `POST /events/{id}/check-in` and `DELETE /events/{id}/check-in` return `403 Check-ins are locked for this event` when locked
- `PUT /events/{id}` accepts `checkInsLocked`

**Frontend**
- `EventCheckIn` accepts a new `signupsLocked` prop, disables the RSVP buttons and clear-response action when set, and swaps in the new "closed" message
- `EventDetail` adds the admin toggle button and passes `checkInsLocked` down to `EventCheckIn`
- EN + DE strings under `events.checkIn.lockedByAdmin` and `events.admin.lockSignups.*`

## Test plan
- [x] Backend TS clean
- [x] Frontend TS clean
- [x] Backend: 1065/1065 tests pass (incl. new 403-when-locked test)
- [x] Frontend: 524/524 tests pass
- [ ] Manual: as admin, click **Lock sign-ups** on an event — confirm wrestlers see disabled buttons and the closed-signups message
- [ ] Manual: as admin, **Unlock sign-ups** — confirm wrestlers can RSVP again
- [ ] Manual: confirm the API rejects a check-in attempt when locked (`403`) and the UI surfaces the error

## Notes
Backend currently rejects *clearing* an RSVP while locked too (no changes while locked). If you want clears to be allowed even when locked, easy to relax — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)