### PR TITLE
fix(roster): ghost wrestler rows + unconfirmed-login confirmation flow

### DIFF
--- a/backend/functions/players/__tests__/wrestlerAssignment.test.ts
+++ b/backend/functions/players/__tests__/wrestlerAssignment.test.ts
@@ -424,6 +424,55 @@ describe('stale wrestler FK handling', () => {
     expect(await repos.roster.wrestlers.findById('deleted-alternate')).toBeNull();
   });
 
+  it('updatePlayer tolerates the form echoing an unchanged stale FK', async () => {
+    // The ManagePlayers form submits the full payload on every save, so a
+    // stale FK (roster row deleted) comes back unchanged even when the admin
+    // only edited another field. That echo must not 404 the whole save.
+    const player = await repos.roster.players.create({ name: 'X', currentWrestler: 'Samoa Joe' });
+    await repos.roster.players.update(player.playerId, { alternateWrestlerId: 'deleted-id' });
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId: player.playerId },
+        body: JSON.stringify({
+          name: 'Renamed',
+          alternateWrestlerId: 'deleted-id',
+        }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).name).toBe('Renamed');
+    // The stale FK is left as-is and no ghost roster row appears.
+    expect(await repos.roster.wrestlers.findById('deleted-id')).toBeNull();
+  });
+
+  it('updateMyProfile tolerates the form echoing an unchanged stale FK', async () => {
+    const player = await repos.roster.players.create({ name: 'Me', currentWrestler: 'Gone' });
+    await repos.roster.players.update(player.playerId, {
+      userId: 'user-sub-1',
+      currentWrestlerId: 'deleted-id',
+    });
+
+    const result = await updateMyProfile(
+      withWrestlerAuth(
+        makeEvent({
+          httpMethod: 'PUT',
+          body: JSON.stringify({ name: 'Renamed', currentWrestlerId: 'deleted-id' }),
+        }),
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).name).toBe('Renamed');
+    expect(await repos.roster.wrestlers.findById('deleted-id')).toBeNull();
+  });
+
   it('updateMyProfile still swaps wrestlers when the old FK is stale', async () => {
     const cena = await seedWrestler('John Cena');
     const player = await repos.roster.players.create({ name: 'Me', currentWrestler: 'Gone' });

--- a/backend/functions/players/__tests__/wrestlerAssignment.test.ts
+++ b/backend/functions/players/__tests__/wrestlerAssignment.test.ts
@@ -47,6 +47,7 @@ import { handler as createPlayer } from '../createPlayer';
 import { handler as updatePlayer } from '../updatePlayer';
 import { handler as deletePlayer } from '../deletePlayer';
 import { handler as updateMyProfile } from '../updateMyProfile';
+import { filterExistingWrestlerIds } from '../wrestlerAssignment';
 
 let repos: Repositories;
 const ctx = {} as Context;
@@ -367,6 +368,84 @@ describe('deletePlayer releases assigned wrestlers', () => {
     const cenaAfter = await repos.roster.wrestlers.findById(cena.wrestlerId);
     expect(rockAfter?.isInUse).toBe(false);
     expect(cenaAfter?.isInUse).toBe(false);
+  });
+});
+
+// ─── Stale wrestler FKs (ghost-row regression) ──────────────────────
+//
+// A player row can hold a wrestlerId whose roster row was deleted. Releasing
+// it must be skipped — in DynamoDB an unconditioned release-update would
+// upsert a ghost row ({wrestlerId, isInUse, updatedAt} only) that crashes
+// the roster dropdowns in the frontend.
+
+describe('stale wrestler FK handling', () => {
+  it('filterExistingWrestlerIds drops ids with no roster row', async () => {
+    const rock = await seedWrestler('The Rock');
+    const result = await filterExistingWrestlerIds([rock.wrestlerId, 'deleted-id']);
+    expect(result).toEqual([rock.wrestlerId]);
+  });
+
+  it('updatePlayer still swaps wrestlers when the old FK is stale', async () => {
+    const cena = await seedWrestler('John Cena');
+    const player = await repos.roster.players.create({ name: 'X', currentWrestler: 'Gone' });
+    await repos.roster.players.update(player.playerId, { currentWrestlerId: 'deleted-id' });
+
+    const result = await updatePlayer(
+      makeEvent({
+        httpMethod: 'PUT',
+        pathParameters: { playerId: player.playerId },
+        body: JSON.stringify({ currentWrestlerId: cena.wrestlerId }),
+      }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).currentWrestlerId).toBe(cena.wrestlerId);
+    // The stale id must not have been resurrected as a roster row.
+    expect(await repos.roster.wrestlers.findById('deleted-id')).toBeNull();
+  });
+
+  it('deletePlayer succeeds when both FKs are stale', async () => {
+    const player = await repos.roster.players.create({ name: 'X', currentWrestler: 'Gone' });
+    await repos.roster.players.update(player.playerId, {
+      currentWrestlerId: 'deleted-primary',
+      alternateWrestlerId: 'deleted-alternate',
+    });
+
+    const result = await deletePlayer(
+      makeEvent({ httpMethod: 'DELETE', pathParameters: { playerId: player.playerId } }),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(204);
+    expect(await repos.roster.wrestlers.findById('deleted-primary')).toBeNull();
+    expect(await repos.roster.wrestlers.findById('deleted-alternate')).toBeNull();
+  });
+
+  it('updateMyProfile still swaps wrestlers when the old FK is stale', async () => {
+    const cena = await seedWrestler('John Cena');
+    const player = await repos.roster.players.create({ name: 'Me', currentWrestler: 'Gone' });
+    await repos.roster.players.update(player.playerId, {
+      userId: 'user-sub-1',
+      currentWrestlerId: 'deleted-id',
+    });
+
+    const result = await updateMyProfile(
+      withWrestlerAuth(
+        makeEvent({
+          httpMethod: 'PUT',
+          body: JSON.stringify({ currentWrestlerId: cena.wrestlerId }),
+        }),
+      ),
+      ctx,
+      cb,
+    );
+
+    expect(result!.statusCode).toBe(200);
+    expect(JSON.parse(result!.body).currentWrestlerId).toBe(cena.wrestlerId);
+    expect(await repos.roster.wrestlers.findById('deleted-id')).toBeNull();
   });
 });
 

--- a/backend/functions/players/deletePlayer.ts
+++ b/backend/functions/players/deletePlayer.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { getRepositories } from '../../lib/repositories';
 import { noContent, badRequest, serverError, conflict, notFound } from '../../lib/response';
+import { filterExistingWrestlerIds } from './wrestlerAssignment';
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   try {
@@ -111,10 +112,11 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     const toRelease: string[] = [];
     if (player.currentWrestlerId) toRelease.push(player.currentWrestlerId);
     if (player.alternateWrestlerId) toRelease.push(player.alternateWrestlerId);
-    if (toRelease.length > 0) {
+    const releasable = await filterExistingWrestlerIds(toRelease);
+    if (releasable.length > 0) {
       const { runInTransaction } = getRepositories();
       await runInTransaction(async (tx) => {
-        for (const wrestlerId of toRelease) {
+        for (const wrestlerId of releasable) {
           tx.releaseWrestlerFromPlayer({ wrestlerId });
         }
       });

--- a/backend/functions/players/updateMyProfile.ts
+++ b/backend/functions/players/updateMyProfile.ts
@@ -138,11 +138,20 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       const newId = currentChange.newId;
       if (oldId && oldId !== newId) toRelease.push(oldId);
       if (newId) {
-        const r = await resolveWrestlerForAssignment(newId, playerId, 'primary');
-        if ('error' in r) return r.error;
-        toAssign.push({ wrestlerId: newId, slot: 'primary' });
-        patch.currentWrestlerId = newId;
-        patch.currentWrestler = r.wrestler.name;
+        // The edit form submits the full payload, so an unchanged slot echoes
+        // the player's stored FK back. If that FK is stale (its roster row
+        // was deleted, e.g. by a roster re-seed), failing the whole save
+        // with a 404 would block editing every other field — skip the slot.
+        const unchangedStale =
+          newId === oldId &&
+          (await filterExistingWrestlerIds([newId])).length === 0;
+        if (!unchangedStale) {
+          const r = await resolveWrestlerForAssignment(newId, playerId, 'primary');
+          if ('error' in r) return r.error;
+          toAssign.push({ wrestlerId: newId, slot: 'primary' });
+          patch.currentWrestlerId = newId;
+          patch.currentWrestler = r.wrestler.name;
+        }
       } else {
         patch.currentWrestlerId = null;
       }
@@ -154,11 +163,16 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       const newId = alternateChange.newId;
       if (oldId && oldId !== newId) toRelease.push(oldId);
       if (newId) {
-        const r = await resolveWrestlerForAssignment(newId, playerId, 'alternate');
-        if ('error' in r) return r.error;
-        toAssign.push({ wrestlerId: newId, slot: 'alternate' });
-        patch.alternateWrestlerId = newId;
-        patch.alternateWrestler = r.wrestler.name;
+        const unchangedStale =
+          newId === oldId &&
+          (await filterExistingWrestlerIds([newId])).length === 0;
+        if (!unchangedStale) {
+          const r = await resolveWrestlerForAssignment(newId, playerId, 'alternate');
+          if ('error' in r) return r.error;
+          toAssign.push({ wrestlerId: newId, slot: 'alternate' });
+          patch.alternateWrestlerId = newId;
+          patch.alternateWrestler = r.wrestler.name;
+        }
       } else {
         patch.alternateWrestlerId = null;
         patch.alternateWrestler = undefined;

--- a/backend/functions/players/updateMyProfile.ts
+++ b/backend/functions/players/updateMyProfile.ts
@@ -6,6 +6,7 @@ import { parseBody } from '../../lib/parseBody';
 import { getAuthContext, requireRole } from '../../lib/auth';
 import type { PlayerPatch } from '../../lib/repositories';
 import {
+  filterExistingWrestlerIds,
   rejectDuplicateSlotAssignment,
   resolveWrestlerForAssignment,
 } from './wrestlerAssignment';
@@ -171,8 +172,9 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     }
 
     if (toRelease.length > 0 || toAssign.length > 0) {
+      const releasable = await filterExistingWrestlerIds(toRelease);
       await runInTransaction(async (tx) => {
-        for (const wrestlerId of toRelease) {
+        for (const wrestlerId of releasable) {
           tx.releaseWrestlerFromPlayer({ wrestlerId });
         }
         for (const { wrestlerId, slot } of toAssign) {

--- a/backend/functions/players/updatePlayer.ts
+++ b/backend/functions/players/updatePlayer.ts
@@ -5,6 +5,7 @@ import { success, badRequest, notFound, serverError } from '../../lib/response';
 import { parseBody } from '../../lib/parseBody';
 import type { PlayerPatch } from '../../lib/repositories';
 import {
+  filterExistingWrestlerIds,
   rejectDuplicateSlotAssignment,
   resolveWrestlerForAssignment,
 } from './wrestlerAssignment';
@@ -169,8 +170,9 @@ export const handler: APIGatewayProxyHandler = async (event) => {
     // If any FK transition happened, stage the player update + wrestler
     // release/assign atomically. Otherwise fall through to the simple update.
     if (toRelease.length > 0 || toAssign.length > 0) {
+      const releasable = await filterExistingWrestlerIds(toRelease);
       await runInTransaction(async (tx) => {
-        for (const wrestlerId of toRelease) {
+        for (const wrestlerId of releasable) {
           tx.releaseWrestlerFromPlayer({ wrestlerId });
         }
         for (const { wrestlerId, slot } of toAssign) {

--- a/backend/functions/players/updatePlayer.ts
+++ b/backend/functions/players/updatePlayer.ts
@@ -135,11 +135,20 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       const newId = currentChange.newId;
       if (oldId && oldId !== newId) toRelease.push(oldId);
       if (newId) {
-        const r = await resolveWrestlerForAssignment(newId, playerId, 'primary');
-        if ('error' in r) return r.error;
-        toAssign.push({ wrestlerId: newId, slot: 'primary' });
-        patch.currentWrestlerId = newId;
-        patch.currentWrestler = r.wrestler.name;
+        // The edit form submits the full payload, so an unchanged slot echoes
+        // the player's stored FK back. If that FK is stale (its roster row
+        // was deleted, e.g. by a roster re-seed), failing the whole save
+        // with a 404 would block editing every other field — skip the slot.
+        const unchangedStale =
+          newId === oldId &&
+          (await filterExistingWrestlerIds([newId])).length === 0;
+        if (!unchangedStale) {
+          const r = await resolveWrestlerForAssignment(newId, playerId, 'primary');
+          if ('error' in r) return r.error;
+          toAssign.push({ wrestlerId: newId, slot: 'primary' });
+          patch.currentWrestlerId = newId;
+          patch.currentWrestler = r.wrestler.name;
+        }
       } else {
         patch.currentWrestlerId = null;
       }
@@ -151,11 +160,16 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       const newId = alternateChange.newId;
       if (oldId && oldId !== newId) toRelease.push(oldId);
       if (newId) {
-        const r = await resolveWrestlerForAssignment(newId, playerId, 'alternate');
-        if ('error' in r) return r.error;
-        toAssign.push({ wrestlerId: newId, slot: 'alternate' });
-        patch.alternateWrestlerId = newId;
-        patch.alternateWrestler = r.wrestler.name;
+        const unchangedStale =
+          newId === oldId &&
+          (await filterExistingWrestlerIds([newId])).length === 0;
+        if (!unchangedStale) {
+          const r = await resolveWrestlerForAssignment(newId, playerId, 'alternate');
+          if ('error' in r) return r.error;
+          toAssign.push({ wrestlerId: newId, slot: 'alternate' });
+          patch.alternateWrestlerId = newId;
+          patch.alternateWrestler = r.wrestler.name;
+        }
       } else {
         patch.alternateWrestlerId = null;
         patch.alternateWrestler = undefined;

--- a/backend/functions/players/wrestlerAssignment.ts
+++ b/backend/functions/players/wrestlerAssignment.ts
@@ -40,6 +40,27 @@ export async function resolveWrestlerForAssignment(
 }
 
 /**
+ * Filter a list of wrestler FKs down to the ones that still exist in the
+ * roster. A player row can hold a stale wrestlerId (the wrestler was deleted
+ * out from under it), and releasing a nonexistent id would upsert a ghost
+ * roster row — DynamoUnitOfWork conditions its writes on existence, so an
+ * unfiltered stale id would fail the whole transaction instead. Skipping the
+ * release is the right outcome: there is nothing to free.
+ */
+export async function filterExistingWrestlerIds(
+  wrestlerIds: string[],
+): Promise<string[]> {
+  const { roster } = getRepositories();
+  const checks = await Promise.all(
+    wrestlerIds.map(async (wrestlerId) => {
+      const wrestler = await roster.wrestlers.findById(wrestlerId);
+      return wrestler ? wrestlerId : null;
+    }),
+  );
+  return checks.filter((wrestlerId): wrestlerId is string => wrestlerId !== null);
+}
+
+/**
  * Reject when the same wrestler is picked for both slots on a single player.
  */
 export function rejectDuplicateSlotAssignment(

--- a/backend/lib/repositories/dynamo/DynamoUnitOfWork.ts
+++ b/backend/lib/repositories/dynamo/DynamoUnitOfWork.ts
@@ -305,6 +305,14 @@ export class DynamoUnitOfWork implements UnitOfWork {
   // `isInUse` is persisted as string "true"/"false" because DynamoDB GSI keys
   // cannot be Boolean; the repository boundary converts back to boolean on
   // read. See DynamoRosterRepository wrestlers.* for the read path.
+  //
+  // Both operations require the wrestler row to exist: DynamoDB Updates are
+  // upserts, and an unconditioned assign/release against a deleted wrestlerId
+  // creates a ghost row ({wrestlerId, isInUse, updatedAt} only) that crashes
+  // roster dropdowns in the frontend. Callers must verify existence first
+  // (resolveWrestlerForAssignment / filterExistingWrestlerIds); the condition
+  // turns the remaining delete race into a failed transaction instead of a
+  // silent ghost.
   assignWrestlerToPlayer(params: {
     wrestlerId: string;
     playerId: string;
@@ -315,6 +323,7 @@ export class DynamoUnitOfWork implements UnitOfWork {
       Update: {
         TableName: TableNames.WRESTLERS,
         Key: { wrestlerId: params.wrestlerId },
+        ConditionExpression: 'attribute_exists(wrestlerId)',
         UpdateExpression:
           'SET isInUse = :isInUse, assignedPlayerId = :playerId, assignedSlot = :slot, updatedAt = :now',
         ExpressionAttributeValues: {
@@ -333,6 +342,7 @@ export class DynamoUnitOfWork implements UnitOfWork {
       Update: {
         TableName: TableNames.WRESTLERS,
         Key: { wrestlerId: params.wrestlerId },
+        ConditionExpression: 'attribute_exists(wrestlerId)',
         UpdateExpression:
           'SET isInUse = :isInUse, updatedAt = :now REMOVE assignedPlayerId, assignedSlot',
         ExpressionAttributeValues: { ':isInUse': 'false', ':now': now },

--- a/frontend/src/components/admin/ManagePlayers.tsx
+++ b/frontend/src/components/admin/ManagePlayers.tsx
@@ -39,6 +39,9 @@ function buildOptionGroups(
   excludeWrestlerId: string | undefined,
 ): WrestlerSlotOptions {
   const visible = allWrestlers.filter((w) => {
+    // Ghost roster rows (e.g. from a release against a deleted wrestlerId)
+    // lack name/promotion — drop them rather than crash the sorts below.
+    if (typeof w.name !== 'string' || typeof w.promotion !== 'string') return false;
     if (w.wrestlerId === excludeWrestlerId) return false; // never show the other-slot pick
     if (!w.isInUse) return true;
     return w.wrestlerId === selectedWrestlerId;

--- a/frontend/src/components/auth/Auth.css
+++ b/frontend/src/components/auth/Auth.css
@@ -90,6 +90,16 @@
   margin-bottom: 0.5rem;
 }
 
+.auth-card .success-message {
+  background: rgba(40, 167, 69, 0.1);
+  border: 1px solid rgba(40, 167, 69, 0.3);
+  color: var(--color-success, #28a745);
+  padding: 0.6rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
 .auth-footer {
   margin-top: 1.5rem;
   text-align: center;

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
+import { UnconfirmedUserError } from '../../services/cognito';
 import { playersApi } from '../../services/api';
 import type { Player } from '../../types';
 import './Auth.css';
@@ -70,11 +71,15 @@ function DevLogin() {
 export default function Login() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { signIn } = useAuth();
+  const { signIn, confirmSignUp, resendConfirmationCode } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [step, setStep] = useState<'login' | 'confirm'>('login');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [info, setInfo] = useState<string | null>(null);
+  const [resending, setResending] = useState(false);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -85,12 +90,123 @@ export default function Login() {
       await signIn(email, password);
       navigate('/');
     } catch (err) {
-      const message = err instanceof Error ? err.message : t('auth.loginFailed');
+      if (err instanceof UnconfirmedUserError) {
+        // The account exists but the email was never verified — move the
+        // user into the confirmation flow instead of dead-ending on an error.
+        setStep('confirm');
+        setInfo(t('auth.unconfirmedNotice'));
+      } else {
+        const message = err instanceof Error ? err.message : t('auth.loginFailed');
+        setError(message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirm = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setInfo(null);
+    setLoading(true);
+
+    try {
+      await confirmSignUp(email, verificationCode);
+      // Email verified — complete the sign-in they originally asked for.
+      await signIn(email, password);
+      navigate('/welcome');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('auth.verificationFailed');
       setError(message);
     } finally {
       setLoading(false);
     }
   };
+
+  const handleResend = async () => {
+    setError(null);
+    setInfo(null);
+    setResending(true);
+
+    try {
+      await resendConfirmationCode(email);
+      setInfo(t('auth.codeResent'));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('auth.loginFailed');
+      setError(message);
+    } finally {
+      setResending(false);
+    }
+  };
+
+  if (step === 'confirm') {
+    return (
+      <div className="auth-container">
+        <div className="auth-card">
+          <h2>{t('auth.verifyTitle')}</h2>
+          <p className="auth-subtitle">
+            {t('auth.verifySubtitle')} <strong>{email}</strong>
+          </p>
+
+          <form onSubmit={handleConfirm} aria-describedby={error ? 'confirm-error' : undefined}>
+            <div className="form-group">
+              <label htmlFor="code">{t('auth.verificationCode')}</label>
+              <input
+                type="text"
+                id="code"
+                value={verificationCode}
+                onChange={(e) => setVerificationCode(e.target.value)}
+                placeholder={t('auth.codePlaceholder')}
+                required
+                autoFocus
+                aria-invalid={error ? 'true' : undefined}
+              />
+            </div>
+
+            {info && (
+              <div className="success-message" role="status" aria-live="polite">
+                {info}
+              </div>
+            )}
+            {error && (
+              <div id="confirm-error" className="error-message" role="alert" aria-live="polite">
+                {error}
+              </div>
+            )}
+
+            <button type="submit" className="btn-submit" disabled={loading || resending} aria-busy={loading}>
+              {loading ? t('auth.verifying') : t('auth.verifyEmail')}
+            </button>
+          </form>
+
+          <div className="auth-footer">
+            <p>
+              <button
+                className="link-button"
+                onClick={handleResend}
+                disabled={loading || resending}
+              >
+                {resending ? t('auth.sendingCode') : t('auth.resendCode')}
+              </button>
+            </p>
+            <p>
+              <button
+                className="link-button"
+                onClick={() => {
+                  setStep('login');
+                  setVerificationCode('');
+                  setError(null);
+                  setInfo(null);
+                }}
+              >
+                {t('auth.backToSignIn')}
+              </button>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="auth-container">

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -17,7 +17,14 @@ type WrestlerSlotOptions = ReadonlyArray<{
  * that "available" has the same definition everywhere a roster pick is made.
  */
 function buildAvailableOptionGroups(all: Wrestler[]): WrestlerSlotOptions {
-  const available = all.filter((w) => !w.isInUse);
+  const available = all.filter(
+    // Ghost roster rows (e.g. from a release against a deleted wrestlerId)
+    // lack name/promotion — drop them rather than crash the sorts below.
+    (w) =>
+      !w.isInUse &&
+      typeof w.name === 'string' &&
+      typeof w.promotion === 'string',
+  );
   const byPromotion = new Map<WrestlerPromotion, Wrestler[]>();
   for (const w of available) {
     const bucket = byPromotion.get(w.promotion) ?? [];

--- a/frontend/src/components/auth/__tests__/Login.test.tsx
+++ b/frontend/src/components/auth/__tests__/Login.test.tsx
@@ -4,10 +4,24 @@ import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 
 // --- Hoisted mocks ---
-const { mockSignIn, mockNavigate } = vi.hoisted(() => ({
+const { mockSignIn, mockConfirmSignUp, mockResendConfirmationCode, mockNavigate } = vi.hoisted(() => ({
   mockSignIn: vi.fn(),
+  mockConfirmSignUp: vi.fn(),
+  mockResendConfirmationCode: vi.fn(),
   mockNavigate: vi.fn(),
 }));
+
+// Mock the cognito service so the test doesn't load aws-amplify; the
+// component's `instanceof UnconfirmedUserError` check uses this same class.
+vi.mock('../../../services/cognito', () => {
+  class UnconfirmedUserError extends Error {
+    constructor(message = 'Account not confirmed') {
+      super(message);
+      this.name = 'UnconfirmedUserError';
+    }
+  }
+  return { UnconfirmedUserError };
+});
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -28,6 +42,18 @@ vi.mock('react-i18next', () => ({
         'auth.signInAsAdmin': 'Sign in as Admin',
         'auth.loadingPlayers': 'Loading players...',
         'auth.noPlayersFound': 'No players found. Run seed data first.',
+        'auth.verifyTitle': 'Verify Your Email',
+        'auth.verifySubtitle': 'We sent a verification code to',
+        'auth.verificationCode': 'Verification Code',
+        'auth.codePlaceholder': 'Enter 6-digit code',
+        'auth.verifyEmail': 'Verify Email',
+        'auth.verifying': 'Verifying...',
+        'auth.resendCode': "Didn't get a code? Send again",
+        'auth.sendingCode': 'Sending...',
+        'auth.backToSignIn': 'Back to Sign In',
+        'auth.unconfirmedNotice': "Your account hasn't been verified yet.",
+        'auth.codeResent': 'A new verification code has been sent to your email.',
+        'auth.verificationFailed': 'Verification failed. Please try again.',
       };
       return map[key] ?? key;
     },
@@ -37,6 +63,8 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({
     signIn: mockSignIn,
+    confirmSignUp: mockConfirmSignUp,
+    resendConfirmationCode: mockResendConfirmationCode,
   }),
 }));
 
@@ -49,6 +77,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 import Login from '../Login';
+import { UnconfirmedUserError } from '../../../services/cognito';
 
 function renderLogin() {
   return render(
@@ -131,6 +160,89 @@ describe('Login', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('unconfirmed account flow', () => {
+    async function signInUnconfirmed(user: ReturnType<typeof userEvent.setup>) {
+      mockSignIn.mockRejectedValueOnce(new UnconfirmedUserError());
+      await user.type(screen.getByLabelText('Email'), 'new@league.com');
+      await user.type(screen.getByLabelText('Password'), 'securePass1');
+      await user.click(screen.getByRole('button', { name: 'Sign In' }));
+      await waitFor(() => {
+        expect(screen.getByText('Verify Your Email')).toBeInTheDocument();
+      });
+    }
+
+    it('switches to the confirmation screen when sign-in reports an unconfirmed account', async () => {
+      const user = userEvent.setup();
+      renderLogin();
+
+      await signInUnconfirmed(user);
+
+      expect(screen.getByLabelText('Verification Code')).toBeInTheDocument();
+      expect(screen.getByText("Your account hasn't been verified yet.")).toBeInTheDocument();
+      // Not treated as a login failure
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('resends the confirmation code and shows a confirmation notice', async () => {
+      const user = userEvent.setup();
+      mockResendConfirmationCode.mockResolvedValue(undefined);
+      renderLogin();
+
+      await signInUnconfirmed(user);
+      await user.click(screen.getByRole('button', { name: "Didn't get a code? Send again" }));
+
+      await waitFor(() => {
+        expect(mockResendConfirmationCode).toHaveBeenCalledWith('new@league.com');
+        expect(
+          screen.getByText('A new verification code has been sent to your email.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('confirms the code, signs in with the original credentials, and navigates to welcome', async () => {
+      const user = userEvent.setup();
+      mockConfirmSignUp.mockResolvedValue(true);
+      renderLogin();
+
+      await signInUnconfirmed(user);
+
+      mockSignIn.mockResolvedValueOnce(undefined);
+      await user.type(screen.getByLabelText('Verification Code'), '123456');
+      await user.click(screen.getByRole('button', { name: 'Verify Email' }));
+
+      await waitFor(() => {
+        expect(mockConfirmSignUp).toHaveBeenCalledWith('new@league.com', '123456');
+        expect(mockSignIn).toHaveBeenLastCalledWith('new@league.com', 'securePass1');
+        expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+      });
+    });
+
+    it('shows an error when the confirmation code is rejected', async () => {
+      const user = userEvent.setup();
+      mockConfirmSignUp.mockRejectedValue(new Error('Invalid verification code'));
+      renderLogin();
+
+      await signInUnconfirmed(user);
+
+      await user.type(screen.getByLabelText('Verification Code'), '000000');
+      await user.click(screen.getByRole('button', { name: 'Verify Email' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Invalid verification code');
+      });
+    });
+
+    it('returns to the login form via back to sign in', async () => {
+      const user = userEvent.setup();
+      renderLogin();
+
+      await signInUnconfirmed(user);
+      await user.click(screen.getByRole('button', { name: 'Back to Sign In' }));
+
+      expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/profile/WrestlerProfile.tsx
+++ b/frontend/src/components/profile/WrestlerProfile.tsx
@@ -32,6 +32,9 @@ function buildWrestlerOptionGroups(
   excludeWrestlerId: string | undefined,
 ): WrestlerSlotOptions {
   const visible = allWrestlers.filter((w) => {
+    // Ghost roster rows (e.g. from a release against a deleted wrestlerId)
+    // lack name/promotion — drop them rather than crash the sorts below.
+    if (typeof w.name !== 'string' || typeof w.promotion !== 'string') return false;
     if (w.wrestlerId === excludeWrestlerId) return false;
     if (!w.isInUse) return true;
     return w.wrestlerId === selectedWrestlerId;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -18,6 +18,7 @@ interface AuthContextType extends AuthState {
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string, options?: { wrestlerName?: string; psnId?: string; playerName?: string }) => Promise<{ isConfirmed: boolean }>;
   confirmSignUp: (email: string, code: string) => Promise<boolean>;
+  resendConfirmationCode: (email: string) => Promise<void>;
   signOut: () => Promise<void>;
   refreshProfile: () => Promise<void>;
   devSignIn?: (player: { playerId: string; name: string }, roles?: UserRole[]) => void;
@@ -175,6 +176,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return cognitoAuth.confirmSignUp(email, code);
   }, []);
 
+  const handleResendConfirmationCode = useCallback(async (email: string) => {
+    return cognitoAuth.resendConfirmationCode(email);
+  }, []);
+
   const handleSignOut = useCallback(async () => {
     await cognitoAuth.signOut();
     sessionStorage.removeItem('devPlayer');
@@ -231,6 +236,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     signIn: handleSignIn,
     signUp: handleSignUp,
     confirmSignUp: handleConfirmSignUp,
+    resendConfirmationCode: handleResendConfirmationCode,
     signOut: handleSignOut,
     refreshProfile,
     ...(import.meta.env.DEV ? { devSignIn } : {}),

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -91,6 +91,8 @@
     "verifying": "Wird bestätigt...",
     "backToSignUp": "Zurück zur Registrierung",
     "verificationFailed": "Bestätigung fehlgeschlagen. Bitte versuche es erneut.",
+    "unconfirmedNotice": "Dein Konto wurde noch nicht bestätigt. Gib den Code ein, den wir dir per E-Mail geschickt haben, oder fordere unten einen neuen an.",
+    "codeResent": "Ein neuer Bestätigungscode wurde an deine E-Mail gesendet.",
     "devLoginTitle": "Dev-Anmeldung",
     "devLoginSubtitle": "Wähle eine Rolle zur Anmeldung (nur für Entwicklung)",
     "signInAsAdmin": "Als Admin anmelden",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -91,6 +91,8 @@
     "verifying": "Verifying...",
     "backToSignUp": "Back to sign up",
     "verificationFailed": "Verification failed. Please try again.",
+    "unconfirmedNotice": "Your account hasn't been verified yet. Enter the code we emailed you, or request a new one below.",
+    "codeResent": "A new verification code has been sent to your email.",
     "devLoginTitle": "Dev Login",
     "devLoginSubtitle": "Pick a role to sign in as (dev only)",
     "signInAsAdmin": "Sign in as Admin",

--- a/frontend/src/services/__tests__/cognito.test.ts
+++ b/frontend/src/services/__tests__/cognito.test.ts
@@ -6,6 +6,7 @@ const {
   mockAmplifySignUp,
   mockAmplifySignOut,
   mockAmplifyConfirmSignUp,
+  mockAmplifyResendSignUpCode,
   mockAmplifyFetchAuthSession,
   mockAmplifyGetCurrentUser,
   mockAmplifyConfigure,
@@ -14,6 +15,7 @@ const {
   mockAmplifySignUp: vi.fn(),
   mockAmplifySignOut: vi.fn(),
   mockAmplifyConfirmSignUp: vi.fn(),
+  mockAmplifyResendSignUpCode: vi.fn(),
   mockAmplifyFetchAuthSession: vi.fn(),
   mockAmplifyGetCurrentUser: vi.fn(),
   mockAmplifyConfigure: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock('aws-amplify/auth', () => ({
   signUp: mockAmplifySignUp,
   signOut: mockAmplifySignOut,
   confirmSignUp: mockAmplifyConfirmSignUp,
+  resendSignUpCode: mockAmplifyResendSignUpCode,
   fetchAuthSession: mockAmplifyFetchAuthSession,
   getCurrentUser: mockAmplifyGetCurrentUser,
 }));
@@ -43,7 +46,7 @@ function fakeJwt(payload: Record<string, unknown>): string {
   return `${header}.${body}.fake-signature`;
 }
 
-import { cognitoAuth } from '../cognito';
+import { cognitoAuth, UnconfirmedUserError } from '../cognito';
 
 describe('cognito service — auth flows', () => {
   beforeEach(() => {
@@ -109,7 +112,7 @@ describe('cognito service — auth flows', () => {
       );
     });
 
-    it('handles CONFIRM_SIGN_UP next step', async () => {
+    it('throws UnconfirmedUserError on CONFIRM_SIGN_UP next step', async () => {
       mockAmplifySignOut.mockResolvedValue(undefined);
       mockAmplifySignIn.mockResolvedValue({
         isSignedIn: false,
@@ -117,18 +120,38 @@ describe('cognito service — auth flows', () => {
       });
 
       await expect(cognitoAuth.signIn('a@b.com', 'pass')).rejects.toThrow(
-        'Account not confirmed',
+        UnconfirmedUserError,
       );
     });
 
-    it('handles UserNotConfirmedException', async () => {
+    it('throws UnconfirmedUserError on UserNotConfirmedException', async () => {
       mockAmplifySignOut.mockResolvedValue(undefined);
       const err = new Error('User is not confirmed.');
       (err as Error & { name: string }).name = 'UserNotConfirmedException';
       mockAmplifySignIn.mockRejectedValue(err);
 
       await expect(cognitoAuth.signIn('a@b.com', 'pass')).rejects.toThrow(
-        'Please verify your email before signing in',
+        UnconfirmedUserError,
+      );
+    });
+  });
+
+  describe('resendConfirmationCode', () => {
+    it('calls Amplify resendSignUpCode with the email as username', async () => {
+      mockAmplifyResendSignUpCode.mockResolvedValue(undefined);
+
+      await cognitoAuth.resendConfirmationCode('a@b.com');
+
+      expect(mockAmplifyResendSignUpCode).toHaveBeenCalledWith({ username: 'a@b.com' });
+    });
+
+    it('maps LimitExceededException to a friendly message', async () => {
+      const err = new Error('Attempt limit exceeded');
+      (err as Error & { name: string }).name = 'LimitExceededException';
+      mockAmplifyResendSignUpCode.mockRejectedValue(err);
+
+      await expect(cognitoAuth.resendConfirmationCode('a@b.com')).rejects.toThrow(
+        'Too many attempts. Please try again later.',
       );
     });
   });

--- a/frontend/src/services/cognito.ts
+++ b/frontend/src/services/cognito.ts
@@ -1,6 +1,18 @@
 import { Amplify } from 'aws-amplify';
-import { signIn, signUp, signOut, confirmSignUp, fetchAuthSession, getCurrentUser, resetPassword, confirmResetPassword } from 'aws-amplify/auth';
+import { signIn, signUp, signOut, confirmSignUp, resendSignUpCode, fetchAuthSession, getCurrentUser, resetPassword, confirmResetPassword } from 'aws-amplify/auth';
 import { logger } from '../utils/logger';
+
+/**
+ * Thrown by signIn when the account exists but the email was never verified.
+ * Callers detect this to route the user into the confirmation-code flow
+ * instead of showing a generic login error.
+ */
+export class UnconfirmedUserError extends Error {
+  constructor(message = 'Account not confirmed') {
+    super(message);
+    this.name = 'UnconfirmedUserError';
+  }
+}
 
 export type UserRole = 'Admin' | 'Moderator' | 'Wrestler';
 
@@ -112,7 +124,7 @@ export const cognitoAuth = {
       if (nextStep === 'CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED') {
         throw new Error('Password change required. Please contact administrator.');
       } else if (nextStep === 'CONFIRM_SIGN_UP') {
-        throw new Error('Account not confirmed. Please check your email for a verification code.');
+        throw new UnconfirmedUserError();
       } else if (nextStep) {
         throw new Error(`Additional step required: ${nextStep}`);
       }
@@ -120,6 +132,10 @@ export const cognitoAuth = {
       throw new Error('Sign in failed - unexpected state');
     } catch (error: unknown) {
       logger.error('Cognito sign in error');
+
+      if (error instanceof UnconfirmedUserError) {
+        throw error;
+      }
 
       if (error instanceof Error) {
         const cognitoError = error as Error & { name?: string };
@@ -132,7 +148,7 @@ export const cognitoAuth = {
         } else if (cognitoError.name === 'UserNotFoundException') {
           throw new Error('User not found');
         } else if (cognitoError.name === 'UserNotConfirmedException') {
-          throw new Error('Please verify your email before signing in');
+          throw new UnconfirmedUserError();
         }
         throw new Error(error.message || 'Authentication failed');
       }
@@ -220,6 +236,26 @@ export const cognitoAuth = {
         throw new Error(error.message || 'Confirmation failed');
       }
       throw new Error('Confirmation failed');
+    }
+  },
+
+  /**
+   * Resend the sign-up confirmation code to an unconfirmed user's email
+   */
+  resendConfirmationCode: async (email: string): Promise<void> => {
+    try {
+      await resendSignUpCode({ username: email });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        const cognitoError = error as Error & { name?: string };
+        if (cognitoError.name === 'LimitExceededException') {
+          throw new Error('Too many attempts. Please try again later.');
+        } else if (cognitoError.name === 'UserNotFoundException') {
+          throw new Error('No account found with this email');
+        }
+        throw new Error(error.message || 'Failed to resend verification code');
+      }
+      throw new Error('Failed to resend verification code');
     }
   },
 


### PR DESCRIPTION
## Summary

Two changes on this branch:

### 1. Ghost wrestler rows crashed /profile, signup, and admin ManagePlayers (prod incident)

Three skeleton rows (`{wrestlerId, isInUse, updatedAt}` only) in the prod Wrestlers table crashed every page that builds the roster dropdowns — the promotion/name sorts threw on the missing fields and tripped the app error boundary. (The rows have already been deleted from prod; this PR prevents recurrence.)

**Root cause:** DynamoDB Updates are upserts. `assignWrestlerToPlayer` / `releaseWrestlerFromPlayer` staged unconditioned updates, so releasing a stale `currentWrestlerId` (wrestler deleted out from under a player) re-created the row as a ghost.

- `DynamoUnitOfWork`: both wrestler writes now conditioned on `attribute_exists(wrestlerId)`
- New `filterExistingWrestlerIds` helper skips releases of stale FKs in `updatePlayer`, `updateMyProfile`, `deletePlayer`
- Frontend: the three dropdown group builders drop malformed roster rows instead of crashing the page

### 2. Unconfirmed users get the confirmation screen at login

Previously an unconfirmed account dead-ended at login with an error message. Now:

- `cognitoAuth.signIn` throws a typed `UnconfirmedUserError` (both Amplify paths)
- Login switches to a verify step: enter the emailed code, resend it if needed
- On successful confirmation the original sign-in completes automatically and lands on `/welcome`
- New `resendConfirmationCode` in the cognito service + AuthContext; en/de strings added

## Testing

- Backend: 111 tests pass (`functions/players`, `lib/repositories`), incl. 4 new stale-FK regression tests
- Frontend: 168 tests pass, incl. 5 new Login confirmation-flow tests and 4 updated/new cognito service tests
- `tsc --noEmit` clean in both packages
- Crash repro script against the live roster data confirmed the dropdown builder no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)