### PR TITLE
feat(rivalries): promos contribute to heat + admin tunables

### DIFF
--- a/backend/functions/admin/getHeatConfig.ts
+++ b/backend/functions/admin/getHeatConfig.ts
@@ -1,0 +1,18 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, serverError } from '../../lib/response';
+import { requireRole } from '../../lib/auth';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const denied = requireRole(event, 'Admin');
+  if (denied) return denied;
+
+  try {
+    const { user: { siteConfig } } = getRepositories();
+    const tunables = await siteConfig.getHeatTunables();
+    return success({ tunables });
+  } catch (error) {
+    console.error('Get heat config error:', error);
+    return serverError('Failed to load rivalry heat configuration');
+  }
+};

--- a/backend/functions/admin/handler.ts
+++ b/backend/functions/admin/handler.ts
@@ -3,6 +3,8 @@ import { handler as updateSiteConfigHandler } from './updateSiteConfig';
 import { handler as clearAllHandler } from './clearAll';
 import { handler as seedDataHandler } from './seedData';
 import { handler as exportDataHandler } from './exportData';
+import { handler as getHeatConfigHandler } from './getHeatConfig';
+import { handler as updateHeatConfigHandler } from './updateHeatConfig';
 import { createRouter, type RouteConfig } from '../../lib/router';
 
 /**
@@ -35,6 +37,16 @@ const routes: ReadonlyArray<RouteConfig> = [
     resource: '/admin/export-data',
     method: 'GET',
     handler: exportDataHandler,
+  },
+  {
+    resource: '/admin/heat-config',
+    method: 'GET',
+    handler: getHeatConfigHandler,
+  },
+  {
+    resource: '/admin/heat-config',
+    method: 'PUT',
+    handler: updateHeatConfigHandler,
   },
 ];
 

--- a/backend/functions/admin/updateHeatConfig.ts
+++ b/backend/functions/admin/updateHeatConfig.ts
@@ -1,0 +1,60 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRepositories } from '../../lib/repositories';
+import { success, badRequest, serverError } from '../../lib/response';
+import { requireRole } from '../../lib/auth';
+import { parseBody } from '../../lib/parseBody';
+import type { RivalryHeatTunables } from '../../lib/repositories/SiteConfigRepository';
+
+interface UpdateHeatConfigBody {
+  tunables: Partial<RivalryHeatTunables>;
+}
+
+// Sane bounds — keep the formula expressive without letting an admin
+// type "-999999" and brick rivalry rendering.
+const FIELD_BOUNDS: Record<keyof RivalryHeatTunables, { min: number; max: number }> = {
+  pivot: { min: 0, max: 5 },
+  maxWeight: { min: 1, max: 50 },
+  scoreCap: { min: 10, max: 500 },
+  motnMultiplier: { min: 1, max: 5 },
+  promoBase: { min: 0, max: 25 },
+  promoReactionStep: { min: 0, max: 10 },
+  promoBonusCap: { min: 0, max: 50 },
+  promoMaxReactionCount: { min: 1, max: 50 },
+};
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const denied = requireRole(event, 'Admin');
+  if (denied) return denied;
+
+  try {
+    const { data: body, error: parseError } = parseBody<UpdateHeatConfigBody>(event);
+    if (parseError) return parseError;
+    const { tunables } = body;
+
+    if (!tunables || typeof tunables !== 'object') {
+      return badRequest('tunables object is required');
+    }
+
+    const patch: Partial<RivalryHeatTunables> = {};
+    for (const [key, value] of Object.entries(tunables)) {
+      if (!(key in FIELD_BOUNDS)) {
+        return badRequest(`Unknown tunable: ${key}`);
+      }
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return badRequest(`Tunable ${key} must be a finite number`);
+      }
+      const bounds = FIELD_BOUNDS[key as keyof RivalryHeatTunables];
+      if (value < bounds.min || value > bounds.max) {
+        return badRequest(`Tunable ${key} must be between ${bounds.min} and ${bounds.max}`);
+      }
+      patch[key as keyof RivalryHeatTunables] = value;
+    }
+
+    const { user: { siteConfig } } = getRepositories();
+    const updated = await siteConfig.updateHeatTunables(patch);
+    return success({ tunables: updated });
+  } catch (error) {
+    console.error('Update heat config error:', error);
+    return serverError('Failed to update rivalry heat configuration');
+  }
+};

--- a/backend/functions/matches/__tests__/submitRating.test.ts
+++ b/backend/functions/matches/__tests__/submitRating.test.ts
@@ -14,7 +14,27 @@ const mockMatchRatingsRepo = {
   getByMatch: vi.fn(),
 };
 
+const mockPromosRepo = {
+  listByRivalry: vi.fn(),
+};
+
+const mockSiteConfigRepo = {
+  getHeatTunables: vi.fn(),
+};
+
 const mockRunInTransaction = vi.fn();
+
+// Tunables default — matches DEFAULT_HEAT_TUNABLES on the backend.
+const DEFAULT_TUNABLES = {
+  pivot: 2.5,
+  maxWeight: 5,
+  scoreCap: 100,
+  motnMultiplier: 1.5,
+  promoBase: 3,
+  promoReactionStep: 1.4,
+  promoBonusCap: 7,
+  promoMaxReactionCount: 5,
+};
 
 vi.mock('../../../lib/repositories', async () => {
   const actual = await vi.importActual<
@@ -25,6 +45,8 @@ vi.mock('../../../lib/repositories', async () => {
     getRepositories: () => ({
       competition: { matches: mockMatchesRepo },
       matchRatings: mockMatchRatingsRepo,
+      content: { promos: mockPromosRepo },
+      user: { siteConfig: mockSiteConfigRepo },
       runInTransaction: mockRunInTransaction,
     }),
   };
@@ -96,6 +118,10 @@ describe('submitRating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.IS_OFFLINE;
+    // Default empty promo set + default tunables for the heat helper.
+    // Individual tests can override these mocks.
+    mockPromosRepo.listByRivalry.mockResolvedValue([]);
+    mockSiteConfigRepo.getHeatTunables.mockResolvedValue(DEFAULT_TUNABLES);
   });
 
   it('happy path: no rivalry — averages two existing 4-star ratings plus new 5', async () => {

--- a/backend/functions/matches/setMatchOfTheNight.ts
+++ b/backend/functions/matches/setMatchOfTheNight.ts
@@ -9,7 +9,8 @@ import {
 } from '../../lib/response';
 import { requireRole } from '../../lib/auth';
 import { parseBody } from '../../lib/parseBody';
-import { computeRivalryHeat, type HeatTier } from '../../lib/policies/rivalryHeat';
+import { type HeatTier } from '../../lib/policies/rivalryHeat';
+import { computeHeatForRivalry } from '../../lib/services/recomputeRivalryHeat';
 
 interface SetMatchOfTheNightBody {
   matchOfTheNight: boolean;
@@ -79,7 +80,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           matchOfTheNight: body.matchOfTheNight,
         });
       }
-      const heat = computeRivalryHeat({ matches: projected });
+      const heat = await computeHeatForRivalry(match.rivalryId, projected);
       rivalryUpdate = {
         rivalryId: match.rivalryId,
         heatScore: heat.heatScore,

--- a/backend/functions/matches/submitRating.ts
+++ b/backend/functions/matches/submitRating.ts
@@ -2,7 +2,8 @@ import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories, RatingAlreadyExistsError } from '../../lib/repositories';
 import { getAuthContext } from '../../lib/auth';
 import { isHalfStarRating, roundToHalfStar } from '../../lib/utils/halfStar';
-import { computeRivalryHeat, type HeatTier } from '../../lib/policies/rivalryHeat';
+import { type HeatTier } from '../../lib/policies/rivalryHeat';
+import { computeHeatForRivalry } from '../../lib/services/recomputeRivalryHeat';
 import { parseBody } from '../../lib/parseBody';
 import {
   created,
@@ -104,7 +105,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           matchOfTheNight: match.matchOfTheNight === true,
         });
       }
-      const heat = computeRivalryHeat({ matches: projected });
+      const heat = await computeHeatForRivalry(match.rivalryId, projected);
       rivalryUpdate = {
         rivalryId: match.rivalryId,
         heatScore: heat.heatScore,

--- a/backend/functions/promos/__tests__/createPromo.test.ts
+++ b/backend/functions/promos/__tests__/createPromo.test.ts
@@ -257,18 +257,21 @@ describe('createPromo', () => {
     expect(body(result).message).toBe('Failed to create promo');
   });
 
-  it('persists rivalryId without validating participant membership (RIV-06)', async () => {
-    mockQuery.mockResolvedValue({
-      Items: [{ playerId: 'player-1', userId: 'user-sub-1', name: 'Test Player' }],
-    });
-    mockPut.mockResolvedValue({});
+  it('returns 404 when rivalryId is provided but the rivalry does not exist', async () => {
+    // mockQuery returns the player row on the first call (player lookup),
+    // then no rivalry rows on the second call (rivalry META lookup).
+    mockQuery
+      .mockResolvedValueOnce({
+        Items: [{ playerId: 'player-1', userId: 'user-sub-1', name: 'Test Player' }],
+      })
+      .mockResolvedValueOnce({ Items: [] });
 
     const event = withAuth(
       makeEvent({
         body: JSON.stringify({
           promoType: 'open-mic',
           content: VALID_CONTENT,
-          rivalryId: 'r1',
+          rivalryId: 'r-missing',
         }),
       }),
       'Wrestler',
@@ -276,9 +279,74 @@ describe('createPromo', () => {
 
     const result = await createPromo(event, ctx, cb);
 
-    expect(result!.statusCode).toBe(201);
-    expect(body(result).rivalryId).toBe('r1');
-    const putArg = mockPut.mock.calls[0][0];
-    expect(putArg.Item.rivalryId).toBe('r1');
+    expect(result!.statusCode).toBe(404);
+    expect(body(result).message).toBe('Rivalry not found');
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when caller is not a participant of the referenced rivalry', async () => {
+    // First query: find player. Second query: rivalry rows with a different participant.
+    mockQuery
+      .mockResolvedValueOnce({
+        Items: [{ playerId: 'player-1', userId: 'user-sub-1', name: 'Test Player' }],
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            rivalryId: 'r1',
+            recordType: 'META',
+            title: 'Storyline X',
+            status: 'active',
+            heat: 'warm',
+            heatScore: 0,
+            requestedBy: 'someone-else',
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+          {
+            rivalryId: 'r1',
+            recordType: 'PARTICIPANT#other-player',
+            participantId: 'other-player',
+            role: 'rival',
+            addedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+    const event = withAuth(
+      makeEvent({
+        body: JSON.stringify({
+          promoType: 'call-out',
+          content: VALID_CONTENT,
+          rivalryId: 'r1',
+          targetPlayerId: 'other-player',
+        }),
+      }),
+      'Wrestler',
+    );
+
+    const result = await createPromo(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(403);
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when a rivalry-type promo is submitted without rivalryId', async () => {
+    mockQuery.mockResolvedValue({
+      Items: [{ playerId: 'player-1', userId: 'user-sub-1', name: 'Test Player' }],
+    });
+
+    const event = withAuth(
+      makeEvent({
+        body: JSON.stringify({ promoType: 'rivalry', content: VALID_CONTENT }),
+      }),
+      'Wrestler',
+    );
+
+    const result = await createPromo(event, ctx, cb);
+
+    expect(result!.statusCode).toBe(400);
+    expect(body(result).message).toContain('rivalryId');
+    expect(mockPut).not.toHaveBeenCalled();
   });
 });

--- a/backend/functions/promos/createPromo.ts
+++ b/backend/functions/promos/createPromo.ts
@@ -1,12 +1,18 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
-import { created, badRequest, serverError } from '../../lib/response';
+import { created, badRequest, forbidden, notFound, serverError } from '../../lib/response';
 import { getAuthContext, hasRole } from '../../lib/auth';
 import { parseBody } from '../../lib/parseBody';
 import { createNotification } from '../../lib/notifications';
+import { recomputeRivalryHeat } from '../../lib/services/recomputeRivalryHeat';
 import type { PromoType } from '../../lib/repositories/types';
 
-const VALID_PROMO_TYPES: PromoType[] = ['open-mic', 'call-out', 'response', 'pre-match', 'post-match', 'championship', 'return'];
+const VALID_PROMO_TYPES: PromoType[] = [
+  'open-mic', 'call-out', 'response', 'pre-match', 'post-match', 'championship', 'return', 'rivalry',
+];
+
+/** Promo types whose presence affects a rivalry's heat score. */
+const HEAT_CONTRIBUTING_TYPES: ReadonlyArray<PromoType> = ['call-out', 'rivalry'];
 
 interface CreatePromoBody {
   promoType: string;
@@ -45,13 +51,30 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     if (promoType === 'response' && !targetPromoId) {
       return badRequest('Response promos must reference an existing promo (targetPromoId)');
     }
+    if (promoType === 'rivalry' && !rivalryId) {
+      return badRequest('Rivalry promos must reference a rivalry (rivalryId)');
+    }
 
-    const { content: { promos }, roster: { players } } = getRepositories();
+    const repos = getRepositories();
+    const { content: { promos }, roster: { players }, rivalries } = repos;
 
     // Find the player via user sub
     const player = await players.findByUserId(auth.sub);
     if (!player) {
       return badRequest('No player profile linked to your account');
+    }
+
+    // Validate rivalryId (when present) refers to a real rivalry that the
+    // caller participates in. Applies to any promo type carrying a
+    // rivalryId — we don't want a non-participant pinning their promo
+    // (and its heat contribution) to someone else's storyline.
+    if (rivalryId) {
+      const rivalry = await rivalries.get(rivalryId);
+      if (!rivalry) return notFound('Rivalry not found');
+      const isParticipant = rivalry.participants.some((p) => p.playerId === player.playerId);
+      if (!isParticipant) {
+        return forbidden('You can only tag a promo to a rivalry you are part of');
+      }
     }
 
     const promo = await promos.create({
@@ -80,6 +103,17 @@ export const handler: APIGatewayProxyHandler = async (event) => {
           sourceId: promo.promoId,
           sourceType: 'promo',
         });
+      }
+    }
+
+    // Push the rivalry's heat forward when this promo contributes.
+    // Failures here shouldn't roll back the promo creation — heat is
+    // eventually consistent via the admin recompute endpoint.
+    if (rivalryId && HEAT_CONTRIBUTING_TYPES.includes(promoType as PromoType)) {
+      try {
+        await recomputeRivalryHeat(rivalryId);
+      } catch (heatErr) {
+        console.error('Failed to recompute rivalry heat after promo create:', heatErr);
       }
     }
 

