### PR TITLE
feat(events): show PSN ID on match card slot row

### DIFF
--- a/backend/functions/events/getEvent.ts
+++ b/backend/functions/events/getEvent.ts
@@ -67,7 +67,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         // Fetch participant player data via repository. The same lookup also
         // feeds slot hydration below, since slot playerIds are a subset of
         // participants in slot-mode matches.
-        const participantData: { playerId: string; playerName: string; wrestlerName: string }[] = [];
+        const participantData: { playerId: string; playerName: string; wrestlerName: string; psnId?: string }[] = [];
         const playerLookup = new Map<string, Player>();
         if (Array.isArray(match.participants) && match.participants.length > 0) {
           const playerPromises = (match.participants as string[]).map(async (playerId: string) => {
@@ -78,6 +78,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
               playerId,
               playerName: player?.name || 'Unknown Player',
               wrestlerName: snapshot ?? player?.currentWrestler ?? 'Unknown Wrestler',
+              psnId: player?.psnId,
             };
           });
           participantData.push(...(await Promise.all(playerPromises)));

--- a/backend/functions/matches/__tests__/hydrateSlots.test.ts
+++ b/backend/functions/matches/__tests__/hydrateSlots.test.ts
@@ -60,6 +60,25 @@ describe('hydrateMatchSlots', () => {
     const out = hydrateMatchSlots(slots, new Map());
     expect(out[0].wrestlerName).toBeUndefined();
     expect(out[0].playerName).toBeUndefined();
+    expect(out[0].psnId).toBeUndefined();
+  });
+
+  it('plumbs psnId from the player record onto filled slots', () => {
+    const slots: MatchSlot[] = [
+      { slotId: 's1', position: 1, playerId: 'p1' },
+    ];
+    const lookup = new Map<string, Player>([['p1', player({ psnId: 'StoneCold_316' })]]);
+    const out = hydrateMatchSlots(slots, lookup);
+    expect(out[0].psnId).toBe('StoneCold_316');
+  });
+
+  it('leaves psnId undefined when the player has none on file', () => {
+    const slots: MatchSlot[] = [
+      { slotId: 's1', position: 1, playerId: 'p1' },
+    ];
+    const lookup = new Map<string, Player>([['p1', player({ psnId: undefined })]]);
+    const out = hydrateMatchSlots(slots, lookup);
+    expect(out[0].psnId).toBeUndefined();
   });
 });
 

