### PR TITLE
feat(events): sign-up lock also disables claim-spot buttons

### DIFF
--- a/backend/functions/matches/claimSlot.ts
+++ b/backend/functions/matches/claimSlot.ts
@@ -139,6 +139,10 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       return conflict('Event is no longer accepting signups');
     }
 
+    if (linkedEvent?.checkInsLocked) {
+      return forbidden('Sign-ups are closed for this event');
+    }
+
     // MSL-04: a wrestler may hold at most one slot across the entire event
     // card. Walk every other match on this event and reject if the caller
     // already occupies a slot anywhere. Admin force-assign via

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -547,11 +547,18 @@ export default function EventDetail() {
               ? (slot) => handleAdminEditSlot(match.matchId, slot)
               : undefined}
             claimDisabled={
-              !!userOccupiedMatchId && userOccupiedMatchId !== match.matchId
+              !!eventData.checkInsLocked ||
+              (!!userOccupiedMatchId && userOccupiedMatchId !== match.matchId)
             }
-            disableClaimReason={t('matches.slots.alreadyBookedTooltip', {
-              defaultValue: 'You already have a slot in another match on this event',
-            })}
+            disableClaimReason={
+              eventData.checkInsLocked
+                ? t('events.checkIn.lockedByAdmin', {
+                    defaultValue: 'Sign-ups are closed for this event.',
+                  })
+                : t('matches.slots.alreadyBookedTooltip', {
+                    defaultValue: 'You already have a slot in another match on this event',
+                  })
+            }
             currentPlayerCurrentWrestler={currentWrestler}
             currentPlayerAlternateWrestler={alternateWrestler}
             winnerPlayerIds={match.matchData.winners}


### PR DESCRIPTION
## Summary
- Event sign-up lock now disables every match's "Claim spot" button on `EventDetail`, with a "Sign-ups are closed" tooltip
- `claimSlot` backend handler returns 403 when the linked event has `checkInsLocked=true`, so the lock can't be bypassed via direct API call
- Release is intentionally left open — a wrestler can still give up a spot they already hold even while sign-ups are locked

## Test plan
- [ ] As admin, lock sign-ups on an event with an open match → "Claim spot" buttons are disabled with the "Sign-ups are closed" tooltip
- [ ] Unlock sign-ups → "Claim spot" buttons re-enable
- [ ] While locked, direct `POST /matches/{id}/slots/{slotId}/claim` returns 403
- [ ] While locked, a wrestler who already holds a slot can still release it

🤖 Generated with [Claude Code](https://claude.com/claude-code)