--- a/backend/functions/promos/deletePromo.ts
+++ b/backend/functions/promos/deletePromo.ts
@@ -2,6 +2,10 @@ import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
 import { noContent, badRequest, notFound, serverError } from '../../lib/response';
 import { requireRole } from '../../lib/auth';
+import { recomputeRivalryHeat } from '../../lib/services/recomputeRivalryHeat';
+import type { PromoType } from '../../lib/repositories/types';
+
+const HEAT_CONTRIBUTING_TYPES: ReadonlyArray<PromoType> = ['call-out', 'rivalry'];
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   const denied = requireRole(event, 'Admin', 'Moderator');
@@ -21,6 +25,16 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     await promos.delete(promoId);
+
+    // Removing a heat-contributing promo should pull the heat back down
+    // (or up, if its trash reactions were dragging it).
+    if (promo.rivalryId && HEAT_CONTRIBUTING_TYPES.includes(promo.promoType)) {
+      try {
+        await recomputeRivalryHeat(promo.rivalryId);
+      } catch (heatErr) {
+        console.error('Failed to recompute rivalry heat after promo delete:', heatErr);
+      }
+    }
 
     return noContent();
   } catch (err) {

--- a/backend/functions/promos/reactToPromo.ts
+++ b/backend/functions/promos/reactToPromo.ts
@@ -3,9 +3,16 @@ import { getRepositories } from '../../lib/repositories';
 import { success, badRequest, notFound, serverError } from '../../lib/response';
 import { parseBody } from '../../lib/parseBody';
 import { getAuthContext, requireRole } from '../../lib/auth';
-import type { ReactionType } from '../../lib/repositories/types';
+import { recomputeRivalryHeat } from '../../lib/services/recomputeRivalryHeat';
+import type { ReactionType, PromoType } from '../../lib/repositories/types';
 
 const VALID_REACTIONS: ReactionType[] = ['fire', 'mic', 'trash', 'mind-blown', 'clap'];
+
+/** Reactions that change a rivalry's heat score. */
+const HEAT_RELEVANT_REACTIONS: ReadonlyArray<ReactionType> = ['fire', 'trash'];
+
+/** Promo types whose reactions feed into rivalry heat. */
+const HEAT_CONTRIBUTING_TYPES: ReadonlyArray<PromoType> = ['call-out', 'rivalry'];
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
@@ -47,6 +54,25 @@ export const handler: APIGatewayProxyHandler = async (event) => {
         await promos.removeReaction(promoId, userId);
       }
       updatedPromo = await promos.addReaction(promoId, userId, reaction as ReactionType);
+    }
+
+    // If this reaction (or the one it replaced) moves the heat dial,
+    // recompute the rivalry's heat. We skip recompute for reaction
+    // changes that can't matter (e.g. clap → mic on a non-rivalry promo)
+    // to keep the hot path cheap.
+    const couldChangeHeat =
+      HEAT_RELEVANT_REACTIONS.includes(reaction as ReactionType) ||
+      (existingReaction !== undefined && HEAT_RELEVANT_REACTIONS.includes(existingReaction));
+    if (
+      couldChangeHeat &&
+      updatedPromo.rivalryId &&
+      HEAT_CONTRIBUTING_TYPES.includes(updatedPromo.promoType)
+    ) {
+      try {
+        await recomputeRivalryHeat(updatedPromo.rivalryId);
+      } catch (heatErr) {
+        console.error('Failed to recompute rivalry heat after reaction:', heatErr);
+      }
     }
 
     return success({ reactions: updatedPromo.reactions, reactionCounts: updatedPromo.reactionCounts });

--- a/backend/functions/rivalries/__tests__/recomputeHeat.test.ts
+++ b/backend/functions/rivalries/__tests__/recomputeHeat.test.ts
@@ -11,12 +11,33 @@ const mockMatchesRepo = {
   findByRivalryId: vi.fn(),
 };
 
+const mockPromosRepo = {
+  listByRivalry: vi.fn(),
+};
+
+const mockSiteConfigRepo = {
+  getHeatTunables: vi.fn(),
+};
+
 const mockRunInTransaction = vi.fn();
+
+const DEFAULT_TUNABLES = {
+  pivot: 2.5,
+  maxWeight: 5,
+  scoreCap: 100,
+  motnMultiplier: 1.5,
+  promoBase: 3,
+  promoReactionStep: 1.4,
+  promoBonusCap: 7,
+  promoMaxReactionCount: 5,
+};
 
 vi.mock('../../../lib/repositories', () => ({
   getRepositories: () => ({
     rivalries: mockRivalries,
     competition: { matches: mockMatchesRepo },
+    content: { promos: mockPromosRepo },
+    user: { siteConfig: mockSiteConfigRepo },
     runInTransaction: mockRunInTransaction,
   }),
 }));
@@ -47,6 +68,9 @@ describe('POST /rivalry-requests/{rivalryId}/recompute-heat', () => {
         return tx;
       },
     );
