### PR TITLE
feat(mobile): standings card view + nav and events polish for phones

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -378,4 +378,10 @@
   .sidebar.mobile-open {
     transform: translateX(0);
   }
+
+  /* The fixed hamburger button (now an X) sits on top of the open drawer —
+     clear its footprint so it doesn't overlap the title. */
+  .sidebar-header {
+    padding-left: 3.5rem;
+  }
 }

--- a/frontend/src/components/Standings.css
+++ b/frontend/src/components/Standings.css
@@ -295,6 +295,92 @@
   margin-bottom: 1rem;
 }
 
+/* Mobile card list — rendered instead of the table below 640px (the
+   useMediaQuery switch in Standings.tsx). Cards keep record, form, and
+   streak visible without horizontal scrolling. */
+.standings-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.standings-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.standings-card:active {
+  border-color: var(--color-primary);
+}
+
+.standings-card-rank {
+  flex: 0 0 1.6rem;
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--color-primary);
+}
+
+.standings-card-avatar {
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.standings-card-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.standings-card-name {
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.standings-card-wrestler {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.standings-card-stats {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.15rem;
+  font-size: 0.8rem;
+}
+
+.standings-card-record {
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.standings-card-winpct {
+  color: var(--color-text-secondary);
+}
+
+.standings-card-ovr {
+  flex-shrink: 0;
+}
+
 @media (max-width: 768px) {
   .standings-header {
     flex-direction: column;

--- a/frontend/src/components/Standings.tsx
+++ b/frontend/src/components/Standings.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { standingsApi, seasonsApi, divisionsApi } from '../services/api';
 import { logger } from '../utils/logger';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { Standings as StandingsType, Season, Division, Player } from '../types';
 import PlayerHoverCard from './PlayerHoverCard';
 import DivisionFilter from './DivisionFilter';
@@ -29,6 +30,7 @@ export default function Standings() {
   const [defaultsResolved, setDefaultsResolved] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMobile = useMediaQuery('(max-width: 640px)');
 
   // Reload standings when retry button is clicked
   const loadStandings = useCallback(async () => {
@@ -231,6 +233,75 @@ export default function Standings() {
         </div>
       </div>
 
+      {/* Below 640px the table hides half its columns off-screen, so swap
+          in a card list that keeps record, form, and streak visible. */}
+      {isMobile ? (
+      <div className="standings-cards">
+        {playersWithStats.map((player, index) => (
+          <div
+            key={player.playerId}
+            className="standings-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => navigate(`/player/${player.playerId}`)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                navigate(`/player/${player.playerId}`);
+              }
+            }}
+            aria-label={player.name}
+          >
+            <span className="standings-card-rank">{index + 1}</span>
+            <img
+              src={resolveImageSrc(player.imageUrl, DEFAULT_WRESTLER_IMAGE)}
+              onError={(event) => applyImageFallback(event, DEFAULT_WRESTLER_IMAGE)}
+              alt={player.currentWrestler}
+              className="standings-card-avatar"
+            />
+            <div className="standings-card-main">
+              <span className="standings-card-name">
+                {player.name}
+                {player.alignment === 'face' && ' 😇'}
+                {player.alignment === 'neutral' && ' ⚖️'}
+                {player.alignment === 'heel' && ' 😈'}
+              </span>
+              <span className="standings-card-wrestler">{player.currentWrestler}</span>
+              <div className="standings-card-stats">
+                <span className="standings-card-record">
+                  {player.wins}-{player.losses}-{player.draws}
+                </span>
+                <span className="standings-card-winpct">{player.winPercentage}%</span>
+                {player.recentForm && player.recentForm.length > 0 && (
+                  <span className="form-dots" aria-label={player.recentForm.join(', ')}>
+                    {player.recentForm.map((r, i) => (
+                      <span
+                        key={i}
+                        className={`form-dot ${r === 'W' ? 'win' : r === 'L' ? 'loss' : 'draw'}`}
+                      />
+                    ))}
+                  </span>
+                )}
+                {player.currentStreak && player.currentStreak.count >= 3 && (
+                  <span
+                    className={`streak-badge ${player.currentStreak.type === 'W' ? 'hot' : player.currentStreak.type === 'L' ? 'cold' : 'neutral'}`}
+                  >
+                    {player.currentStreak.type === 'W' && '🔥 '}
+                    {player.currentStreak.type === 'L' && '❄️ '}
+                    {player.currentStreak.type === 'D' && '➖ '}
+                    {player.currentStreak.count}
+                    {player.currentStreak.type}
+                  </span>
+                )}
+              </div>
+            </div>
+            {player.mainOverall !== undefined && (
+              <span className="overall-badge-sm standings-card-ovr">{player.mainOverall}</span>
+            )}
+          </div>
+        ))}
+      </div>
+      ) : (
       <div className="standings-table-wrapper">
         <table className="standings-table">
           <thead>
@@ -361,6 +432,7 @@ export default function Standings() {
           </tbody>
         </table>
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/events/EventsCalendar.css
+++ b/frontend/src/components/events/EventsCalendar.css
@@ -49,6 +49,14 @@
   overflow-x: auto;
 }
 
+@media (max-width: 640px) {
+  /* Wrap instead of clipping off-screen — every filter stays visible. */
+  .events-filter-tabs {
+    flex-wrap: wrap;
+    overflow-x: visible;
+  }
+}
+
 .events-filter-tab {
   background: none;
   border: none;

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Track a CSS media query from React state. Returns false in environments
+ * without matchMedia (JSDOM), so tests exercise the desktop layout.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(() =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(query).matches
+      : false,
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const mediaQueryList = window.matchMedia(query);
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+    setMatches(mediaQueryList.matches);
+    mediaQueryList.addEventListener('change', onChange);
+    return () => mediaQueryList.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

Ran a mobile audit (390px-viewport Playwright screenshots of the live prod site) across the main public pages. The site is already largely responsive — three real gaps surfaced, all fixed here:

### 1. Standings was unusable on phones
The table hid half its columns off-screen: record (W-L-D), win %, Last 5 form, and streak were unreachable — on the league's most important page. Below 640px the table is now replaced by a card list showing rank, avatar, player + alignment, wrestler, record, win %, form dots, streak badge, and OVR. Cards navigate to the player profile like table rows do.

Implemented via a new `useMediaQuery` hook (JS-driven swap rather than CSS `display` toggling, so only one layout exists in the DOM/accessibility tree; it also responds to live viewport changes — verified by resizing a running page in both directions).

### 2. Nav drawer title collision
The fixed hamburger button (an X while open) overlapped the "WWE 2K League" title in the open drawer. The drawer header now clears its footprint.

### 3. Events filter tabs clipped
The All/PPV/Weekly/Special/House Show filter row ran past the right edge. It wraps below 640px so every filter stays visible.

## Testing

- Before/after screenshots at 390×844 (iPhone-class viewport) confirm all three fixes
- Programmatic check: no page has horizontal document overflow; standings renders 16 cards + no table at 390px, table + no cards at 1280px, swapping live on resize
- `tsc --noEmit` clean; Standings + events test suites pass (59 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)