--- a/backend/functions/matches/hydrateSlots.ts
+++ b/backend/functions/matches/hydrateSlots.ts
@@ -10,6 +10,14 @@ export interface HydratedMatchSlot extends MatchSlot {
    * predate MSL-03's snapshot field. Only set when the slot is filled.
    */
   wrestlerName?: string;
+  /**
+   * Live PSN gamertag from the player record. Unlike `wrestlerName`, this
+   * is not snapshotted — a renamed PSN propagates to historical match
+   * cards because the value's purpose is "the gamertag to add today", not
+   * a brand identity tied to a moment in time. Undefined when the player
+   * has no PSN on file or the slot is unfilled.
+   */
+  psnId?: string;
 }
 
 /**
@@ -35,6 +43,7 @@ export function hydrateMatchSlots(
       ...slot,
       playerName: player?.name ?? 'Unknown Player',
       wrestlerName,
+      psnId: player?.psnId,
     };
   });
 }

--- a/frontend/src/components/events/MatchSlots.css
+++ b/frontend/src/components/events/MatchSlots.css
@@ -148,6 +148,13 @@
   font-size: 0.85em;
 }
 
+.match-slot-psn {
+  /* Inherits color + font-size from .match-slot-player so PSN reads as
+     part of the same parenthetical. Tabular numerals keep digit-heavy
+     gamertags aligned across rows. */
+  font-feature-settings: "tnum";
+}
+
 .match-slot-empty {
   color: #888;
   font-style: italic;

--- a/frontend/src/components/events/MatchSlots.tsx
+++ b/frontend/src/components/events/MatchSlots.tsx
@@ -219,7 +219,15 @@ export default function MatchSlots(props: MatchSlotsProps) {
                   <Link to={`/players/${slot.playerId}`} className="match-slot-link">
                     <span className="match-slot-wrestler">{slot.wrestlerName ?? slot.playerId}</span>
                     {slot.playerName && (
-                      <span className="match-slot-player"> ({slot.playerName})</span>
+                      slot.psnId ? (
+                        <span className="match-slot-player">
+                          {' ('}{slot.playerName}{' · '}
+                          <span className="match-slot-psn">{slot.psnId}</span>
+                          {')'}
+                        </span>
+                      ) : (
+                        <span className="match-slot-player"> ({slot.playerName})</span>
+                      )
                     )}
                     {isWinner && (
                       <span className="match-slot-winner-badge" aria-label="Winner">W</span>

--- a/frontend/src/components/events/__tests__/MatchSlots.test.tsx
+++ b/frontend/src/components/events/__tests__/MatchSlots.test.tsx
@@ -72,6 +72,22 @@ describe('MatchSlots', () => {
     expect(screen.getByText('(Bob)')).toBeInTheDocument();
   });
 
+  it('renders psnId in its own span when present, alongside the player name', () => {
+    const { container } = renderSlots({ slots: [filled({ psnId: 'StoneCold_316' })] });
+    // PSN gets its own span so it can be styled (.match-slot-psn).
+    const psn = container.querySelector('.match-slot-psn');
+    expect(psn).not.toBeNull();
+    expect(psn?.textContent).toBe('StoneCold_316');
+    // The parenthetical still contains the player name + a separator.
+    const player = container.querySelector('.match-slot-player');
+    expect(player?.textContent).toBe(' (Bob · StoneCold_316)');
+  });
+
+  it('omits the psn span entirely when the player has no psnId', () => {
+    const { container } = renderSlots({ slots: [filled({ psnId: undefined })] });
+    expect(container.querySelector('.match-slot-psn')).toBeNull();
+  });
+
   it('renders open slot with Claim button when authenticated', () => {
     renderSlots({ slots: [open()], isAuthenticated: true });
     expect(screen.getByRole('button', { name: 'Claim spot' })).toBeInTheDocument();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,8 @@ export interface MatchSlot {
 export interface HydratedMatchSlot extends MatchSlot {
   playerName?: string;
   wrestlerName?: string;
+  /** Live PSN gamertag from the player record; undefined when unset. */
+  psnId?: string;
 }
 
 /** Input for one slot when scheduling a match in slot mode. */


### PR DESCRIPTION
## Summary
- Match card slot rows now show `{Wrestler} ({Player Name} · {PSN ID})` when the player has a PSN on file; format stays `{Wrestler} ({Player Name})` for players without one.
- PSN is plumbed live (not snapshotted) — rationale: this value's purpose is "the gamertag to add today", so a rename should propagate to historical cards too. Wrestler name remains snapshotted per the existing MSL-03 rule.

## Implementation
- Backend: `HydratedMatchSlot` (`backend/functions/matches/hydrateSlots.ts`) and `getEvent`'s `participantData` carry optional `psnId`, sourced from `player.psnId`.
- Frontend: `HydratedMatchSlot` type mirrored in `frontend/src/types/index.ts`. `MatchSlots.tsx` renders the PSN inside a nested `.match-slot-psn` span only when present, so the no-PSN render path is byte-identical to before.
- CSS: `.match-slot-psn` inherits muted color/size from `.match-slot-player` and adds `font-feature-settings: "tnum"` so digit-heavy gamertags align across rows.

Implements [IMP-01 on the kanban](https://kanban.jpdxsolo.com/) (issue #151).

## Test plan
- [x] `cd backend && npx tsc --project tsconfig.json --noEmit` — clean
- [x] `cd backend && npx vitest run functions/matches/__tests__/hydrateSlots.test.ts` — 7 pass (2 new: plumbs psnId; leaves undefined when absent)
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `cd frontend && npx vitest run src/components/events/__tests__/MatchSlots.test.tsx` — 20 pass (2 new: PSN renders in own span; omitted when absent)
- [ ] Manual on devtest: open an event with a filled slot whose player has PSN → row reads `{Wrestler} ({Name} · {PSN})`
- [ ] Manual on devtest: open an event where the player has no PSN → row reads `{Wrestler} ({Name})` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)