### PR TITLE
feat(events): show PSN on booked-match participant chips

### DIFF
--- a/frontend/src/components/events/EventDetail.css
+++ b/frontend/src/components/events/EventDetail.css
@@ -587,6 +587,12 @@
   font-weight: 400;
 }
 
+.participant-psn {
+  /* Inherits color/size from .participant-player; tabular numerals
+     keep digit-heavy gamertags aligned across stacked rows. */
+  font-feature-settings: "tnum";
+}
+
 .winner-indicator {
   font-size: 0.7rem;
   font-weight: 700;

--- a/frontend/src/components/events/EventDetail.tsx
+++ b/frontend/src/components/events/EventDetail.tsx
@@ -893,6 +893,8 @@ interface MatchEntryProps {
         playerId: string;
         playerName: string;
         wrestlerName: string;
+        /** Live PSN gamertag from the player record; undefined when unset. */
+        psnId?: string;
       }[];
       winners?: string[];
       losers?: string[];
@@ -992,7 +994,15 @@ function MatchEntry({
               className={`participant ${isWinner ? 'winner' : ''} ${isLoser ? 'loser' : ''}`}
             >
               {p.wrestlerName}
-              <span className="participant-player">({p.playerName})</span>
+              {p.psnId ? (
+                <span className="participant-player">
+                  ({p.playerName}{' · '}
+                  <span className="participant-psn">{p.psnId}</span>
+                  {')'}
+                </span>
+              ) : (
+                <span className="participant-player">({p.playerName})</span>
+              )}
               {isWinner && <span className="winner-indicator"> {t('events.detail.winner')}</span>}
             </span>
           );


### PR DESCRIPTION
## Summary
Follow-up to #360 — the slot-row PSN rendering already shipped, but the **booked-match participant chips** at the top of each match card (screenshot below) still show only `{Wrestler} ({Name})`. This PR mirrors the same `{Wrestler} ({Name} · {PSN})` format on those chips so PSN visibility is consistent across both views.

## Implementation
- Backend `participantData` already carries `psnId` (added in #360 via `getEvent.ts`); no backend change needed.
- Extends the inline `MatchEntryProps.participants` type in `EventDetail.tsx` with optional `psnId`.
- Renders PSN inside a nested `.participant-psn` span only when present, so the no-PSN render path stays byte-identical.
- New `.participant-psn` CSS inherits muted color/size from `.participant-player` and adds `font-feature-settings: "tnum"` for digit alignment.

## Test plan
- [x] `cd frontend && npx tsc --project tsconfig.app.json --noEmit` — clean
- [x] `cd frontend && npx vitest run src/components/events/__tests__` — 52 tests pass (no regressions)
- [ ] Manual on devtest: open an event with booked matches where participants have PSN on file → header chip reads `{Wrestler} ({Name} · {PSN})`
- [ ] Manual on devtest: same event with participants who have no PSN → chip reads `{Wrestler} ({Name})` (unchanged)

**No new test file** — `EventDetail.tsx` has no existing `EventDetail.test.tsx` harness, and standing one up just for a 6-line JSX change is over-scope. The slot-row analogue from #360 has direct coverage in `MatchSlots.test.tsx`.

IMP-01 follow-up on the kanban (#151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)