+    // Default: no promos contribute, default tunables.
+    mockPromosRepo.listByRivalry.mockResolvedValue([]);
+    mockSiteConfigRepo.getHeatTunables.mockResolvedValue(DEFAULT_TUNABLES);
   });
 
   it('rejects non-Admin/Moderator callers with 403', async () => {

--- a/backend/lib/policies/__tests__/rivalryHeat.test.ts
+++ b/backend/lib/policies/__tests__/rivalryHeat.test.ts
@@ -5,9 +5,14 @@ import {
   HEAT_SCORE_CAP,
   HEAT_TIER_CENTRES,
   MOTN_HEAT_MULTIPLIER,
+  PROMO_HEAT_BASE,
+  PROMO_REACTION_STEP,
+  PROMO_BONUS_CAP,
+  PROMO_MAX_REACTION_COUNT,
   computeRivalryHeat,
   scoreToTier,
   type RatedMatchInput,
+  type PromoHeatInput,
 } from '../rivalryHeat';
 
 const match = (avg: number, count: number, motn = false): RatedMatchInput => ({
@@ -16,12 +21,18 @@ const match = (avg: number, count: number, motn = false): RatedMatchInput => ({
   matchOfTheNight: motn,
 });
 
+const promo = (fire: number, trash: number): PromoHeatInput => ({
+  fireCount: fire,
+  trashCount: trash,
+});
+
 describe('computeRivalryHeat', () => {
   it('returns warm + 0 + 0 for an empty rivalry', () => {
     const result = computeRivalryHeat({ matches: [] });
     expect(result.heatScore).toBe(0);
     expect(result.tier).toBe('warm');
     expect(result.ratedMatchCount).toBe(0);
+    expect(result.promoCount).toBe(0);
   });
 
   it('rates a single 5★ match with 1 rating at +2.5 → warm', () => {
@@ -229,5 +240,146 @@ describe('HEAT_TIER_CENTRES', () => {
       expect(result.heatScore).toBe(HEAT_SCORE_CAP);
       expect(result.tier).toBe('scorching');
     });
+  });
+});
+
+describe('promo heat contribution', () => {
+  it('a single promo with zero reactions adds exactly PROMO_HEAT_BASE', () => {
+    const result = computeRivalryHeat({ matches: [], promos: [promo(0, 0)] });
+    expect(result.heatScore).toBeCloseTo(PROMO_HEAT_BASE);
+    expect(result.promoCount).toBe(1);
+    expect(result.ratedMatchCount).toBe(0);
+  });
+
+  it('fire reactions add PROMO_REACTION_STEP each, up to PROMO_BONUS_CAP', () => {
+    const result = computeRivalryHeat({
+      matches: [],
+      promos: [promo(PROMO_MAX_REACTION_COUNT, 0)],
+    });
+    // base + min(5 * step, cap)
+    const expectedBonus = Math.min(PROMO_MAX_REACTION_COUNT * PROMO_REACTION_STEP, PROMO_BONUS_CAP);
+    expect(result.heatScore).toBeCloseTo(PROMO_HEAT_BASE + expectedBonus);
+  });
+
+  it('trash reactions subtract PROMO_REACTION_STEP each', () => {
+    const result = computeRivalryHeat({
+      matches: [],
+      promos: [promo(0, 2)],
+    });
+    expect(result.heatScore).toBeCloseTo(PROMO_HEAT_BASE - 2 * PROMO_REACTION_STEP);
+  });
+
+  it('reactions beyond PROMO_MAX_REACTION_COUNT do not move the bonus', () => {
+    const capped = computeRivalryHeat({
+      matches: [],
+      promos: [promo(PROMO_MAX_REACTION_COUNT + 100, 0)],
+    });
+    const atCap = computeRivalryHeat({
+      matches: [],
+      promos: [promo(PROMO_MAX_REACTION_COUNT, 0)],
+    });
+    expect(capped.heatScore).toBeCloseTo(atCap.heatScore);
+  });
+
+  it('fire and trash cancel each other before the cap', () => {
+    const result = computeRivalryHeat({
+      matches: [],
+      promos: [promo(3, 3)],
+    });
+    expect(result.heatScore).toBeCloseTo(PROMO_HEAT_BASE);
+  });
+
+  it('the reaction bonus is clamped per promo to ±PROMO_BONUS_CAP', () => {
+    // Wide-but-imbalanced reactions: only the first PROMO_MAX_REACTION_COUNT count.
+    const result = computeRivalryHeat({
+      matches: [],
+      promos: [promo(PROMO_MAX_REACTION_COUNT, 0)],
+    });
+    expect(result.heatScore).toBeLessThanOrEqual(PROMO_HEAT_BASE + PROMO_BONUS_CAP);
+  });
+
+  it('multiple promos add their contributions together', () => {
+    const single = computeRivalryHeat({ matches: [], promos: [promo(2, 0)] });
+    const triple = computeRivalryHeat({
+      matches: [],
+      promos: [promo(2, 0), promo(2, 0), promo(2, 0)],
+    });
+    expect(triple.heatScore).toBeCloseTo(single.heatScore * 3);
+    expect(triple.promoCount).toBe(3);
+  });
+
+  it('promos stack with match contributions', () => {
+    const matchesOnly = computeRivalryHeat({ matches: [match(5, 5)] });
+    const both = computeRivalryHeat({ matches: [match(5, 5)], promos: [promo(0, 0)] });
+    expect(both.heatScore).toBeCloseTo(matchesOnly.heatScore + PROMO_HEAT_BASE);
+    expect(both.ratedMatchCount).toBe(1);
+    expect(both.promoCount).toBe(1);
+  });
+
+  it('promoCount is 0 when no promos are passed (back-compat)', () => {
+    const result = computeRivalryHeat({ matches: [match(5, 5)] });
+    expect(result.promoCount).toBe(0);
+  });
+
+  it('negative reaction counts are treated as zero (defensive)', () => {
+    const result = computeRivalryHeat({
+      matches: [],
+      promos: [{ fireCount: -5, trashCount: -5 }],
+    });
+    expect(result.heatScore).toBeCloseTo(PROMO_HEAT_BASE);
+  });
+});
+
+describe('HeatTunables overrides', () => {
+  it('a smaller promoBase reduces a no-reaction promo proportionally', () => {
+    const result = computeRivalryHeat(
+      { matches: [], promos: [promo(0, 0)] },
+      { promoBase: 1 },
+    );
+    expect(result.heatScore).toBeCloseTo(1);
+  });
+
+  it('a larger promoBonusCap lets the bonus exceed the default ceiling', () => {
+    const overrideCap = PROMO_BONUS_CAP * 3;
+    const result = computeRivalryHeat(
+      { matches: [], promos: [promo(PROMO_MAX_REACTION_COUNT, 0)] },
+      { promoBonusCap: overrideCap, promoReactionStep: 5 },
+    );
+    // 5 fire × step(5) = 25, clamped to overrideCap(21) -> heat = base + 21
+    expect(result.heatScore).toBeCloseTo(PROMO_HEAT_BASE + Math.min(25, overrideCap));
+  });
+
+  it('overriding pivot shifts the zero-contribution match rating', () => {
+    const baseline = computeRivalryHeat({ matches: [match(3, 5)] });
+    const shifted = computeRivalryHeat({ matches: [match(3, 5)] }, { pivot: 3 });
+    expect(baseline.heatScore).not.toBe(0);
+    expect(shifted.heatScore).toBe(0);
+  });
+
+  it('overriding maxWeight changes how much a single match dominates', () => {
+    const tight = computeRivalryHeat({ matches: [match(5, 50)] }, { maxWeight: 1 });
+    expect(tight.heatScore).toBeCloseTo(5 - HEAT_PIVOT);
+  });
+
+  it('overriding scoreCap clamps the final score to the new bound', () => {
+    const matches = Array.from({ length: 20 }, () => match(5, 5));
+    const result = computeRivalryHeat({ matches }, { scoreCap: 30 });
+    expect(result.heatScore).toBe(30);
+  });
+
+  it('overriding tierThresholds reclassifies the same heat score', () => {
+    const result = computeRivalryHeat(
+      { matches: [], promos: [promo(0, 0)] },
+      {
+        tierThresholds: [
+          { min: 1, tier: 'scorching' },
+          { min: 0, tier: 'hot' },
+          { min: -1, tier: 'warm' },
+          { min: -2, tier: 'cold' },
+          { min: -Infinity, tier: 'frozen' },
+        ],
+      },
+    );
+    expect(result.tier).toBe('scorching');
   });
 });

--- a/backend/lib/policies/rivalryHeat.ts
+++ b/backend/lib/policies/rivalryHeat.ts
@@ -1,23 +1,28 @@
 /**
- * Rivalry heat policy (RIV-21).
+ * Rivalry heat policy (RIV-21, extended for promo bonus).
  *
- * Pure, side-effect-free math that turns a list of rated matches into a
- * `heatScore` (number) and a `tier` (named bucket). Handlers in RIV-23 and
- * RIV-26 invoke this; tuning thresholds here changes the entire feature
- * without touching I/O code.
+ * Pure, side-effect-free math that turns rated matches + promos into a
+ * `heatScore` (number) and a `tier` (named bucket). Handlers invoke this;
+ * tuning thresholds here changes the entire feature without touching I/O code.
  *
- * Model:
+ * Match contribution:
  *   - Each rated match contributes `(ratingAverage - HEAT_PIVOT) * weight`.
  *   - `weight = min(ratingsCount, HEAT_MAX_WEIGHT)` so a single popular
  *     match can't run away with the score, and a single-rating match still
  *     moves the needle a little.
  *   - Matches with `ratingsCount === 0` are ignored (no signal).
- *   - The sum is clamped to ±HEAT_SCORE_CAP, then bucketed via
- *     HEAT_TIER_THRESHOLDS.
  *
- * Above-pivot ratings push the score positive (hot/scorching); below-pivot
- * ratings pull it negative (cold/frozen). A rivalry with no rated matches
- * sits at 0 → 'warm'.
+ * Promo contribution (call-out + rivalry promo types):
+ *   - Each contributing promo adds `PROMO_HEAT_BASE` plus a reaction
+ *     bonus of `(fire5 − trash5) * PROMO_REACTION_STEP`, where fireN/trashN
+ *     are the first PROMO_MAX_REACTION_COUNT reactions of each type (mirrors
+ *     the HEAT_MAX_WEIGHT cap for matches — viral promos don't run away).
+ *   - The reaction bonus is clamped to ±PROMO_BONUS_CAP per promo.
+ *
+ * The summed score is clamped to ±HEAT_SCORE_CAP, then bucketed via
+ * HEAT_TIER_THRESHOLDS. Above-pivot ratings + fire-heavy promos push the
+ * score positive (hot/scorching); below-pivot ratings + trash-heavy promos
+ * pull it negative (cold/frozen). A rivalry with no signal sits at 0 → 'warm'.
  */
 
 /** A single match's rating roll-up. */
@@ -36,15 +41,45 @@ export type RatedMatchInput = {
   matchOfTheNight?: boolean;
 };
 
+/**
+ * A single contributing promo (call-out or rivalry type, tied to a
+ * specific rivalry via `rivalryId`). Only `fire` and `trash` counts
+ * factor in — other reactions are flavor.
+ */
+export type PromoHeatInput = {
+  /** Count of `fire` reactions (clamped at PROMO_MAX_REACTION_COUNT). */
+  fireCount: number;
+  /** Count of `trash` reactions (clamped at PROMO_MAX_REACTION_COUNT). */
+  trashCount: number;
+};
+
 /** The five visible heat tiers, coldest → hottest. */
 export type HeatTier = 'frozen' | 'cold' | 'warm' | 'hot' | 'scorching';
 
-/** What the policy returns. `ratedMatchCount` is informational. */
+/** What the policy returns. `ratedMatchCount` / `promoCount` are informational. */
 export type HeatResult = {
   heatScore: number;
   tier: HeatTier;
   ratedMatchCount: number;
+  promoCount: number;
 };
+
+/**
+ * Runtime overrides for the tunables below. Any field left undefined
+ * falls back to the exported file-level constant. Admin endpoints feed
+ * a `HeatTunables` object through `computeRivalryHeat`'s second arg.
+ */
+export type HeatTunables = Partial<{
+  pivot: number;
+  maxWeight: number;
+  scoreCap: number;
+  motnMultiplier: number;
+  promoBase: number;
+  promoReactionStep: number;
+  promoBonusCap: number;
+  promoMaxReactionCount: number;
+  tierThresholds: ReadonlyArray<{ min: number; tier: HeatTier }>;
+}>;
 
 /** Neutral rating — at this average a match contributes nothing. */
 export const HEAT_PIVOT = 2.5;
@@ -61,6 +96,29 @@ export const HEAT_SCORE_CAP = 100;
  * `12.5` — enough to push a rivalry tier without dominating the score.
  */
 export const MOTN_HEAT_MULTIPLIER = 1.5;
+
+/**
+ * Base heat added per contributing promo (call-out or rivalry type with
+ * a `rivalryId`). A no-reaction promo nudges heat by exactly this much.
+ */
+export const PROMO_HEAT_BASE = 3;
+
+/** Heat added per `fire` reaction (and removed per `trash`), up to the cap. */
+export const PROMO_REACTION_STEP = 1.4;
+
+/**
+ * Max magnitude of the reaction bonus per promo. Caps a viral promo so
+ * it can't dwarf a great match — at the defaults this is ±7, so a promo
+ * tops out at `3 + 7 = 10` heat (about as much as a 5★ match × 4 votes).
+ */
+export const PROMO_BONUS_CAP = 7;
+
+/**
+ * Cap on how many reactions of each type count toward the bonus.
+ * Mirrors HEAT_MAX_WEIGHT for matches — past the cap, more reactions
+ * don't move the needle further.
+ */
+export const PROMO_MAX_REACTION_COUNT = 5;
 
 /**
  * Inclusive lower bounds for each tier. Ordered hottest → coldest so the
@@ -93,37 +151,71 @@ const clamp = (value: number, lo: number, hi: number): number =>
   Math.max(lo, Math.min(hi, value));
 
 /**
- * Resolve a raw `heatScore` to its named tier. Pure.
+ * Resolve a raw `heatScore` to its named tier. Pure. When custom
+ * `thresholds` are passed they must be ordered hottest → coldest with
+ * `-Infinity` as the final lower bound (same shape as HEAT_TIER_THRESHOLDS).
  */
-export function scoreToTier(score: number): HeatTier {
-  for (const { min, tier } of HEAT_TIER_THRESHOLDS) {
+export function scoreToTier(
+  score: number,
+  thresholds: ReadonlyArray<{ min: number; tier: HeatTier }> = HEAT_TIER_THRESHOLDS,
+): HeatTier {
+  for (const { min, tier } of thresholds) {
     if (score >= min) return tier;
   }
-  // Unreachable: the last threshold uses -Infinity as its lower bound.
+  // Unreachable when the threshold list ends at -Infinity.
   return 'frozen';
 }
 
 /**
- * Map a rivalry's rated matches to a heat score + tier.
+ * Map a rivalry's rated matches + promos to a heat score + tier.
  *
  * Pure: no I/O, no randomness, no time. Safe to call from anywhere.
+ * Pass `tunables` to override the file-level constants (used by the
+ * admin config screen so the live formula can be tweaked without a deploy).
  */
-export function computeRivalryHeat(input: {
-  matches: RatedMatchInput[];
-}): HeatResult {
+export function computeRivalryHeat(
+  input: {
+    matches: RatedMatchInput[];
+    promos?: PromoHeatInput[];
+  },
+  tunables: HeatTunables = {},
+): HeatResult {
+  const pivot = tunables.pivot ?? HEAT_PIVOT;
+  const maxWeight = tunables.maxWeight ?? HEAT_MAX_WEIGHT;
+  const scoreCap = tunables.scoreCap ?? HEAT_SCORE_CAP;
+  const motnMultiplier = tunables.motnMultiplier ?? MOTN_HEAT_MULTIPLIER;
+  const promoBase = tunables.promoBase ?? PROMO_HEAT_BASE;
+  const promoReactionStep = tunables.promoReactionStep ?? PROMO_REACTION_STEP;
+  const promoBonusCap = tunables.promoBonusCap ?? PROMO_BONUS_CAP;
+  const promoMaxReactionCount = tunables.promoMaxReactionCount ?? PROMO_MAX_REACTION_COUNT;
+  const tierThresholds = tunables.tierThresholds ?? HEAT_TIER_THRESHOLDS;
+
   let scoreSum = 0;
   let ratedMatchCount = 0;
   for (const m of input.matches) {
     if (!m || m.ratingsCount <= 0) continue;
-    const weight = Math.min(m.ratingsCount, HEAT_MAX_WEIGHT);
-    const motnMultiplier = m.matchOfTheNight ? MOTN_HEAT_MULTIPLIER : 1;
-    scoreSum += (m.ratingAverage - HEAT_PIVOT) * weight * motnMultiplier;
+    const weight = Math.min(m.ratingsCount, maxWeight);
+    const motnFactor = m.matchOfTheNight ? motnMultiplier : 1;
+    scoreSum += (m.ratingAverage - pivot) * weight * motnFactor;
     ratedMatchCount += 1;
   }
-  const heatScore = clamp(scoreSum, -HEAT_SCORE_CAP, HEAT_SCORE_CAP);
+
+  let promoCount = 0;
+  for (const p of input.promos ?? []) {
+    if (!p) continue;
+    const fire = Math.min(Math.max(0, p.fireCount), promoMaxReactionCount);
+    const trash = Math.min(Math.max(0, p.trashCount), promoMaxReactionCount);
+    const rawBonus = (fire - trash) * promoReactionStep;
+    const bonus = clamp(rawBonus, -promoBonusCap, promoBonusCap);
+    scoreSum += promoBase + bonus;
+    promoCount += 1;
+  }
+
+  const heatScore = clamp(scoreSum, -scoreCap, scoreCap);
   return {
     heatScore,
-    tier: scoreToTier(heatScore),
+    tier: scoreToTier(heatScore, tierThresholds),
     ratedMatchCount,
+    promoCount,
   };
 }

--- a/backend/lib/repositories/ContentRepository.ts
+++ b/backend/lib/repositories/ContentRepository.ts
@@ -93,6 +93,11 @@ export interface PromosMethods {
   list(): Promise<Promo[]>;
   listByPlayer(playerId: string): Promise<Promo[]>;
   listByType(promoType: PromoType): Promise<Promo[]>;
+  /**
+   * All promos tagged to a given rivalry. Powers the rivalry-heat
+   * recompute path so promos contribute to a rivalry's score.
+   */
+  listByRivalry(rivalryId: string): Promise<Promo[]>;
   listResponsesTo(targetPromoId: string): Promise<Promo[]>;
   create(input: PromoCreateInput): Promise<Promo>;
   update(promoId: string, patch: Partial<Promo>): Promise<Promo>;

--- a/backend/lib/repositories/SiteConfigRepository.ts
+++ b/backend/lib/repositories/SiteConfigRepository.ts
@@ -16,7 +16,46 @@ export const DEFAULT_FEATURES: FeatureFlags = {
   rivalries: true,
 };
 
+/**
+ * Admin-tunable knobs for the rivalry-heat formula. These mirror the
+ * exported constants in `backend/lib/policies/rivalryHeat.ts`; setting
+ * any of them overrides the file default at runtime so the formula
+ * can be retuned without a deploy. Read by `computeRivalryHeat`'s
+ * second argument.
+ */
+export interface RivalryHeatTunables {
+  /** Neutral match rating — at this average a match contributes zero. */
+  pivot: number;
+  /** Max ratings count that can amplify a single match's weight. */
+  maxWeight: number;
+  /** Bounds for the final heatScore (both directions). */
+  scoreCap: number;
+  /** Multiplier applied to a Match-of-the-Night's contribution. */
+  motnMultiplier: number;
+  /** Base heat per contributing promo (call-out or rivalry type). */
+  promoBase: number;
+  /** Heat per fire reaction (and per trash reaction, inverted). */
+  promoReactionStep: number;
+  /** Max magnitude of the reaction bonus per promo. */
+  promoBonusCap: number;
+  /** Max reactions of each type that count toward the bonus. */
+  promoMaxReactionCount: number;
+}
+
+export const DEFAULT_HEAT_TUNABLES: RivalryHeatTunables = {
+  pivot: 2.5,
+  maxWeight: 5,
+  scoreCap: 100,
+  motnMultiplier: 1.5,
+  promoBase: 3,
+  promoReactionStep: 1.4,
+  promoBonusCap: 7,
+  promoMaxReactionCount: 5,
+};
+
 export interface SiteConfigRepository {
   getFeatures(): Promise<FeatureFlags>;
   updateFeatures(patch: Partial<FeatureFlags>): Promise<FeatureFlags>;
+  getHeatTunables(): Promise<RivalryHeatTunables>;
+  updateHeatTunables(patch: Partial<RivalryHeatTunables>): Promise<RivalryHeatTunables>;
 }

--- a/backend/lib/repositories/UserRepository.ts
+++ b/backend/lib/repositories/UserRepository.ts
@@ -7,7 +7,7 @@ import type {
   FantasyPick,
   WrestlerCost,
 } from './types';
-import type { FeatureFlags } from './SiteConfigRepository';
+import type { FeatureFlags, RivalryHeatTunables } from './SiteConfigRepository';
 
 // ─── Notification types ─────────────────────────────────────────────
 
@@ -87,6 +87,8 @@ export interface FantasyMethods {
 export interface SiteConfigMethods {
   getFeatures(): Promise<FeatureFlags>;
   updateFeatures(patch: Partial<FeatureFlags>): Promise<FeatureFlags>;
+  getHeatTunables(): Promise<RivalryHeatTunables>;
+  updateHeatTunables(patch: Partial<RivalryHeatTunables>): Promise<RivalryHeatTunables>;
 }
 
 // ─── Aggregate interface ────────────────────────────────────────────

--- a/backend/lib/repositories/dynamo/DynamoContentRepository.ts
+++ b/backend/lib/repositories/dynamo/DynamoContentRepository.ts
@@ -287,6 +287,19 @@ function buildPromosMethods(): PromosMethods {
       return promos;
     },
 
+    async listByRivalry(rivalryId: string): Promise<Promo[]> {
+      // No GSI on rivalryId (yet); promo volume per rivalry is small,
+      // so a filtered scan is fine. Mirrors `listResponsesTo`.
+      const items = await dynamoDb.scanAll({
+        TableName: TableNames.PROMOS,
+        FilterExpression: 'rivalryId = :rid',
+        ExpressionAttributeValues: { ':rid': rivalryId },
+      });
+      const promos = items as unknown as Promo[];
+      promos.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      return promos;
+    },
+
     async create(input: PromoCreateInput): Promise<Promo> {
       const now = new Date().toISOString();
       const item: Promo = {

--- a/backend/lib/repositories/dynamo/DynamoUserRepository.ts
+++ b/backend/lib/repositories/dynamo/DynamoUserRepository.ts
@@ -21,8 +21,8 @@ import type {
   FantasyPick,
   WrestlerCost,
 } from '../types';
-import type { FeatureFlags } from '../SiteConfigRepository';
-import { DEFAULT_FEATURES } from '../SiteConfigRepository';
+import type { FeatureFlags, RivalryHeatTunables } from '../SiteConfigRepository';
+import { DEFAULT_FEATURES, DEFAULT_HEAT_TUNABLES } from '../SiteConfigRepository';
 import type { CrudRepository } from '../CrudRepository';
 
 // ─── Notifications sub-object ──────────────────────────────────────
@@ -467,6 +467,35 @@ class SiteConfigDelegate implements SiteConfigMethods {
       Item: {
         configKey: 'features',
         features: updated,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    return updated;
+  }
+
+  async getHeatTunables(): Promise<RivalryHeatTunables> {
+    const result = await dynamoDb.get({
+      TableName: TableNames.SITE_CONFIG,
+      Key: { configKey: 'rivalryHeatTunables' },
+    });
+
+    const stored = result.Item?.tunables as Partial<RivalryHeatTunables> | undefined;
+    // Merge so missing fields fall back to defaults — keeps the formula
+    // working even after we add a new tunable that older stored configs
+    // don't have yet.
+    return { ...DEFAULT_HEAT_TUNABLES, ...(stored ?? {}) };
+  }
+
+  async updateHeatTunables(patch: Partial<RivalryHeatTunables>): Promise<RivalryHeatTunables> {
+    const current = await this.getHeatTunables();
+    const updated = { ...current, ...patch };
+
+    await dynamoDb.put({
+      TableName: TableNames.SITE_CONFIG,
+      Item: {
+        configKey: 'rivalryHeatTunables',
+        tunables: updated,
         updatedAt: new Date().toISOString(),
       },
     });

--- a/backend/lib/repositories/inMemory/InMemoryContentRepository.ts
+++ b/backend/lib/repositories/inMemory/InMemoryContentRepository.ts
@@ -197,6 +197,12 @@ class PromosImpl implements PromosMethods {
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 
+  async listByRivalry(rivalryId: string): Promise<Promo[]> {
+    return Array.from(this.store.values())
+      .filter((p) => p.rivalryId === rivalryId)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }
+
   async create(input: PromoCreateInput): Promise<Promo> {
     const now = new Date().toISOString();
     const item: Promo = {

--- a/backend/lib/repositories/inMemory/InMemoryUserRepository.ts
+++ b/backend/lib/repositories/inMemory/InMemoryUserRepository.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { NotFoundError } from '../errors';
-import type { FeatureFlags } from '../SiteConfigRepository';
-import { DEFAULT_FEATURES } from '../SiteConfigRepository';
+import type { FeatureFlags, RivalryHeatTunables } from '../SiteConfigRepository';
+import { DEFAULT_FEATURES, DEFAULT_HEAT_TUNABLES } from '../SiteConfigRepository';
 import type {
   UserRepository,
   NotificationPage,
@@ -314,6 +314,7 @@ class FantasyImpl implements FantasyMethods {
 
 class SiteConfigImpl implements SiteConfigMethods {
   features: FeatureFlags = { ...DEFAULT_FEATURES };
+  heatTunables: RivalryHeatTunables = { ...DEFAULT_HEAT_TUNABLES };
 
   async getFeatures(): Promise<FeatureFlags> {
     return { ...this.features };
@@ -322,6 +323,15 @@ class SiteConfigImpl implements SiteConfigMethods {
   async updateFeatures(patch: Partial<FeatureFlags>): Promise<FeatureFlags> {
     this.features = { ...this.features, ...patch };
     return { ...this.features };
+  }
+
+  async getHeatTunables(): Promise<RivalryHeatTunables> {
+    return { ...this.heatTunables };
+  }
+
+  async updateHeatTunables(patch: Partial<RivalryHeatTunables>): Promise<RivalryHeatTunables> {
+    this.heatTunables = { ...this.heatTunables, ...patch };
+    return { ...this.heatTunables };
   }
 }
 

--- a/backend/lib/repositories/types.ts
+++ b/backend/lib/repositories/types.ts
@@ -363,7 +363,7 @@ export interface EventCheckIn {
   ttl?: number;
 }
 
-export type PromoType = 'open-mic' | 'call-out' | 'response' | 'pre-match' | 'post-match' | 'championship' | 'return';
+export type PromoType = 'open-mic' | 'call-out' | 'response' | 'pre-match' | 'post-match' | 'championship' | 'return' | 'rivalry';
 export type ReactionType = 'fire' | 'mic' | 'trash' | 'mind-blown' | 'clap';
 
 export interface Promo {

--- a/backend/lib/services/__tests__/recomputeRivalryHeat.test.ts
+++ b/backend/lib/services/__tests__/recomputeRivalryHeat.test.ts
@@ -6,14 +6,36 @@ const mockMatchesRepo = {
   findByRivalryId: vi.fn(),
 };
 
+const mockPromosRepo = {
+  listByRivalry: vi.fn(),
+};
+
+const mockSiteConfigRepo = {
+  getHeatTunables: vi.fn(),
+};
+
 const mockRunInTransaction = vi.fn();
 
 vi.mock('../../repositories', () => ({
   getRepositories: () => ({
     competition: { matches: mockMatchesRepo },
+    content: { promos: mockPromosRepo },
+    user: { siteConfig: mockSiteConfigRepo },
     runInTransaction: mockRunInTransaction,
   }),
 }));
+
+// Tunables default — matches DEFAULT_HEAT_TUNABLES on the backend.
+const DEFAULT_TUNABLES = {
+  pivot: 2.5,
+  maxWeight: 5,
+  scoreCap: 100,
+  motnMultiplier: 1.5,
+  promoBase: 3,
+  promoReactionStep: 1.4,
+  promoBonusCap: 7,
+  promoMaxReactionCount: 5,
+};
 
 import { recomputeRivalryHeat } from '../recomputeRivalryHeat';
 import type { UnitOfWork } from '../../repositories/unitOfWork';
@@ -44,6 +66,10 @@ function stubOwnTransaction(): { tx: TxRecord } {
 describe('recomputeRivalryHeat', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no promos contribute, default tunables. Individual tests
+    // can override these mocks before calling recomputeRivalryHeat.
+    mockPromosRepo.listByRivalry.mockResolvedValue([]);
+    mockSiteConfigRepo.getHeatTunables.mockResolvedValue(DEFAULT_TUNABLES);
   });
 
   it('opens its own transaction when no tx is supplied and stages the rivalry update', async () => {
@@ -109,9 +135,110 @@ describe('recomputeRivalryHeat', () => {
 
     const result = await recomputeRivalryHeat('riv-empty');
 
-    expect(result).toEqual({ heatScore: 0, heat: 'warm', ratedMatchCount: 0 });
+    expect(result).toEqual({ heatScore: 0, heat: 'warm', ratedMatchCount: 0, promoCount: 0 });
     expect(tx.updateRivalry).toHaveBeenCalledWith('riv-empty', {
       heatScore: 0,
+      heat: 'warm',
+    });
+  });
+
+  it('folds in call-out + rivalry promos and reports promoCount', async () => {
+    const { tx } = stubOwnTransaction();
+    mockMatchesRepo.findByRivalryId.mockResolvedValueOnce([]);
+    mockPromosRepo.listByRivalry.mockResolvedValueOnce([
+      {
+        promoId: 'p1',
+        promoType: 'call-out',
+        rivalryId: 'riv-p',
+        reactionCounts: { fire: 2, trash: 0, mic: 0, 'mind-blown': 0, clap: 0 },
+        isHidden: false,
+      },
+      {
+        promoId: 'p2',
+        promoType: 'rivalry',
+        rivalryId: 'riv-p',
+        reactionCounts: { fire: 0, trash: 1, mic: 0, 'mind-blown': 0, clap: 0 },
+        isHidden: false,
+      },
+    ]);
+
+    const result = await recomputeRivalryHeat('riv-p');
+
+    expect(result.promoCount).toBe(2);
+    // 2 promos × base(3) = 6; reactions: +(2*1.4) − (1*1.4) = +1.4
+    expect(result.heatScore).toBeCloseTo(6 + 1.4);
+    expect(tx.updateRivalry).toHaveBeenCalledWith('riv-p', {
+      heatScore: result.heatScore,
+      heat: result.heat,
+    });
+  });
+
+  it('ignores non-contributing promo types', async () => {
+    const { tx } = stubOwnTransaction();
+    mockMatchesRepo.findByRivalryId.mockResolvedValueOnce([]);
+    mockPromosRepo.listByRivalry.mockResolvedValueOnce([
+      // 'open-mic' is tagged to a rivalry for context but doesn't move heat.
+      {
+        promoId: 'p-omn',
+        promoType: 'open-mic',
+        rivalryId: 'riv-x',
+        reactionCounts: { fire: 5, trash: 0, mic: 0, 'mind-blown': 0, clap: 0 },
+        isHidden: false,
+      },
+    ]);
+
+    const result = await recomputeRivalryHeat('riv-x');
+
+    expect(result.promoCount).toBe(0);
+    expect(result.heatScore).toBe(0);
+    expect(tx.updateRivalry).toHaveBeenCalledWith('riv-x', {
+      heatScore: 0,
+      heat: 'warm',
+    });
+  });
+
+  it('skips hidden promos so admins can mute a viral promo from heat', async () => {
+    const { tx } = stubOwnTransaction();
+    mockMatchesRepo.findByRivalryId.mockResolvedValueOnce([]);
+    mockPromosRepo.listByRivalry.mockResolvedValueOnce([
+      {
+        promoId: 'p-hidden',
+        promoType: 'call-out',
+        rivalryId: 'riv-h',
+        reactionCounts: { fire: 5, trash: 0, mic: 0, 'mind-blown': 0, clap: 0 },
+        isHidden: true,
+      },
+    ]);
+
+    const result = await recomputeRivalryHeat('riv-h');
+
+    expect(result.promoCount).toBe(0);
+    expect(result.heatScore).toBe(0);
+    expect(tx.updateRivalry).toHaveBeenCalled();
+  });
+
+  it('respects admin-overridden tunables (promoBase) from siteConfig', async () => {
+    const { tx } = stubOwnTransaction();
+    mockMatchesRepo.findByRivalryId.mockResolvedValueOnce([]);
+    mockPromosRepo.listByRivalry.mockResolvedValueOnce([
+      {
+        promoId: 'p1',
+        promoType: 'call-out',
+        rivalryId: 'riv-t',
+        reactionCounts: { fire: 0, trash: 0, mic: 0, 'mind-blown': 0, clap: 0 },
+        isHidden: false,
+      },
+    ]);
+    mockSiteConfigRepo.getHeatTunables.mockResolvedValueOnce({
+      ...DEFAULT_TUNABLES,
+      promoBase: 9,
+    });
+
+    const result = await recomputeRivalryHeat('riv-t');
+
+    expect(result.heatScore).toBeCloseTo(9);
+    expect(tx.updateRivalry).toHaveBeenCalledWith('riv-t', {
+      heatScore: 9,
       heat: 'warm',
     });
   });

--- a/backend/lib/services/recomputeRivalryHeat.ts
+++ b/backend/lib/services/recomputeRivalryHeat.ts
@@ -1,37 +1,87 @@
 import type { UnitOfWork } from '../repositories/unitOfWork';
 import { getRepositories } from '../repositories';
-import { computeRivalryHeat, type HeatTier } from '../policies/rivalryHeat';
+import {
+  computeRivalryHeat,
+  type HeatTier,
+  type HeatResult,
+  type RatedMatchInput,
+  type PromoHeatInput,
+  type HeatTunables,
+} from '../policies/rivalryHeat';
+import type { Promo } from '../repositories/types';
 
 export interface RecomputeRivalryHeatResult {
   heatScore: number;
   heat: HeatTier;
   ratedMatchCount: number;
+  promoCount: number;
+}
+
+/**
+ * Map a `Promo` to the policy's reaction-only input shape. Only
+ * 'call-out' and 'rivalry' promo types contribute to heat — other
+ * types may carry a `rivalryId` for context, but they don't change
+ * the score. Promos without a `rivalryId` never reach this function.
+ */
+const PROMO_TYPES_CONTRIBUTING_TO_HEAT: ReadonlyArray<Promo['promoType']> = [
+  'call-out',
+  'rivalry',
+];
+
+function promoToHeatInput(promo: Promo): PromoHeatInput | null {
+  if (!PROMO_TYPES_CONTRIBUTING_TO_HEAT.includes(promo.promoType)) return null;
+  if (promo.isHidden) return null;
+  return {
+    fireCount: promo.reactionCounts?.fire ?? 0,
+    trashCount: promo.reactionCounts?.trash ?? 0,
+  };
+}
+
+/**
+ * Compute a rivalry's heat from a caller-supplied `matches` projection
+ * plus the rivalry's persisted promos + the live admin tunables.
+ *
+ * `matches` is provided by the caller because the inline submit-rating
+ * flow needs to project an in-flight rating that isn't committed yet.
+ * The recompute path (below) builds it from persisted aggregates.
+ *
+ * Pure-ish: only reads (promos + tunables); no writes.
+ */
+export async function computeHeatForRivalry(
+  rivalryId: string,
+  matches: RatedMatchInput[],
+): Promise<HeatResult> {
+  const repos = getRepositories();
+  const [promos, tunables] = await Promise.all([
+    repos.content.promos.listByRivalry(rivalryId),
+    repos.user.siteConfig.getHeatTunables(),
+  ]);
+  const promoInputs = promos
+    .map(promoToHeatInput)
+    .filter((p): p is PromoHeatInput => p !== null);
+  const tunablesOverride: HeatTunables = { ...tunables };
+  return computeRivalryHeat({ matches, promos: promoInputs }, tunablesOverride);
 }
 
 /**
  * Recompute a rivalry's heat from the values currently persisted on its
- * matches' rating aggregates. RIV-26.
+ * matches' rating aggregates plus its promos. RIV-26 + promo-heat extension.
  *
  * Use this from:
  *   - The backfill script (`scripts/backfill-rivalry-heat.ts`)
  *   - The admin recompute endpoint
  *     (`POST /rivalry-requests/{rivalryId}/recompute-heat`)
- *   - Any future post-commit healing flow (e.g. a sweep after a manual
- *     match edit)
+ *   - `createPromo` / `reactToPromo` (promo-driven heat changes)
+ *   - Any future post-commit healing flow
  *
- * **NOT** used by `submitRating` — that handler must project the
- * *in-flight* rating values for the match being rated (because the
- * rating hasn't been committed yet at projection time). Mixing the two
- * use cases would either re-read stale aggregates or require a more
- * complex override-shape API; the duplication is intentional and tiny.
+ * The submit-rating handler still projects in-flight match aggregates
+ * inline via `computeHeatForRivalry` because the new rating isn't
+ * committed at projection time.
  *
  * When `tx` is provided, the rivalry write is staged on the supplied
  * UnitOfWork so the caller can combine the recompute with other writes
  * in a single transaction. When `tx` is omitted, the helper opens its
  * own `runInTransaction` and flushes immediately.
- *
- * Either way, the freshly-computed heat values are returned so the
- * caller can log / surface them without an extra read.
  */
 export async function recomputeRivalryHeat(
   rivalryId: string,
@@ -39,12 +89,13 @@ export async function recomputeRivalryHeat(
 ): Promise<RecomputeRivalryHeatResult> {
   const repos = getRepositories();
   const matches = await repos.competition.matches.findByRivalryId(rivalryId);
-  const ratedInputs = matches.map((m) => ({
+  const ratedInputs: RatedMatchInput[] = matches.map((m) => ({
     ratingAverage: m.ratingAverage ?? 0,
     ratingsCount: m.ratingsCount ?? 0,
     matchOfTheNight: m.matchOfTheNight === true,
   }));
-  const result = computeRivalryHeat({ matches: ratedInputs });
+
+  const result = await computeHeatForRivalry(rivalryId, ratedInputs);
   const patch = { heatScore: result.heatScore, heat: result.tier };
 
   if (tx) {
@@ -59,5 +110,6 @@ export async function recomputeRivalryHeat(
     heatScore: result.heatScore,
     heat: result.tier,
     ratedMatchCount: result.ratedMatchCount,
+    promoCount: result.promoCount,
   };
 }

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -300,6 +300,16 @@ functions:
           method: get
           cors: *corsConfig
           authorizer: adminAuthorizer
+      - http:
+          path: admin/heat-config
+          method: get
+          cors: *corsConfig
+          authorizer: adminAuthorizer
+      - http:
+          path: admin/heat-config
+          method: put
+          cors: *corsConfig
+          authorizer: adminAuthorizer
 
   # Players (Phase 2 consolidated: getPlayers, createPlayer, updatePlayer, deletePlayer, getMyProfile, updateMyProfile)
   players:

--- a/frontend/src/components/admin/AdminHeatConfig.tsx
+++ b/frontend/src/components/admin/AdminHeatConfig.tsx
@@ -1,0 +1,233 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { siteConfigApi, type RivalryHeatTunables } from '../../services/api/siteConfig.api';
+import './AdminContenderConfig.css';
+
+/**
+ * Mirrors `DEFAULT_HEAT_TUNABLES` on the backend. Used as the initial
+ * form state until the API responds, and as the "reset" target.
+ */
+const DEFAULTS: RivalryHeatTunables = {
+  pivot: 2.5,
+  maxWeight: 5,
+  scoreCap: 100,
+  motnMultiplier: 1.5,
+  promoBase: 3,
+  promoReactionStep: 1.4,
+  promoBonusCap: 7,
+  promoMaxReactionCount: 5,
+};
+
+interface FieldSpec {
+  key: keyof RivalryHeatTunables;
+  labelKey: string;
+  labelFallback: string;
+  hintKey: string;
+  hintFallback: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+const FIELDS: FieldSpec[] = [
+  {
+    key: 'pivot',
+    labelKey: 'admin.heatConfig.pivot',
+    labelFallback: 'Match rating pivot',
+    hintKey: 'admin.heatConfig.pivotHint',
+    hintFallback: 'Ratings above this value push heat positive; below pulls it negative. (0–5)',
+    min: 0,
+    max: 5,
+    step: 0.5,
+  },
+  {
+    key: 'maxWeight',
+    labelKey: 'admin.heatConfig.maxWeight',
+    labelFallback: 'Max match weight',
+    hintKey: 'admin.heatConfig.maxWeightHint',
+    hintFallback: 'Cap on how many ratings amplify a single match.',
+    min: 1,
+    max: 50,
+    step: 1,
+  },
+  {
+    key: 'scoreCap',
+    labelKey: 'admin.heatConfig.scoreCap',
+    labelFallback: 'Heat score cap (±)',
+    hintKey: 'admin.heatConfig.scoreCapHint',
+    hintFallback: 'Final heat score is clamped to ±this value.',
+    min: 10,
+    max: 500,
+    step: 10,
+  },
+  {
+    key: 'motnMultiplier',
+    labelKey: 'admin.heatConfig.motnMultiplier',
+    labelFallback: 'Match-of-the-Night multiplier',
+    hintKey: 'admin.heatConfig.motnMultiplierHint',
+    hintFallback: 'How much a MOTN match\'s contribution is multiplied.',
+    min: 1,
+    max: 5,
+    step: 0.1,
+  },
+  {
+    key: 'promoBase',
+    labelKey: 'admin.heatConfig.promoBase',
+    labelFallback: 'Promo base bonus',
+    hintKey: 'admin.heatConfig.promoBaseHint',
+    hintFallback: 'Heat added per call-out or rivalry promo (before reactions).',
+    min: 0,
+    max: 25,
+    step: 0.5,
+  },
+  {
+    key: 'promoReactionStep',
+    labelKey: 'admin.heatConfig.promoReactionStep',
+    labelFallback: 'Per-reaction step',
+    hintKey: 'admin.heatConfig.promoReactionStepHint',
+    hintFallback: 'Heat per fire reaction (subtracted per trash).',
+    min: 0,
+    max: 10,
+    step: 0.1,
+  },
+  {
+    key: 'promoBonusCap',
+    labelKey: 'admin.heatConfig.promoBonusCap',
+    labelFallback: 'Reaction bonus cap (±)',
+    hintKey: 'admin.heatConfig.promoBonusCapHint',
+    hintFallback: 'Max magnitude of the reaction bonus per promo.',
+    min: 0,
+    max: 50,
+    step: 0.5,
+  },
+  {
+    key: 'promoMaxReactionCount',
+    labelKey: 'admin.heatConfig.promoMaxReactionCount',
+    labelFallback: 'Reactions counted per type',
+    hintKey: 'admin.heatConfig.promoMaxReactionCountHint',
+    hintFallback: 'Only the first N fire / trash reactions affect the bonus.',
+    min: 1,
+    max: 50,
+    step: 1,
+  },
+];
+
+export default function AdminHeatConfig() {
+  const { t } = useTranslation();
+  const [tunables, setTunables] = useState<RivalryHeatTunables>(DEFAULTS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    siteConfigApi
+      .getHeatTunables(controller.signal)
+      .then((res) => setTunables(res.tunables))
+      .catch(() => {
+        // Fall through to DEFAULTS on load failure; admin can still save.
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, []);
+
+  const handleChange = (key: keyof RivalryHeatTunables, value: string) => {
+    const num = parseFloat(value);
+    if (Number.isNaN(num)) return;
+    setTunables((prev) => ({ ...prev, [key]: num }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await siteConfigApi.updateHeatTunables(tunables);
+      setTunables(res.tunables);
+      setMessage({
+        type: 'success',
+        text: t('admin.heatConfig.savedMessage', 'Rivalry heat tunables saved. New rivalry writes will use these values.'),
+      });
+      setTimeout(() => setMessage(null), 5000);
+    } catch (err) {
+      setMessage({
+        type: 'error',
+        text: err instanceof Error ? err.message : 'Failed to save heat tunables',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    setTunables(DEFAULTS);
+    setMessage(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="admin-contender-config">
+        <h3>{t('admin.heatConfig.title', 'Rivalry Heat Tunables')}</h3>
+        <p>{t('common.loading', 'Loading...')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="admin-contender-config">
+      <h3>{t('admin.heatConfig.title', 'Rivalry Heat Tunables')}</h3>
+      <p className="config-subtitle">
+        {t(
+          'admin.heatConfig.subtitle',
+          'Tune the rivalry heat formula. Changes apply on the next rivalry write (match rating, promo create, manual recompute).',
+        )}
+      </p>
+
+      <div className="config-fields">
+        {FIELDS.map((field) => (
+          <div className="config-field" key={field.key}>
+            <label className="config-label" htmlFor={`heat-${field.key}`}>
+              {t(field.labelKey, field.labelFallback)}
+            </label>
+            <input
+              id={`heat-${field.key}`}
+              type="number"
+              className="config-input"
+              value={tunables[field.key]}
+              onChange={(e) => handleChange(field.key, e.target.value)}
+              min={field.min}
+              max={field.max}
+              step={field.step}
+            />
+            <span className="config-hint">{t(field.hintKey, field.hintFallback)}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="config-actions">
+        <button className="btn-recalculate" onClick={handleSave} disabled={saving}>
+          {saving
+            ? t('common.saving', 'Saving...')
+            : t('admin.heatConfig.save', 'Save Heat Tunables')}
+        </button>
+        <button
+          type="button"
+          className="btn-recalculate"
+          style={{ marginLeft: '0.5rem', background: '#374151' }}
+          onClick={handleReset}
+          disabled={saving}
+        >
+          {t('admin.heatConfig.reset', 'Reset to Defaults')}
+        </button>
+      </div>
+
+      {message && (
+        <div
+          className={message.type === 'success' ? 'save-success-msg' : 'save-error-msg'}
+          style={message.type === 'error' ? { color: '#f87171', marginTop: '0.5rem' } : { marginTop: '0.5rem' }}
+        >
+          {message.text}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminPanel.tsx
+++ b/frontend/src/components/admin/AdminPanel.tsx
@@ -32,10 +32,11 @@ import ManageOveralls from './ManageOveralls';
 import ManageTransfers from './ManageTransfers';
 import ManageStorylineRequests from './ManageStorylineRequests';
 import AdminRivalries from './AdminRivalries';
+import AdminHeatConfig from './AdminHeatConfig';
 
-type AdminTab = 'players' | 'divisions' | 'wrestlers' | 'match-config' | 'schedule' | 'championships' | 'tournaments' | 'promos' | 'seasons' | 'season-awards' | 'events' | 'contender-config' | 'contender-overrides' | 'companies' | 'locations' | 'shows' | 'factions' | 'tag-teams' | 'announcements' | 'videos' | 'overalls' | 'transfers' | 'storyline-requests' | 'rivalries' | 'danger' | 'users' | 'features';
+type AdminTab = 'players' | 'divisions' | 'wrestlers' | 'match-config' | 'schedule' | 'championships' | 'tournaments' | 'promos' | 'seasons' | 'season-awards' | 'events' | 'contender-config' | 'contender-overrides' | 'companies' | 'locations' | 'shows' | 'factions' | 'tag-teams' | 'announcements' | 'videos' | 'overalls' | 'transfers' | 'storyline-requests' | 'rivalries' | 'heat-config' | 'danger' | 'users' | 'features';
 
-const VALID_TABS: AdminTab[] = ['players', 'divisions', 'wrestlers', 'match-config', 'schedule', 'championships', 'tournaments', 'promos', 'seasons', 'season-awards', 'events', 'contender-config', 'contender-overrides', 'companies', 'locations', 'shows', 'factions', 'tag-teams', 'announcements', 'videos', 'overalls', 'transfers', 'storyline-requests', 'rivalries', 'danger', 'users', 'features'];
+const VALID_TABS: AdminTab[] = ['players', 'divisions', 'wrestlers', 'match-config', 'schedule', 'championships', 'tournaments', 'promos', 'seasons', 'season-awards', 'events', 'contender-config', 'contender-overrides', 'companies', 'locations', 'shows', 'factions', 'tag-teams', 'announcements', 'videos', 'overalls', 'transfers', 'storyline-requests', 'rivalries', 'heat-config', 'danger', 'users', 'features'];
 
 
 export default function AdminPanel() {
@@ -98,6 +99,7 @@ export default function AdminPanel() {
     transfers: <ManageTransfers />,
     'storyline-requests': <ManageStorylineRequests />,
     rivalries: <AdminRivalries />,
+    'heat-config': <AdminHeatConfig />,
     danger: <ClearAllData />,
   };
 

--- a/frontend/src/components/admin/AdminRivalries.tsx
+++ b/frontend/src/components/admin/AdminRivalries.tsx
@@ -173,14 +173,19 @@ export default function AdminRivalries() {
     <div className="admin-rivalries">
       <header className="admin-rivalries__header">
         <h2>{t('rivalries.admin.heading')}</h2>
-        <button
-          type="button"
-          className="admin-rivalries__bulk"
-          disabled={resolvedCount === 0}
-          onClick={() => setModal({ action: 'bulk-clear', bulkCount: resolvedCount })}
-        >
-          {t('rivalries.admin.bulkClear')} ({resolvedCount})
-        </button>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <Link to="/admin/heat-config" className="admin-rivalries__bulk" style={{ textDecoration: 'none' }}>
+            {t('admin.panel.tabs.heatConfig', 'Heat Tunables')}
+          </Link>
+          <button
+            type="button"
+            className="admin-rivalries__bulk"
+            disabled={resolvedCount === 0}
+            onClick={() => setModal({ action: 'bulk-clear', bulkCount: resolvedCount })}
+          >
+            {t('rivalries.admin.bulkClear')} ({resolvedCount})
+          </button>
+        </div>
       </header>
 
       <div className="admin-rivalries__chips" role="toolbar">

--- a/frontend/src/components/promos/PromoCard.tsx
+++ b/frontend/src/components/promos/PromoCard.tsx
@@ -25,6 +25,7 @@ const PROMO_TYPE_COLORS: Record<PromoType, string> = {
   'post-match': '#10b981',
   championship: '#d4af37',
   return: '#ec4899',
+  rivalry: '#a855f7',
 };
 
 function getInitial(name: string): string {

--- a/frontend/src/components/promos/PromoEditor.tsx
+++ b/frontend/src/components/promos/PromoEditor.tsx
@@ -3,8 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams, useLocation } from 'react-router-dom';
 import { PromoType, PromoWithContext } from '../../types/promo';
 import { playersApi, promosApi, championshipsApi, matchesApi, challengesApi, stipulationsApi, matchTypesApi, tagTeamsApi } from '../../services/api';
+import { rivalriesApi } from '../../services/api/rivalries.api';
 import type { Player, Match, Championship, Stipulation, MatchType } from '../../types';
 import type { TagTeam } from '../../types/tagTeam';
+import type { Rivalry } from '../../types/rivalry';
 import { useSiteConfig } from '../../contexts/SiteConfigContext';
 import PromoCard from './PromoCard';
 import './PromoEditor.css';
@@ -59,6 +61,13 @@ const PROMO_TYPES: { value: PromoType; labelKey: string; fallback: string; descK
     descKey: 'promos.editor.typeDesc.return',
     descFallback: 'Announce your return to the league.',
   },
+  {
+    value: 'rivalry',
+    labelKey: 'promos.types.rivalry',
+    fallback: 'Rivalry',
+    descKey: 'promos.editor.typeDesc.rivalry',
+    descFallback: 'Advance one of your rivalries without calling anyone out directly.',
+  },
 ];
 
 const VALID_PROMO_TYPES = new Set<string>(PROMO_TYPES.map((pt) => pt.value));
@@ -112,6 +121,7 @@ export default function PromoEditor() {
   });
   const [matchId, setMatchId] = useState('');
   const [championshipId, setChampionshipId] = useState('');
+  const [rivalryId, setRivalryId] = useState('');
   const [showPreview, setShowPreview] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -132,6 +142,7 @@ export default function PromoEditor() {
   const [currentPlayer, setCurrentPlayer] = useState<Player | null>(null);
   const [tagTeams, setTagTeams] = useState<TagTeam[]>([]);
   const [playerTagTeam, setPlayerTagTeam] = useState<TagTeam | null>(null);
+  const [myRivalries, setMyRivalries] = useState<Rivalry[]>([]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -176,6 +187,14 @@ export default function PromoEditor() {
             (tt) => tt.player1Id === foundPlayer!.playerId || tt.player2Id === foundPlayer!.playerId
           );
           setPlayerTagTeam(myTeam || null);
+
+          // Load rivalries the current player is a participant in.
+          // Fire-and-forget; if it fails, the rivalry promo picker will
+          // just show an empty list rather than blocking the editor.
+          rivalriesApi
+            .list({ participantId: foundPlayer.playerId, limit: 50 }, controller.signal)
+            .then((res) => setMyRivalries(res.rivalries ?? []))
+            .catch(() => {});
         }
       })
       .catch(() => {});
@@ -187,6 +206,7 @@ export default function PromoEditor() {
   const showTargetPromo = promoType === 'response';
   const showMatch = promoType === 'pre-match' || promoType === 'post-match';
   const showChampionship = promoType === 'championship';
+  const showRivalryPicker = promoType === 'rivalry';
 
   const targetPromos = useMemo(() => {
     if (!targetPlayerId) return [];
@@ -197,7 +217,14 @@ export default function PromoEditor() {
   const isContentValid = contentLength >= MIN_CONTENT && contentLength <= MAX_CONTENT;
   const needsTargetPromo = promoType === 'response';
   const hasTargetPromo = !!targetPromoId;
-  const canSubmit = isContentValid && promoType && !submitting && (!needsTargetPromo || hasTargetPromo);
+  const needsRivalry = promoType === 'rivalry';
+  const hasRivalry = !!rivalryId;
+  const canSubmit =
+    isContentValid &&
+    promoType &&
+    !submitting &&
+    (!needsTargetPromo || hasTargetPromo) &&
+    (!needsRivalry || hasRivalry);
 
   const previewPromo = useMemo((): PromoWithContext => {
     const targetPlayer = players.find((p) => p.playerId === targetPlayerId);
@@ -263,6 +290,7 @@ export default function PromoEditor() {
         targetPromoId: targetPromoId || undefined,
         matchId: matchId || undefined,
         championshipId: championshipId || undefined,
+        rivalryId: rivalryId || undefined,
         ...(promoType === 'call-out' && challengeMode === 'tag_team' && playerTagTeam && selectedTeam ? {
           challengeMode: 'tag_team',
           challengerTagTeamName: playerTagTeam.name,
@@ -339,6 +367,7 @@ export default function PromoEditor() {
                 setTargetPromoId('');
                 setMatchId('');
                 setChampionshipId('');
+                setRivalryId('');
                 setChallengeMatchType('');
                 setChallengeStipulation('');
                 setChallengeCreated(false);
@@ -392,6 +421,7 @@ export default function PromoEditor() {
                   setTargetPromoId('');
                   setMatchId('');
                   setChampionshipId('');
+                  setRivalryId('');
                 }}
               >
                 <span className="type-name">{t(pt.labelKey, pt.fallback)}</span>
@@ -597,6 +627,55 @@ export default function PromoEditor() {
                 </option>
               ))}
             </select>
+          </div>
+        )}
+
+        {/* Rivalry picker (rivalry promo type only) */}
+        {showRivalryPicker && (
+          <div className="form-group">
+            <label className="form-label" htmlFor="rivalry-select">
+              {t('promos.editor.rivalry', 'Rivalry')}
+              <span className="form-required" aria-label="required"> *</span>
+            </label>
+            {myRivalries.length === 0 ? (
+              <p className="form-hint">
+                {t(
+                  'promos.editor.noRivalries',
+                  "You're not in any rivalries yet. Have a GM start one, or pick a different promo type.",
+                )}
+              </p>
+            ) : (
+              <select
+                id="rivalry-select"
+                className="form-select"
+                value={rivalryId}
+                onChange={(e) => setRivalryId(e.target.value)}
+                required
+              >
+                <option value="">
+                  {t('promos.editor.selectRivalry', '-- Select a rivalry --')}
+                </option>
+                {myRivalries.map((r) => {
+                  const opponents = r.participants
+                    .filter((p) => p.playerId !== currentPlayer?.playerId)
+                    .map((p) => {
+                      const player = players.find((pl) => pl.playerId === p.playerId);
+                      return player?.currentWrestler ?? player?.name ?? p.playerId;
+                    })
+                    .join(', ');
+                  const label = r.title
+                    ? r.title
+                    : opponents
+                      ? t('promos.editor.rivalryVs', 'vs {{opponents}}', { opponents })
+                      : r.rivalryId;
+                  return (
+                    <option key={r.rivalryId} value={r.rivalryId}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </select>
+            )}
           </div>
         )}
 

--- a/frontend/src/config/navConfig.ts
+++ b/frontend/src/config/navConfig.ts
@@ -164,6 +164,7 @@ export const ADMIN_NAV_GROUPS: NavGroup[] = [
       { path: '/admin/storyline-requests', i18nKey: 'admin.panel.tabs.storylineRequests' },
       { path: '/admin/promos', i18nKey: 'admin.panel.tabs.promos' },
       { path: '/admin/rivalries', i18nKey: 'admin.panel.tabs.rivalries' },
+      { path: '/admin/heat-config', i18nKey: 'admin.panel.tabs.heatConfig' },
     ],
   },
   {
@@ -207,7 +208,7 @@ export function getAdminGroupForPath(pathname: string): string | null {
   const rosterSeasons = ['/admin/players', '/admin/divisions', '/admin/wrestlers', '/admin/transfers', '/admin/seasons', '/admin/season-awards'];
   const titlesTournaments = ['/admin/championships', '/admin/tournaments', '/admin/companies', '/admin/locations', '/admin/shows'];
   const adminRankings = ['/admin/contender-config', '/admin/contender-overrides'];
-  const content = ['/admin/announcements', '/admin/videos', '/admin/storyline-requests', '/admin/promos'];
+  const content = ['/admin/announcements', '/admin/videos', '/admin/storyline-requests', '/admin/promos', '/admin/rivalries', '/admin/heat-config'];
   const adminFactions = ['/admin/factions', '/admin/tag-teams'];
   const system = ['/admin/users', '/admin/features', '/admin/danger'];
   if (matchDay.some((p) => pathname === p)) return 'matchDay';

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -565,6 +565,29 @@
     }
   },
   "admin": {
+    "heatConfig": {
+      "title": "Rivalitäts-Heat-Einstellungen",
+      "subtitle": "Stelle die Heat-Formel ein. Änderungen greifen beim nächsten Rivalitäts-Update (Match-Bewertung, Promo-Erstellung, manuelle Neuberechnung).",
+      "save": "Heat-Einstellungen speichern",
+      "reset": "Auf Standard zurücksetzen",
+      "savedMessage": "Heat-Einstellungen gespeichert. Neue Rivalitäts-Updates verwenden diese Werte.",
+      "pivot": "Match-Bewertung Pivot",
+      "pivotHint": "Bewertungen über diesem Wert erhöhen Heat; darunter senken sie ihn. (0–5)",
+      "maxWeight": "Max. Match-Gewicht",
+      "maxWeightHint": "Begrenzt, wie viele Bewertungen ein einzelnes Match verstärken können.",
+      "scoreCap": "Heat-Score-Limit (±)",
+      "scoreCapHint": "Der endgültige Heat-Score wird auf ±diesen Wert beschränkt.",
+      "motnMultiplier": "Match-des-Abends-Multiplikator",
+      "motnMultiplierHint": "Wie stark der Beitrag eines MOTN-Matches multipliziert wird.",
+      "promoBase": "Promo-Basisbonus",
+      "promoBaseHint": "Heat pro Call-Out- oder Rivalitäts-Promo (vor Reaktionen).",
+      "promoReactionStep": "Schritt pro Reaktion",
+      "promoReactionStepHint": "Heat pro Feuer-Reaktion (wird pro Müll abgezogen).",
+      "promoBonusCap": "Reaktions-Bonus-Limit (±)",
+      "promoBonusCapHint": "Maximale Höhe des Reaktionsbonus pro Promo.",
+      "promoMaxReactionCount": "Gezählte Reaktionen pro Typ",
+      "promoMaxReactionCountHint": "Nur die ersten N Feuer/Müll-Reaktionen wirken sich auf den Bonus aus."
+    },
     "panel": {
       "title": "Admin-Bereich",
       "tabs": {
@@ -597,6 +620,7 @@
         "transfers": "Divisionstransfers",
         "storylineRequests": "Storyline-Anfragen",
         "rivalries": "Rivalitäten",
+        "heatConfig": "Heat-Einstellungen",
         "dangerZone": "Gefahrenzone"
       },
       "groups": {
@@ -1411,7 +1435,8 @@
         "pre-match": "Heize einen bevorstehenden Kampf an.",
         "post-match": "Reagiere auf einen abgeschlossenen Kampf.",
         "championship": "Sprich eine Meisterschaftssituation an.",
-        "return": "Kündige deine Rückkehr in die Liga an."
+        "return": "Kündige deine Rückkehr in die Liga an.",
+        "rivalry": "Bringe eine deiner Rivalitäten voran, ohne jemanden direkt anzusprechen."
       },
       "promoTitle": "Titel",
       "titlePlaceholder": "Gib deiner Promo einen einprägsamen Titel...",
@@ -1443,7 +1468,11 @@
       "challengeFailed": "Promo veröffentlicht, aber die Herausforderung konnte nicht erstellt werden. Du kannst sie separat aussprechen.",
       "matchType": "Match-Typ",
       "stipulation": "Auflagen",
-      "cutCallOut": "Call-Out-Promo schneiden"
+      "cutCallOut": "Call-Out-Promo schneiden",
+      "rivalry": "Rivalität",
+      "selectRivalry": "-- Rivalität auswählen --",
+      "noRivalries": "Du bist noch in keiner Rivalität. Lass einen GM eine starten oder wähle einen anderen Promo-Typ.",
+      "rivalryVs": "vs {{opponents}}"
     },
     "reactions": {
       "fire": "Feuer",
@@ -1459,7 +1488,8 @@
       "pre-match": "Vor dem Kampf",
       "post-match": "Nach dem Kampf",
       "championship": "Meisterschaft",
-      "return": "Rückkehr"
+      "return": "Rückkehr",
+      "rivalry": "Rivalität"
     },
     "admin": {
       "title": "Promos verwalten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -565,6 +565,29 @@
     }
   },
   "admin": {
+    "heatConfig": {
+      "title": "Rivalry Heat Tunables",
+      "subtitle": "Tune the rivalry heat formula. Changes apply on the next rivalry write (match rating, promo create, manual recompute).",
+      "save": "Save Heat Tunables",
+      "reset": "Reset to Defaults",
+      "savedMessage": "Rivalry heat tunables saved. New rivalry writes will use these values.",
+      "pivot": "Match rating pivot",
+      "pivotHint": "Ratings above this value push heat positive; below pulls it negative. (0–5)",
+      "maxWeight": "Max match weight",
+      "maxWeightHint": "Cap on how many ratings amplify a single match.",
+      "scoreCap": "Heat score cap (±)",
+      "scoreCapHint": "Final heat score is clamped to ±this value.",
+      "motnMultiplier": "Match-of-the-Night multiplier",
+      "motnMultiplierHint": "How much a MOTN match's contribution is multiplied.",
+      "promoBase": "Promo base bonus",
+      "promoBaseHint": "Heat added per call-out or rivalry promo (before reactions).",
+      "promoReactionStep": "Per-reaction step",
+      "promoReactionStepHint": "Heat per fire reaction (subtracted per trash).",
+      "promoBonusCap": "Reaction bonus cap (±)",
+      "promoBonusCapHint": "Max magnitude of the reaction bonus per promo.",
+      "promoMaxReactionCount": "Reactions counted per type",
+      "promoMaxReactionCountHint": "Only the first N fire / trash reactions affect the bonus."
+    },
     "panel": {
       "title": "Admin Panel",
       "tabs": {
@@ -597,6 +620,7 @@
         "transfers": "Division Transfers",
         "storylineRequests": "Storyline Requests",
         "rivalries": "Rivalries",
+        "heatConfig": "Heat Tunables",
         "dangerZone": "Danger Zone"
       },
       "groups": {
@@ -1414,7 +1438,8 @@
         "pre-match": "Hype up an upcoming match.",
         "post-match": "React to a completed match.",
         "championship": "Address a championship situation.",
-        "return": "Announce your return to the league."
+        "return": "Announce your return to the league.",
+        "rivalry": "Advance one of your rivalries without calling anyone out directly."
       },
       "promoTitle": "Title",
       "titlePlaceholder": "Give your promo a catchy title...",
@@ -1446,7 +1471,11 @@
       "challengeFailed": "Promo published, but the challenge could not be created. You can issue it separately.",
       "matchType": "Match Type",
       "stipulation": "Stipulation",
-      "cutCallOut": "Cut a Call-Out Promo"
+      "cutCallOut": "Cut a Call-Out Promo",
+      "rivalry": "Rivalry",
+      "selectRivalry": "-- Select a rivalry --",
+      "noRivalries": "You're not in any rivalries yet. Have a GM start one, or pick a different promo type.",
+      "rivalryVs": "vs {{opponents}}"
     },
     "reactions": {
       "fire": "Fire",
@@ -1462,7 +1491,8 @@
       "pre-match": "Pre-Match",
       "post-match": "Post-Match",
       "championship": "Championship",
-      "return": "Return"
+      "return": "Return",
+      "rivalry": "Rivalry"
     },
     "admin": {
       "title": "Manage Promos",

--- a/frontend/src/services/api/siteConfig.api.ts
+++ b/frontend/src/services/api/siteConfig.api.ts
@@ -10,6 +10,21 @@ export interface SiteFeatures {
   rivalries: boolean;
 }
 
+/**
+ * Admin-tunable knobs for the rivalry-heat formula. Mirrors the
+ * `RivalryHeatTunables` interface on the backend.
+ */
+export interface RivalryHeatTunables {
+  pivot: number;
+  maxWeight: number;
+  scoreCap: number;
+  motnMultiplier: number;
+  promoBase: number;
+  promoReactionStep: number;
+  promoBonusCap: number;
+  promoMaxReactionCount: number;
+}
+
 export const siteConfigApi = {
   getFeatures: async (signal?: AbortSignal): Promise<{ features: SiteFeatures }> => {
     return fetchWithAuth(`${API_BASE_URL}/site-config`, {}, signal);
@@ -19,6 +34,19 @@ export const siteConfigApi = {
     return fetchWithAuth(`${API_BASE_URL}/admin/site-config`, {
       method: 'PUT',
       body: JSON.stringify({ features }),
+    });
+  },
+
+  getHeatTunables: async (signal?: AbortSignal): Promise<{ tunables: RivalryHeatTunables }> => {
+    return fetchWithAuth(`${API_BASE_URL}/admin/heat-config`, {}, signal);
+  },
+
+  updateHeatTunables: async (
+    tunables: Partial<RivalryHeatTunables>,
+  ): Promise<{ tunables: RivalryHeatTunables }> => {
+    return fetchWithAuth(`${API_BASE_URL}/admin/heat-config`, {
+      method: 'PUT',
+      body: JSON.stringify({ tunables }),
     });
   },
 };

--- a/frontend/src/types/promo.ts
+++ b/frontend/src/types/promo.ts
@@ -5,7 +5,8 @@ export type PromoType =
   | 'pre-match'
   | 'post-match'
   | 'championship'
-  | 'return';
+  | 'return'
+  | 'rivalry';
 
 export type ReactionType = 'fire' | 'mic' | 'trash' | 'mind-blown' | 'clap';
 


### PR DESCRIPTION
## Summary
- **Promos affect rivalry heat.** Call-out and the new `rivalry`-type promos add a base bonus (default +3) plus a reaction-driven swing (the first 5 fire and trash reactions count, mirroring the match-rating weight cap). All knobs are adjustable from the admin panel.
- **New `rivalry` promo type.** Requires `rivalryId`, validated against rivalry participants — wrestlers can advance a storyline without a direct call-out. The picker in `PromoEditor` is scoped to rivalries the current player is in.
- **Admin heat-config panel** at `/admin/heat-config` (Admins only) exposes `pivot`, `maxWeight`, `scoreCap`, `motnMultiplier`, `promoBase`, `promoReactionStep`, `promoBonusCap`, `promoMaxReactionCount` with per-field bounds and a reset-to-defaults button. Persisted in `SITE_CONFIG` and read live by `computeHeatForRivalry`.
- **Recompute hooks** fire from `createPromo`, `reactToPromo` (only on fire/trash toggles for contributing promo types), and `deletePromo`. Failures log but don't roll back the user action — heat is eventually consistent.

## Notes
- Forward-only: existing call-out promos don't backfill into heat unless they're acted on or the admin recompute endpoint is hit.
- `submitRating` and `setMatchOfTheNight` now route through the new `computeHeatForRivalry` helper so match-driven heat writes pick up promos + tunables instead of running the pure policy with stale defaults.

## Test plan
- [x] Backend unit + handler tests pass (1271/1271)
- [x] Frontend tests pass (567/567)
- [x] `npx tsc --noEmit` clean (backend + frontend)
- [x] `npm run lint` clean (backend + frontend)
- [ ] Smoke test against devtest: cut a call-out promo on a rivalry, react with fire/trash, observe heat shift; tune `promoBase` from /admin/heat-config and watch a recompute apply the new value.
- [ ] Verify non-participant cannot tag a promo to someone else's rivalry (403).
- [ ] Verify `rivalry`-type promo without `rivalryId` is rejected (400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)