### PR TITLE
fix(auth): refresh expired session on 401 and retry

### DIFF
--- a/frontend/src/components/tagTeams/__tests__/MyTagTeam.test.tsx
+++ b/frontend/src/components/tagTeams/__tests__/MyTagTeam.test.tsx
@@ -117,8 +117,10 @@ describe('MyTagTeam — TTP-01 edit-identity form', () => {
     const myWrestlerInput = screen.getByLabelText('Your wrestler in this team');
     const partnerWrestlerInput = screen.getByLabelText("Partner's wrestler in this team");
 
-    // Fields are seeded from the loaded detail (override falls back to currentWrestler)
-    expect(teamNameInput).toHaveValue('The Brood');
+    // Fields are seeded from the loaded detail (override falls back to
+    // currentWrestler) by an effect that runs after the form first renders —
+    // wait for the seeded value instead of asserting the intermediate state.
+    await waitFor(() => expect(teamNameInput).toHaveValue('The Brood'));
     expect(myWrestlerInput).toHaveValue('Edge (solo)');
     expect(partnerWrestlerInput).toHaveValue('Christian (solo)');
 

--- a/frontend/src/services/__tests__/api-core.test.ts
+++ b/frontend/src/services/__tests__/api-core.test.ts
@@ -9,6 +9,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { authApi, profileApi, playersApi } from '../api';
 
+// fetchWithAuth lazily imports the cognito service on the 401-refresh path;
+// mock it so tests never load aws-amplify.
+const { mockRefreshSession } = vi.hoisted(() => ({ mockRefreshSession: vi.fn() }));
+vi.mock('../cognito', () => ({
+  cognitoAuth: { refreshSession: mockRefreshSession },
+}));
+
 const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
 
 // ---------------------------------------------------------------------------
@@ -112,6 +119,58 @@ describe('fetchWithAuth (indirect)', () => {
       expect.any(String),
       expect.objectContaining({ signal: controller.signal }),
     );
+  });
+
+  describe('expired-session refresh on 401', () => {
+    beforeEach(() => {
+      mockRefreshSession.mockReset();
+    });
+
+    it('refreshes the session and retries once when a token-bearing request gets 401', async () => {
+      sessionStorage.setItem('accessToken', 'expired-token');
+      mockRefreshSession.mockResolvedValue({ accessToken: 'fresh-token' });
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 401, json: vi.fn() })
+        .mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue([]) });
+
+      const result = await playersApi.getAll();
+
+      expect(result).toEqual([]);
+      expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const retryHeaders = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1][1]
+        .headers as Record<string, string>;
+      expect(retryHeaders['Authorization']).toBe('Bearer fresh-token');
+    });
+
+    it('throws a session-expired message when refresh fails', async () => {
+      sessionStorage.setItem('accessToken', 'expired-token');
+      mockRefreshSession.mockResolvedValue(null);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: vi.fn().mockResolvedValue({ message: 'Unauthorized' }),
+      });
+
+      await expect(playersApi.getAll()).rejects.toThrow(
+        'Your session has expired. Please sign in again.',
+      );
+      expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not attempt a refresh for unauthenticated 401s', async () => {
+      mockRefreshSession.mockResolvedValue(null);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: vi.fn().mockResolvedValue({ message: 'Unauthorized' }),
+      });
+
+      await expect(playersApi.getAll()).rejects.toThrow('Unauthorized');
+      expect(mockRefreshSession).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/frontend/src/services/api/apiClient.ts
+++ b/frontend/src/services/api/apiClient.ts
@@ -5,25 +5,43 @@ export const getAuthToken = (): string | null => {
   return sessionStorage.getItem('accessToken');
 };
 
-// Helper to make authenticated requests with optional abort signal
-export const fetchWithAuth = async (url: string, options: RequestInit = {}, signal?: AbortSignal) => {
-  const token = getAuthToken();
+const buildRequest = (
+  options: RequestInit,
+  token: string | null,
+  signal?: AbortSignal,
+): RequestInit => {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     ...(options.headers as Record<string, string> || {}),
   };
-
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
   }
+  return { ...options, headers, signal };
+};
 
-  const response = await fetch(url, {
-    ...options,
-    headers,
-    signal,
-  });
+// Helper to make authenticated requests with optional abort signal
+export const fetchWithAuth = async (url: string, options: RequestInit = {}, signal?: AbortSignal) => {
+  const token = getAuthToken();
+  let response = await fetch(url, buildRequest(options, token, signal));
+
+  // Access tokens live 24h but admin tabs stay open longer: a 401 on a
+  // request that carried a token usually means it expired mid-session.
+  // Refresh once (30-day refresh token) and retry before giving up.
+  // Imported lazily so the amplify-backed cognito module only loads on
+  // the rare 401 path, not for every API consumer.
+  if (response.status === 401 && token) {
+    const { cognitoAuth } = await import('../cognito');
+    const refreshed = await cognitoAuth.refreshSession();
+    if (refreshed) {
+      response = await fetch(url, buildRequest(options, refreshed.accessToken, signal));
+    }
+  }
 
   if (!response.ok) {
+    if (response.status === 401 && token) {
+      throw new Error('Your session has expired. Please sign in again.');
+    }
     const error = await response.json().catch(() => ({ message: 'Request failed' }));
     throw new Error(error.message || `HTTP ${response.status}`);
   }


### PR DESCRIPTION
## Summary

Admin actions in a long-lived tab were failing with a bare **"Unauthorized"** banner (reported on Manage Players when changing a wrestler). Root cause: Cognito access tokens live 24h, `sessionStorage` keeps the old token as long as the tab is open, and the refresh-token flow only ran on app mount — so once the token expired mid-session, every authorized call 401'd until a reload.

**Verified against prod**: the exact same wrestler change that produced "Unauthorized" succeeds with a fresh token (Playwright login + edit → PUT /players 200).

## Change

`fetchWithAuth` now:
- on a **401 for a token-bearing request**, refreshes the Cognito session once (30-day refresh token) and retries with the new access token — the action just works, no reload needed
- if the refresh fails, throws **"Your session has expired. Please sign in again."** instead of the opaque "Unauthorized"
- leaves unauthenticated 401s untouched (no refresh attempt)
- imports the cognito module lazily on the 401 path only, so api consumers don't load aws-amplify

## Testing

- 3 new tests: refresh-and-retry with new bearer token, session-expired message when refresh fails, no refresh attempt for unauthenticated 401s
- All 115 services + 91 component/context tests pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)